### PR TITLE
Warn when reducer is not a function

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -121,6 +121,8 @@ export default function combineReducers(reducers) {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof reducers[key] === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
+      } else if (typeof reducers[key] !== 'function') {
+        warning(`The reducer for "${key}" is not a function`)
       }
     }
 

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -196,6 +196,31 @@ describe('Utils', () => {
       console.error = preSpy
     })
 
+    it('warns if a reducer is not a function', () => {
+      const preSpy = console.error
+      const spy = jest.fn()
+      console.error = spy
+
+      let isFunction = state => null
+      let isNotFunction = 'isNotFunction'
+      let reducer = combineReducers({ isFunction, isNotFunction })
+      reducer({})
+      expect(spy.mock.calls[0][0]).toMatch(
+        /The reducer for "isNotFunction" is not a function/
+      )
+
+      spy.mockClear()
+      isNotFunction = []
+      reducer = combineReducers({ isFunction, isNotFunction })
+      reducer({})
+      expect(spy.mock.calls[0][0]).toMatch(
+        /The reducer for "isNotFunction" is not a function/
+      )
+
+      spy.mockClear()
+      console.error = preSpy
+    })
+
     it('warns if input state does not match reducer shape', () => {
       const preSpy = console.error
       const spy = jest.fn()


### PR DESCRIPTION
``` js
const rootReducer = combineReducers({ 
  todos: todosReducer, 
  steps: {} // no warning, this is simply ignored 
})
```
- If the object supplied to combineReducers has a key whose value is not a function, it simply ignores it. With this fix, it gives a warning, letting the user know that each key in the object must point to a function. 


