### PR TITLE
Fix a TypeError exception in real-world example

### DIFF
--- a/examples/real-world/src/containers/UserPage.js
+++ b/examples/real-world/src/containers/UserPage.js
@@ -32,7 +32,7 @@ class UserPage extends Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.login !== this.props.login) {
-      loadData(this.props.login)
+      loadData(this.props)
     }
   }
 


### PR DESCRIPTION
Fix a TypeError exception, raised because wrong argument is passed to a function call.