### PR TITLE
introduce listeners freeze functionality

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -51,6 +51,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
   let currentListeners = []
   let nextListeners = currentListeners
   let isDispatching = false
+  let isFrozen = false
 
   function ensureCanMutateNextListeners() {
     if (nextListeners === currentListeners) {
@@ -180,6 +181,14 @@ export default function createStore(reducer, preloadedState, enhancer) {
     if (isDispatching) {
       throw new Error('Reducers may not dispatch actions.')
     }
+    
+    if (action.type === ActionTypes.FREEZE) {
+      isFrozen = true
+    }
+
+    if (action.type === ActionTypes.UNFREEZE) {
+      isFrozen = false
+    }
 
     try {
       isDispatching = true
@@ -188,10 +197,12 @@ export default function createStore(reducer, preloadedState, enhancer) {
       isDispatching = false
     }
 
-    const listeners = (currentListeners = nextListeners)
-    for (let i = 0; i < listeners.length; i++) {
-      const listener = listeners[i]
-      listener()
+    if (!isFrozen) {
+      const listeners = (currentListeners = nextListeners)
+      for (let i = 0; i < listeners.length; i++) {
+        const listener = listeners[i]
+        listener()
+      }
     }
 
     return action

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -14,6 +14,8 @@ const randomString = () =>
 
 const ActionTypes = {
   INIT: `@@redux/INIT${randomString()}`,
+  FREEZE: `@@redux/FREEZE`,
+  UNFREEZE: `@@redux/UNFREEZE`,
   REPLACE: `@@redux/REPLACE${randomString()}`,
   PROBE_UNKNOWN_ACTION: () => `@@redux/PROBE_UNKNOWN_ACTION${randomString()}`
 }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -760,4 +760,24 @@ describe('createStore', () => {
     expect(console.error.mock.calls.length).toBe(0)
     console.error = originalConsoleError
   })
+
+  it('should not notify subscribers while frozen', () => {
+    const store = createStore(() => { })
+    const listener = jest.fn()
+    store.subscribe(listener)
+    expect(listener.mock.calls.length).toEqual(0)
+
+    store.dispatch({ type: 'foo' })
+    expect(listener.mock.calls.length).toEqual(1)
+
+    store.dispatch({ type: `@@redux/FREEZE` })
+    expect(listener.mock.calls.length).toEqual(1)
+
+    store.dispatch({ type: 'foo' })
+    store.dispatch({ type: 'foo2' })
+    expect(listener.mock.calls.length).toEqual(1)
+
+    store.dispatch({ type: `@@redux/UNFREEZE` })
+    expect(listener.mock.calls.length).toEqual(2)
+  })
 })


### PR DESCRIPTION
**NB** this PR is a call to discussion, as it's something that might or might not become something usable for wide masses

**Problem**

It is not possible to control notifications to subscribers.

**Motivations**

- In some business cases it should be possible to freeze UI.
- Bunching of actions becomes easy controllable by `dispatch(freeze);dispatch(do1);dispatch(do2);dispatch(unfreeze)`
