### PR TITLE
Fixed a bug for Android Chrome browser in HOC example

### DIFF
--- a/docs/recipes/UsingImmutableJS.md
+++ b/docs/recipes/UsingImmutableJS.md
@@ -273,22 +273,24 @@ Here is an example of such a HOC:
 import React from 'react'
 import { Iterable } from 'immutable'
 
-export const toJS = WrappedComponent => wrappedComponentProps => {
-  const KEY = 0
-  const VALUE = 1
+const prepareValue = (value) => {
+  return Iterable.isIterable(value) ? value.toJS() : value
+}
 
-  const propsJS = Object.entries(
-    wrappedComponentProps
-  ).reduce((newProps, wrappedComponentProp) => {
-    newProps[wrappedComponentProp[KEY]] = Iterable.isIterable(
-      wrappedComponentProp[VALUE]
-    )
-      ? wrappedComponentProp[VALUE].toJS()
-      : wrappedComponentProp[VALUE]
-    return newProps
+const convertToJsProps = (object) => {
+  return Object.keys(object).reduce((props, key) => {
+    const value = prepareValue(object[key])
+    return { ...props, [key]: value }
   }, {})
+}
 
-  return <WrappedComponent {...propsJS} />
+export default (WrappedComponent) => {
+  const HOC = (wrappedComponentProps, ref) => {
+    const propsJS = convertToJsProps(wrappedComponentProps)
+    return <WrappedComponent {...propsJS} ref={ref} />
+  }
+
+  return React.forwardRef(HOC)
 }
 ```
 


### PR DESCRIPTION
Hi there!
I've run into a problem on my Android Chrome browser. I've visited my app and the main page was turned into a blank white page (at the first visit the main page worked fine, but after refreshing it crashed though). I've connected my android device with a laptop for debugging. It turns out translation function `t()` (provided by another library) is not a function, but it's a string.

I've spent a lot of time to determine where the problem is and I've managed to find it out.
The following [example of high order component](https://github.com/reduxjs/redux/blob/master/docs/recipes/UsingImmutableJS.md#use-a-higher-order-component-to-convert-your-smart-components-immutablejs-props-to-your-dumb-components-javascript-props) contains `Object.entries` that works in the wrong way periodically.

I have an object like this:
```
const obj = {
  prop1: 5,
  prop2: "hello, world!",
  prop3: null,
  t: f(),
}
```
The first call of `Object.entries(obj)` returns:
```
(4) [Array(2), Array(2), Array(2), Array(2)]
> 0: (2) ["prop1", 5],
> 1: (2) ["prop2", "hello, world!"],
> 2: (2) ["prop3", null],
> 3: (2) ["t", f]
```
Everything is fine, but after a while my react component renders itself again and there is a need to convert Immutable props to JS props, so there is the second call of `Object.entries` with the following result:
```
(2) [Array(2), Array(2)]
> 0: (2) ["prop3", null],
> 1: (2) ["t", "t"]
```
Translation function `t()` now is a string and my app crashes.

I've replaced `Object.entries` with `Object.keys(obj).map((key) => { return [key, obj[key]]; })` and now my app on my android works very well.

My device and browser configurations:

**Android Version:** 5.1.1 LM47V
**Chrome browser:** 65.0.3325.109

In this PR the bug is fixed and provided with a small refactor of HOC component.