### PR TITLE
Remove extra space in docs example

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -21,7 +21,7 @@ and configure it to use [babel-preset-env](https://github.com/babel/babel/tree/m
 
 ```js
 {
-   "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 


### PR DESCRIPTION
This is very minor, I noticed it when copy-pasting into my own `.babelrc`.