### PR TITLE
 Remove unneeded middlewareAPI.dispatch declaration

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -28,7 +28,7 @@ export default function applyMiddleware(...middlewares) {
 
     const middlewareAPI = {
       getState: store.getState,
-      dispatch: (...args) => dispatch(...args)
+      dispatch
     }
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)


### PR DESCRIPTION
`(...args) => dispatch(...args)` equals `dispatch`