### PR TITLE
Use console.warn to log warnings instead of console.error

### DIFF
--- a/src/utils/warning.js
+++ b/src/utils/warning.js
@@ -6,8 +6,8 @@
  */
 export default function warning(message) {
   /* eslint-disable no-console */
-  if (typeof console !== 'undefined' && typeof console.error === 'function') {
-    console.error(message)
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(message)
   }
   /* eslint-enable no-console */
   try {

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -33,9 +33,9 @@ describe('Utils', () => {
     })
 
     it('warns if a reducer prop is undefined', () => {
-      const preSpy = console.error
+      const preSpy = console.warn
       const spy = jest.fn()
-      console.error = spy
+      console.warn = spy
 
       let isNotDefined
       combineReducers({ isNotDefined })
@@ -50,7 +50,7 @@ describe('Utils', () => {
       )
 
       spy.mockClear()
-      console.error = preSpy
+      console.warn = preSpy
     })
 
     it('throws an error if a reducer returns undefined handling an action', () => {
@@ -183,9 +183,9 @@ describe('Utils', () => {
     })
 
     it('warns if no reducers are passed to combineReducers', () => {
-      const preSpy = console.error
+      const preSpy = console.warn
       const spy = jest.fn()
-      console.error = spy
+      console.warn = spy
 
       const reducer = combineReducers({})
       reducer({})
@@ -193,13 +193,13 @@ describe('Utils', () => {
         /Store does not have a valid reducer/
       )
       spy.mockClear()
-      console.error = preSpy
+      console.warn = preSpy
     })
 
     it('warns if input state does not match reducer shape', () => {
-      const preSpy = console.error
+      const preSpy = console.warn
       const spy = jest.fn()
-      console.error = spy
+      console.warn = spy
 
       const reducer = combineReducers({
         foo(state = { bar: 1 }) {
@@ -253,13 +253,13 @@ describe('Utils', () => {
       )
 
       spy.mockClear()
-      console.error = preSpy
+      console.warn = preSpy
     })
 
     it('only warns for unexpected keys once', () => {
-      const preSpy = console.error
+      const preSpy = console.warn
       const spy = jest.fn()
-      console.error = spy
+      console.warn = spy
 
       const foo = (state = { foo: 1 }) => state
       const bar = (state = { bar: 2 }) => state
@@ -279,7 +279,7 @@ describe('Utils', () => {
       expect(spy.mock.calls.length).toBe(2)
 
       spy.mockClear()
-      console.error = preSpy
+      console.warn = preSpy
     })
   })
 })

--- a/test/utils/warning.spec.js
+++ b/test/utils/warning.spec.js
@@ -3,20 +3,20 @@ import warning from '../../src/utils/warning'
 
 describe('Utils', () => {
   describe('warning', () => {
-    it('calls console.error when available', () => {
-      const preSpy = console.error
+    it('calls console.warn when available', () => {
+      const preSpy = console.warn
       const spy = jest.fn()
-      console.error = spy
+      console.warn = spy
       try {
         warning('Test')
         expect(spy.mock.calls[0][0]).toBe('Test')
       } finally {
         spy.mockClear()
-        console.error = preSpy
+        console.warn = preSpy
       }
     })
 
-    it('does not throw when console.error is not available', () => {
+    it('does not throw when console.warn is not available', () => {
       const realConsole = global.console
       Object.defineProperty(global, 'console', { value: {} })
       try {


### PR DESCRIPTION
- Changed `console.error` references to `console.warn` in
  - `src/utils/warning.js`
  - `test/combineReducers.spec.js`
  - `test/utils/warning.spec.js`

  This PR addresses issue: #3029 