### PR TITLE
The Medium article should be optional reading.

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -18,9 +18,7 @@ If you don't use npm, you may grab the latest UMD build from unpkg (either a [de
 
 ## Presentational and Container Components
 
-React bindings for Redux embrace the idea of **separating presentational and container components**. If you're not familiar with these terms, [read about them first](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0), and then come back. They are important, so we'll wait!
-
-Finished reading the article? Let's recount their differences:
+React bindings for Redux separate _presentational_ components from _container_ components. This approach can make your app easier to understand and allow you to more easily reuse components. Here's a summary of the differences between presentational and container components (but if you're unfamiliar, we recommend that you also read [this article](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)):
 
 <table>
     <thead>

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -18,7 +18,7 @@ If you don't use npm, you may grab the latest UMD build from unpkg (either a [de
 
 ## Presentational and Container Components
 
-React bindings for Redux separate _presentational_ components from _container_ components. This approach can make your app easier to understand and allow you to more easily reuse components. Here's a summary of the differences between presentational and container components (but if you're unfamiliar, we recommend that you also read [this article](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)):
+React bindings for Redux separate _presentational_ components from _container_ components. This approach can make your app easier to understand and allow you to more easily reuse components. Here's a summary of the differences between presentational and container components (but if you're unfamiliar, we recommend that you also read [Dan Abramov's original article describing the concept of presentational and container components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)):
 
 <table>
     <thead>


### PR DESCRIPTION
It's great to provide links to more in-depth material, but what if we made it seem more optional? It might be better to allow the reader to keep their momentum here.

This is loosely related to #2591.