### PR TITLE
Force node environment for Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "format:check": "prettier --list-different \"{src,test}/**/*.{js,ts}\" index.d.ts",
     "lint": "eslint src test",
     "pretest": "npm run build",
-    "test": "jest",
+    "test": "NODE_ENV=test jest",
     "test:watch": "npm test -- --watch",
     "test:cov": "npm test -- --coverage",
     "build": "rollup -c",


### PR DESCRIPTION
This resolves NPM installations that install Redux via a git branch (e.g. `npm install reduxjs/redux#master`). I know that this generally frowned upon, but I wanted to test the latest version that includes the `es-modules` compatible distribution.

Note that I also tried to set the `globals` option in the `package.json#jest`, however the `NODE_ENV` in `.babelrc.js` would still be `production`. Updating the `test` script in `package.json` does force the correct environment.