### PR TITLE
Changing ‘ to ' for consistency in DataFlow.md

### DIFF
--- a/docs/basics/DataFlow.md
+++ b/docs/basics/DataFlow.md
@@ -18,7 +18,7 @@ The data lifecycle in any Redux app follows these 4 steps:
     { type: 'ADD_TODO', text: 'Read the Redux docs.' }
    ```
 
-  Think of an action as a very brief snippet of news. “Mary liked article 42.” or “‘Read the Redux docs.' was added to the list of todos.”
+  Think of an action as a very brief snippet of news. “Mary liked article 42.” or “'Read the Redux docs.' was added to the list of todos.”
 
   You can call [`store.dispatch(action)`](../api/Store.md#dispatch) from anywhere in your app, including components and XHR callbacks, or even at scheduled intervals.
 


### PR DESCRIPTION
Changing `‘` to `'` for consistency in DataFlow.md.
Per [contributing#doc](https://github.com/reduxjs/redux/blob/master/CONTRIBUTING.md#docs) section, we should use `'`.