### PR TITLE
Add dev.to link as a learning resource

### DIFF
--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -397,3 +397,4 @@ This page includes our recommendations for some of the best external resources a
 - [React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
 - [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.
 - [Awesome Redux](https://github.com/xgrommx/awesome-redux) is an extensive list of Redux-related repositories.  
+- [DEV Community](https://dev.to/t/redux) is a place to share Redux projects, articles and tutorials as well as start discussions and ask for feedback on Redux-related topics. Developers of all skill-levels are welcome to take part.


### PR DESCRIPTION
[DEV Community](https://dev.to) Community is a burgeoning source of guidance and discussion on software topics, especially web dev. This will be a useful link to point to the official place to discuss Redux matters on the platform.

A few additional links pertaining to [dev.to](https://dev.to)

Traffic stats: https://www.similarweb.com/website/dev.to
Twitter: https://twitter.com/thepracticaldev
Redux tag (as included in PR): https://dev.to/t/redux

Some example Redux posts:
https://dev.to/oathkeeper/learning-redux-and-notes--43ae
https://dev.to/websavi/how-to-code-split-redux-store-to-further-improve-your-apps-performance-4gg9
https://dev.to/saigowthamr/build-your-own-redux-from-scratch-5a4d
https://dev.to/bnorbertjs/async-react-basics-with-redux-thunk--redux-saga-4af7

Happy coding ❤️