### PR TITLE
Update ConfiguringYourStore.md

### DIFF
--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -296,9 +296,7 @@ const renderApp = () => render(
 )
 
 if (process.env.NODE_ENV !== 'production' && module.hot) {
-  module.hot.accept('./components/App', () => {
-    renderApp()
-  })
+  module.hot.accept('./components/App', renderApp})
 }
 
 renderApp()

--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -296,7 +296,7 @@ const renderApp = () => render(
 )
 
 if (process.env.NODE_ENV !== 'production' && module.hot) {
-  module.hot.accept('./components/App', renderApp})
+  module.hot.accept('./components/App', renderApp)
 }
 
 renderApp()


### PR DESCRIPTION
No need to wrap `renderApp` inside a new arrow function every time we hot reload; we can just use `renderApp` itself.