### PR TITLE
Mark StoreCreator's preloadedState argument as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -220,7 +220,7 @@ export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
  */
 export interface StoreCreator {
   <S, A extends Action, Ext, StateExt>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<Ext, StateExt>): Store<S & StateExt, A> & Ext;
-  <S, A extends Action, Ext, StateExt>(reducer: Reducer<S, A>, preloadedState: DeepPartial<S>, enhancer?: StoreEnhancer<Ext>): Store<S & StateExt, A> & Ext;
+  <S, A extends Action, Ext, StateExt>(reducer: Reducer<S, A>, preloadedState?: DeepPartial<S>, enhancer?: StoreEnhancer<Ext>): Store<S & StateExt, A> & Ext;
 }
 
 /**


### PR DESCRIPTION
When wrapping `createStore()` using typescript, the typescript definition prevents an optional `preloadedState` argument:

```typescript
function myCreateStore<S>(reducer: Reducer<S>, preloadedState?: Redux.DeepPartial<S>) {
    return createStore(reducer, preloadedState);
}
```

This will complain that type `undefined` is not assignable to `DeepPartial<S>`. Marking the `preloadedState` argument as optional fixes this problem.