### PR TITLE
Remove a dead link and an archived example

### DIFF
--- a/docs/faq/Miscellaneous.md
+++ b/docs/faq/Miscellaneous.md
@@ -14,10 +14,8 @@
 
 Yes, lots of them!  To name just a few:
 
-- [Twitter's mobile site](https://twitter.com/necolas/status/727538799966715904)
 - [Wordpress's new admin page](https://github.com/Automattic/wp-calypso)
 - [Firefox's new debugger](https://github.com/jlongster/debugger.html)
-- [Mozilla's experimental browser testbed](https://github.com/mozilla/tofino)
 - [The HyperTerm terminal application](https://github.com/zeit/hyperterm)
 
 And many, many more!  The Redux Addons Catalog has **[a list of Redux-based applications and examples](https://github.com/markerikson/redux-ecosystem-links/blob/master/apps-and-examples.md)** that points to a variety of actual applications, large and small.


### PR DESCRIPTION
The link which says Twitter Mobile uses Redux is a dead link (the tweet was deleted), I looked around and couldn't find a reliable source saying Twitter Mobile uses Redux, and other one links to an archived repository which isn't the best example to show. Here are 2 alternate websites which say they are using redux, if they are a suitable replacement for these examples, they are respectably complex applications: https://www.artsy.net / https://www.vistaprint.com