### PR TITLE
Cache finalReducerKeys.length to optimize perf

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -129,6 +129,7 @@ export default function combineReducers(reducers) {
     }
   }
   const finalReducerKeys = Object.keys(finalReducers)
+  const finalReducerKeysLength = finalReducerKeys.length
 
   let unexpectedKeyCache
   if (process.env.NODE_ENV !== 'production') {
@@ -161,7 +162,7 @@ export default function combineReducers(reducers) {
 
     let hasChanged = false
     const nextState = {}
-    for (let i = 0; i < finalReducerKeys.length; i++) {
+    for (let i = 0; i < finalReducerKeysLength; i++) {
       const key = finalReducerKeys[i]
       const reducer = finalReducers[key]
       const previousStateForKey = state[key]


### PR DESCRIPTION
In src/combineReducers.js, the finalReducerKeys.length won't change. So to optimize performance, it would be better to cache it.

This is related to #3085.