### PR TITLE
TypeScript: `combineReducers` returns reducer that accepts partial state

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ export type ReducersMapObject<S = any, A extends Action = Action> = {
  *   object, and builds a state object with the same shape.
  */
 export function combineReducers<S>(reducers: ReducersMapObject<S, any>): Reducer<S>;
-export function combineReducers<S, A extends Action = AnyAction>(reducers: ReducersMapObject<S, A>): Reducer<S, A>;
+export function combineReducers<S, A extends Action = AnyAction>(reducers: ReducersMapObject<S, A>): (state: Partial<S> | undefined, action: A) => S;
 
 
 /* store */

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -39,11 +39,14 @@ function simple() {
   // typings:expect-error
   reducer('string', { type: 'INCREMENT' })
 
-  // Combined reducer also accepts any action.
-  const combined = combineReducers({ sub: reducer })
+  type RootState = { sub: State; sub2: State };
 
-  let cs: { sub: State } = combined(undefined, { type: 'init' })
+  // Combined reducer also accepts any action.
+  const combined = combineReducers({ sub: reducer, sub2: reducer })
+
+  let cs: RootState = combined(undefined, { type: 'init' })
   cs = combined(cs, { type: 'INCREMENT', count: 10 })
+  cs = combined({ sub: 1 }, { type: 'INCREMENT', count: 10 })
 
   // Combined reducer's state is strictly checked.
   // typings:expect-error


### PR DESCRIPTION
`combineReducers` returns a reducer that accepts partial state, not the whole state.