### PR TITLE
docs: fix `composeWithDevTools` capitalization

### DIFF
--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -204,14 +204,14 @@ First, we install the package via npm:
 npm install --save-dev redux-devtools-extension
 ```
 
-Next, we remove the `compose` function which we imported from `redux`, and replace it with a new `composeWithDevtools` function imported from `redux-devtools-extension`.
+Next, we remove the `compose` function which we imported from `redux`, and replace it with a new `composeWithDevTools` function imported from `redux-devtools-extension`.
 
 The final code looks like this:
 
 ```js
 import { applyMiddleware, createStore } from 'redux'
 import thunkMiddleware from 'redux-thunk'
-import { composeWithDevtools } from 'redux-devtools-extension'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 import monitorReducersEnhancer from './enhancers/monitorReducers'
 import loggerMiddleware from './middleware/logger'
@@ -222,7 +222,7 @@ export default function configureStore(preloadedState) {
   const middlewareEnhancer = applyMiddleware(...middlewares)
 
   const enhancers = [middlewareEnhancer, monitorReducersEnhancer]
-  const composedEnhancers = composeWithDevtools(...enhancers)
+  const composedEnhancers = composeWithDevTools(...enhancers)
 
   const store = createStore(rootReducer, preloadedState, composedEnhancers)
 


### PR DESCRIPTION
Should be imported `composeWithDevTools`,  instead of `composeWithDevtools`.

Misspelling appears to compile fine in the console, but the browser returns an error: `TypeError: Cannot read property 'apply' of undefined`