### PR TITLE
Fix the link to "Advanced" from "Recipes/Configuring Your Store" footer

### DIFF
--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -308,4 +308,4 @@ The only extra change here is that we have encapsulated our app's rendering into
 
 ## Next Steps
 
-Now that you know how to encapsulate your store configuration to make it easier to maintain, you can [learn more about the advanced features Redux provides](../basics/README.md), or take a closer look at some of the [extensions available in the Redux ecosystem](../introduction/ecosystem).
+Now that you know how to encapsulate your store configuration to make it easier to maintain, you can [learn more about the advanced features Redux provides](../advanced/README.md), or take a closer look at some of the [extensions available in the Redux ecosystem](../introduction/ecosystem).


### PR DESCRIPTION
It was pointing to the "Basics" section