### PR TITLE
fix: Throw error if createStore is passed several enhancers

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -29,6 +29,17 @@ import isPlainObject from './utils/isPlainObject'
  * and subscribe to changes.
  */
 export default function createStore(reducer, preloadedState, enhancer) {
+  if (
+    (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
+    (typeof enhancer === 'function' && typeof arguments[3] === 'function')
+  ) {
+    throw new Error(
+      'It looks like you are passing several store enhancers to ' +
+        'createStore(). This is not supported. Instead, compose them ' +
+        'together to a single function'
+    )
+  }
+
   if (typeof preloadedState === 'function' && typeof enhancer === 'undefined') {
     enhancer = preloadedState
     preloadedState = undefined

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -761,4 +761,20 @@ describe('createStore', () => {
     expect(console.error.mock.calls.length).toBe(0)
     console.error = originalConsoleError
   })
+
+  it('throws if passing several enhancer functions without preloaded state', () => {
+    const rootReducer = combineReducers(reducers)
+    const dummyEnhancer = f => f
+    expect(() =>
+      createStore(rootReducer, dummyEnhancer, dummyEnhancer)
+    ).toThrow()
+  })
+
+  it('throws if passing several enhancer functions with preloaded state', () => {
+    const rootReducer = combineReducers(reducers)
+    const dummyEnhancer = f => f
+    expect(() =>
+      createStore(rootReducer, { todos: [] }, dummyEnhancer, dummyEnhancer)
+    ).toThrow()
+  })
 })


### PR DESCRIPTION
This commit adds a check for whether the user is passing several
enhancers to the `createStore` function.

Fixes #3114.