### PR TITLE
Add a minimal packaging for different module versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 *.log
 node_modules
-dist
-lib
-es
-coverage
+/dist
+/lib
+/es
+/coverage

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
     "prepare": "npm run clean && npm run format:check && npm run lint && npm test && npm run build",
     "examples:lint": "eslint examples",
-    "examples:test": "cross-env CI=true babel-node examples/testAll.js"
+    "examples:test": "cross-env CI=true babel-node examples/testAll.js",
+    "publishPackages": "npm run build && node packages/publish.js"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,8 @@
+# Redux Packages
+
+These are different packagings of Redux that contain a minimal copy of the app. They are all published under the @redux-js namespace on npm.
+
+- [`cjs`](./cjs) - Common JS formatted code (i.e., `require()`)
+- [`es`](./es) - ES Module formatted code (i.e., `import`)
+- [`umd`](./umd) - Universal Module Defition for compatibility with any module loader (SystemJS, AMD, `<script>`, etc.)
+- [`umd-min`](./umd-min) - A minified form of the Universal Module Defition version

--- a/packages/cjs/.gitignore
+++ b/packages/cjs/.gitignore
@@ -1,0 +1,1 @@
+redux.js

--- a/packages/cjs/README.md
+++ b/packages/cjs/README.md
@@ -1,0 +1,3 @@
+# Redux
+
+More information is available in [the main README](https://github.com/reduxjs/redux/blob/master/README.md) and in [our documentation](https://redux.js.org/).

--- a/packages/cjs/package.json
+++ b/packages/cjs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@redux-js/cjs",
+  "version": "4.0.0",
+  "description": "Predictable state container for JavaScript apps",
+  "license": "MIT",
+  "homepage": "http://redux.js.org",
+  "repository": "github:reduxjs/redux",
+  "main": "redux.js",
+  "files": [
+    "redux.js"
+  ],
+  "dependencies": {
+    "symbol-observable": "^1.2.0"
+  }
+}

--- a/packages/es/.gitignore
+++ b/packages/es/.gitignore
@@ -1,0 +1,1 @@
+redux.js

--- a/packages/es/README.md
+++ b/packages/es/README.md
@@ -1,0 +1,3 @@
+# Redux
+
+More information is available in [the main README](https://github.com/reduxjs/redux/blob/master/README.md) and in [our documentation](https://redux.js.org/).

--- a/packages/es/package.json
+++ b/packages/es/package.json
@@ -1,0 +1,1 @@
+{"name":"@redux-js/es","version":"4.0.0","description":"Predictable state container for JavaScript apps","license":"MIT","homepage":"http://redux.js.org","repository":"github:reduxjs/redux","main":"redux.js","files":["redux.js"],"dependencies":{"symbol-observable":"^1.2.0"}}

--- a/packages/publish.js
+++ b/packages/publish.js
@@ -1,0 +1,33 @@
+const { copyFileSync, writeFileSync } = require('fs')
+const { resolve } = require('path')
+
+const { spawnSync } = require('child_process')
+
+const packages = {
+  cjs: 'lib/redux.js',
+  es: 'es/redux.js',
+  umd: 'dist/redux.js',
+  'umd-min': 'dist/redux.min.js'
+}
+
+const { version } = require('../package.json')
+let packageJSON
+
+Object.entries(packages).forEach(([pkgName, source]) => {
+  copyFileSync(
+    resolve(__dirname, `../${source}`),
+    resolve(__dirname, `./${pkgName}/redux.js`)
+  )
+
+  packageJSON = require(`./${pkgName}/package.json`)
+  packageJSON.version = version
+  writeFileSync(
+    resolve(__dirname, `./${pkgName}/package.json`),
+    JSON.stringify(packageJSON)
+  )
+
+  spawnSync('npm', ['publish'], {
+    cwd: resolve(__dirname, pkgName),
+    stdio: 'inherit'
+  })
+})

--- a/packages/umd-min/.gitignore
+++ b/packages/umd-min/.gitignore
@@ -1,0 +1,1 @@
+redux.js

--- a/packages/umd-min/README.md
+++ b/packages/umd-min/README.md
@@ -1,0 +1,3 @@
+# Redux
+
+More information is available in [the main README](https://github.com/reduxjs/redux/blob/master/README.md) and in [our documentation](https://redux.js.org/).

--- a/packages/umd-min/package.json
+++ b/packages/umd-min/package.json
@@ -1,0 +1,1 @@
+{"name":"@redux-js/umd-min","version":"4.0.0","description":"Predictable state container for JavaScript apps","license":"MIT","homepage":"http://redux.js.org","repository":"github:reduxjs/redux","main":"redux.js","files":["redux.js"],"dependencies":{"symbol-observable":"^1.2.0"}}

--- a/packages/umd/.gitignore
+++ b/packages/umd/.gitignore
@@ -1,0 +1,1 @@
+redux.js

--- a/packages/umd/README.md
+++ b/packages/umd/README.md
@@ -1,0 +1,3 @@
+# Redux
+
+More information is available in [the main README](https://github.com/reduxjs/redux/blob/master/README.md) and in [our documentation](https://redux.js.org/).

--- a/packages/umd/package.json
+++ b/packages/umd/package.json
@@ -1,0 +1,1 @@
+{"name":"@redux-js/umd","version":"4.0.0","description":"Predictable state container for JavaScript apps","license":"MIT","homepage":"http://redux.js.org","repository":"github:reduxjs/redux","main":"redux.js","files":["redux.js"],"dependencies":{"symbol-observable":"^1.2.0"}}


### PR DESCRIPTION
Closes #3040

This will publish a set of minimal packages under the @redux-js npm org. They contain a minimal package.json and README, along with a single redux.js file that matches whatever module format that package uses. There's a script to automate publishing too. 

I haven't yet published to npm, but will if this looks good to others.

And unfortunately, the `weedux` npm name is taken 😢 