### PR TITLE
Add introductory links from docs in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We have a variety of resources available to help you learn Redux, no matter what
 
 If you're brand new to Redux and want to understand the basic concepts, see:
 
+- The **[Motivation](https://redux.js.org/introduction/motivation)** behind building Redux, the **[Core Concepts](https://redux.js.org/introduction/coreconcepts)**, and the **[Three Principles](https://redux.js.org/introduction/threeprinciples)**.
 - The **[basic tutorial in the Redux docs](https://redux.js.org/basics)**
 - Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://egghead.io/series/getting-started-with-redux)** on Egghead.io
 - Redux co-maintainer Mark Erikson's **["Redux Fundamentals" slideshow](http://blog.isquaredsoftware.com/2018/03/presentation-reactathon-redux-fundamentals/)** and **[list of suggested resources for learning Redux](http://blog.isquaredsoftware.com/2017/12/blogged-answers-learn-redux/)**


### PR DESCRIPTION
Hi there,

I think these three pages from the docs (**[Motivation](https://redux.js.org/introduction/motivation)**, **[Core Concepts](https://redux.js.org/introduction/coreconcepts)**, and **[Three Principles](https://redux.js.org/introduction/threeprinciples)**) provide a smoother introduction to Redux, rather than the current first link to **[Redux > Basics](https://redux.js.org/basics)** which feels a bit more dry.

Also, the Readme on GitHub lacks the sidebar which exists under https://redux.js.org, making it a bit harder to find these pages.

Cheers!