### PR TITLE
Add unpkg field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "Andrew Clark <acdlite@me.com> (https://github.com/acdlite)"
   ],
   "main": "lib/redux.js",
+  "unpkg": "dist/redux.js",
   "module": "es/redux.js",
   "typings": "./index.d.ts",
   "files": [


### PR DESCRIPTION
This allows unpkg.com to point to the UMD build of redux via https://unpkg.com/redux. Currently, this points at lib/redux.js (as it falls back to using the `main` field) which will not run in browsers.