### PR TITLE
Pass dispatch without wrapping

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -28,7 +28,7 @@ export default function applyMiddleware(...middlewares) {
 
     const middlewareAPI = {
       getState: store.getState,
-      dispatch: (...args) => dispatch(...args)
+      dispatch
     }
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)


### PR DESCRIPTION
I'm not sure if there was a reason we are wrapping dispatch. If there is, then close my PR. I was just looking over the code and saw this could be simplified. 