### PR TITLE
docs: Add language identifier to all code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Visit the [issue tracker](https://github.com/reduxjs/redux/issues) to find a lis
 
 Fork, then clone the repo:
 
-```
+```sh
 git clone https://github.com/your-username/redux.git
 ```
 
@@ -44,7 +44,7 @@ git clone https://github.com/your-username/redux.git
 
 Running the `build` task will create a CommonJS module-per-module build, a ES Modules build and a UMD build.
 
-```
+```sh
 npm run build
 ```
 
@@ -52,19 +52,19 @@ npm run build
 
 To only run linting:
 
-```
+```sh
 npm run lint
 ```
 
 To only run tests:
 
-```
+```sh
 npm run test
 ```
 
 To continuously watch and run tests, run the following:
 
-```
+```sh
 npm run test:watch
 ```
 
@@ -84,7 +84,7 @@ When adding a new example, please adhere to the style and format of the existing
 
 To test the official Redux examples, run the following:
 
-```
+```sh
 npm run examples:test
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Even if you haven't used Flux or Elm, Redux only takes a few minutes to get star
 
 To install the stable version:
 
-```
+```sh
 npm install --save redux
 ```
 
@@ -108,7 +108,7 @@ The Redux source code is written in ES2015 but we precompile both CommonJS and U
 
 Most likely, you'll also need [the React bindings](https://github.com/reduxjs/react-redux) and [the developer tools](https://github.com/reduxjs/redux-devtools).
 
-```
+```sh
 npm install --save react-redux
 npm install --save-dev redux-devtools
 ```

--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -9,7 +9,7 @@ The resulting reducer calls every child reducer, and gathers their results into 
 
 Example:
 
-```
+```js
 rootReducer = combineReducers({potato: potatoReducer, tomato: tomatoReducer})
 // This would produce the following state object
 {

--- a/docs/basics/Actions.md
+++ b/docs/basics/Actions.md
@@ -95,7 +95,7 @@ const boundCompleteTodo = index => dispatch(completeTodo(index))
 
 Now you'll be able to call them directly:
 
-```
+```js
 boundAddTodo(text)
 boundCompleteTodo(index)
 ```

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -12,7 +12,7 @@ We will use React to build our simple todo app, and cover the basics of how to u
 
 [React bindings](https://github.com/reduxjs/react-redux) are not included in Redux by default. You need to install them explicitly:
 
-```
+```sh
 npm install --save react-redux
 ```
 

--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -6,7 +6,7 @@ Redux is distributed with a few examples in its [source code](https://github.com
 
 Run the [Counter Vanilla](https://github.com/reactjs/redux/tree/master/examples/counter-vanilla) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/counter-vanilla
@@ -19,7 +19,7 @@ It does not require a build system or a view framework and exists to show the ra
 
 Run the [Counter](https://github.com/reactjs/redux/tree/master/examples/counter) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/counter
@@ -39,7 +39,7 @@ This example includes tests.
 
 Run the [Todos](https://github.com/reactjs/redux/tree/master/examples/todos) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/todos
@@ -57,7 +57,7 @@ This example includes tests.
 
 Run the [Todos with Undo](https://github.com/reactjs/redux/tree/master/examples/todos-with-undo) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/todos-with-undo
@@ -73,7 +73,7 @@ This is a variation on the previous example. It is almost identical, but additio
 
 Run the [TodoMVC](https://github.com/reactjs/redux/tree/master/examples/todomvc) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/todomvc
@@ -91,7 +91,7 @@ This example includes tests.
 
 Run the [Shopping Cart](https://github.com/reactjs/redux/tree/master/examples/shopping-cart) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/shopping-cart
@@ -107,7 +107,7 @@ This example shows important idiomatic Redux patterns that become important as y
 
 Run the [Tree View](https://github.com/reactjs/redux/tree/master/examples/tree-view) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/tree-view
@@ -125,7 +125,7 @@ This example includes tests.
 
 Run the [Async](https://github.com/reactjs/redux/tree/master/examples/async) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/async
@@ -141,7 +141,7 @@ This example includes reading from an asynchronous API, fetching data in respons
 
 Run the [Universal](https://github.com/reactjs/redux/tree/master/examples/universal) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/universal
@@ -155,7 +155,7 @@ This is a basic demonstration of [server rendering](../recipes/ServerRendering.m
 
 Run the [Real World](https://github.com/reactjs/redux/tree/master/examples/real-world) example:
 
-```
+```sh
 git clone https://github.com/reactjs/redux.git
 
 cd redux/examples/real-world

--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -42,7 +42,7 @@ We will add two middlewares and one enhancer:
 
 #### Install `redux-thunk`
 
-```
+```sh
 npm install --save redux-thunk
 ```
 
@@ -207,7 +207,7 @@ There are several ways to integrate the extension, but we will use the most conv
 
 First, we install the package via npm:
 
-```
+```sh
 npm install --save-dev redux-devtools-extension
 ```
 

--- a/docs/recipes/ImplementingUndoHistory.md
+++ b/docs/recipes/ImplementingUndoHistory.md
@@ -375,7 +375,7 @@ In this part of the recipe, you will learn how to make the [Todo List example](h
 
 First of all, you need to run
 
-```
+```sh
 npm install --save redux-undo
 ```
 

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -26,7 +26,7 @@ In the following recipe, we are going to look at how to set up server-side rende
 
 For this example, we'll be using [Express](http://expressjs.com/) as a simple web server. We also need to install the React bindings for Redux, since they are not included in Redux by default.
 
-```
+```sh
 npm install --save express react-redux
 ```
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -7,13 +7,13 @@ Because most of the Redux code you write are functions, and many of them are pur
 We recommend [Jest](http://facebook.github.io/jest/) as the testing engine.
 Note that it runs in a Node environment, so you won't have access to the DOM.
 
-```
+```sh
 npm install --save-dev jest
 ```
 
 To use it together with [Babel](http://babeljs.io), you will need to install `babel-jest`:
 
-```
+```sh
 npm install --save-dev babel-jest
 ```
 
@@ -254,13 +254,13 @@ A nice thing about React components is that they are usually small and only rely
 
 First, we will install [Enzyme](http://airbnb.io/enzyme/). Enzyme uses the [React Test Utilities](https://facebook.github.io/react/docs/test-utils.html) underneath, but is more convenient, readable, and powerful.
 
-```
+```sh
 npm install --save-dev enzyme
 ```
 
 We will also need to install Enzyme adapter for our version of React. Enzyme has adapters that provide compatibility with `React 16.x`, `React 15.x`, `React 0.14.x` and `React 0.13.x`. If you are using React 16 you can run:
 
-```
+```sh
 npm install --save-dev enzyme-adapter-react-16
 ```
 


### PR DESCRIPTION
This PR adds a language identifier to all the code blocks under `/docs` that were missing one.

There are two cases where a `js` identifier was missing, causing the block not to be highlighted.

Apart from those two, this PR adds a `sh` identifier to all blocks containing shell commands.

In case the latter is not wanted, let me know and I can change this to only add the two missing `js` identifiers.