### PR TITLE
Update async action creators test: Remove redundant method

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -128,7 +128,6 @@ const mockStore = configureMockStore(middlewares)
 
 describe('async actions', () => {
   afterEach(() => {
-    fetchMock.reset()
     fetchMock.restore()
   })
 


### PR DESCRIPTION
In the [fetch-mock docs](http://www.wheresrhys.co.uk/fetch-mock/#api-lifecyclerestore_reset), restore() is an alias for reset()
Remove reset() since both accomplish the same task