### PR TITLE
Change "there's" to "there are" in Learning Resources documentation

### DIFF
--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -1,6 +1,6 @@
 # Learning Resources
 
-The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there's many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
+The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there are many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
 
 This page includes our recommendations for some of the best external resources available to learn Redux.  For an additional extensive list of tutorials, articles, and other resources on React, Redux, Javascript, and related topics, see the [React/Redux Links list](https://github.com/markerikson/react-redux-links).
 


### PR DESCRIPTION
Because "many resources" is plural, I think the sentence should begin with "There are" rather than "There's" or "There is". 

Grammarly reference: https://www.grammarly.com/blog/there-is-there-are/