### PR TITLE
Minor improvement on Basic -> Reducers doc.

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -367,7 +367,7 @@ function reducer(state = {}, action) {
 }
 ```
 
-All [`combineReducers()`](../api/combineReducers.md) does is generate a function that calls your reducers **with the slices of state selected according to their keys**, and combining their results into a single object again. [It's not magic.](https://github.com/reduxjs/redux/issues/428#issuecomment-129223274) And like other reducers, `combineReducers()` does not create a new object if all of the reducers provided to it do not change state.
+All [`combineReducers()`](../api/combineReducers.md) does is generating a function that calls your reducers **with the slices of state selected according to their keys**, and combining their results into a single object again. [It's not magic.](https://github.com/reduxjs/redux/issues/428#issuecomment-129223274) And like other reducers, `combineReducers()` does not create a new object if all of the reducers provided to it do not change state.
 
 >##### Note for ES6 Savvy Users
 


### PR DESCRIPTION
This is a small PR that changes

> All combineReducers() does is _**generate**_ a function that calls your reducers with the slices of state selected according to their keys, and **combining** their results into a single object again.

to

> All combineReducers() does is _**generating**_ a function that calls your reducers with the slices of state selected according to their keys, and **combining** their results into a single object again.

Sorry for my OCD.

