### PR TITLE
move Header component out of Header container file

### DIFF
--- a/examples/todomvc/src/components/Header.js
+++ b/examples/todomvc/src/components/Header.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import TodoTextInput from './TodoTextInput'
+
+const Header = ({ addTodo }) => (
+  <header className="header">
+    <h1>todos</h1>
+    <TodoTextInput
+      newTodo
+      onSave={(text) => {
+        if (text.length !== 0) {
+          addTodo(text)
+        }
+      }}
+      placeholder="What needs to be done?"
+    />
+  </header>
+)
+
+Header.propTypes = {
+  addTodo: PropTypes.func.isRequired
+}
+
+export default Header

--- a/examples/todomvc/src/components/Header.spec.js
+++ b/examples/todomvc/src/components/Header.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { createRenderer } from 'react-test-renderer/shallow';
-import { Header } from './Header'
+import Header from './Header'
 import TodoTextInput from '../components/TodoTextInput'
 
 const setup = () => {

--- a/examples/todomvc/src/containers/Header.js
+++ b/examples/todomvc/src/containers/Header.js
@@ -1,26 +1,5 @@
-import React from 'react'
 import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
-import TodoTextInput from '../components/TodoTextInput'
+import Header from '../components/Header'
 import { addTodo } from '../actions'
-
-export const Header = ({ addTodo }) => (
-  <header className="header">
-    <h1>todos</h1>
-    <TodoTextInput
-      newTodo
-      onSave={(text) => {
-        if (text.length !== 0) {
-          addTodo(text)
-        }
-      }}
-      placeholder="What needs to be done?"
-    />
-  </header>
-)
-
-Header.propTypes = {
-  addTodo: PropTypes.func.isRequired
-}
 
 export default connect(null, { addTodo })(Header)


### PR DESCRIPTION
I was going through the todomvc example and I noticed that the Header container file also included the Header component. I moved it and its test into the components directory to clean it up a little bit.

- [x] Navigate to /examples/todomvc in your terminal, npm install, npm start, make sure the todomvc example compiles and runs
- [x] Navigate to /examples/todomvc in your terminal, npm test, and make sure all tests pass