### PR TITLE
examples/todomvc: fixed two Warning about checkbox set either `onChange` or `readOnly` and input autoFocus

### DIFF
--- a/examples/todomvc/src/components/MainSection.js
+++ b/examples/todomvc/src/components/MainSection.js
@@ -13,6 +13,7 @@ const MainSection = ({ todosCount, completedCount, actions }) =>
             className="toggle-all"
             type="checkbox"
             checked={completedCount === todosCount}
+            readOnly
           />
           <label onClick={actions.completeAllTodos}/>
         </span>

--- a/examples/todomvc/src/components/TodoTextInput.js
+++ b/examples/todomvc/src/components/TodoTextInput.js
@@ -44,7 +44,7 @@ export default class TodoTextInput extends Component {
         })}
         type="text"
         placeholder={this.props.placeholder}
-        autoFocus="true"
+        autoFocus={true}
         value={this.state.text}
         onBlur={this.handleBlur}
         onChange={this.handleChange}


### PR DESCRIPTION
# examples/todomvc/src/components/MainSection.js
get the Warning:
```
index.js:1452 Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. 
This will render a read-only field. 
If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.
    in input (at MainSection.js:12)
    in span (at MainSection.js:11)
    in section (at MainSection.js:8)
    in MainSection (created by Connect(MainSection))
    in Connect(MainSection) (at App.js:8)
    in div (at App.js:6)
    in App (at src/index.js:13)
    in Provider (at src/index.js:12)
```
## solution
line 12, input set readOnly

# examples/todomvc/src/components/TodoTextInput.js
get the Warning: 
```
Warning: Received the string `true` for the boolean attribute `autoFocus`. Although this works, 
it will not work as expected if you pass the string "false". Did you mean autoFocus={true}?
    in input (at TodoTextInput.js:40)
    in TodoTextInput (at Header.js:8)
    in header (at Header.js:6)
    in Header (created by Connect(Header))
    in Connect(Header) (at App.js:7)
    in div (at App.js:6)
    in App (at src/index.js:13)
    in Provider (at src/index.js:12)
```
## solution
line 47, modify `autoFocus="true“` to `autoFocus={true}`