### PR TITLE
Remove outdated Link, Add Redux Book

### DIFF
--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -168,10 +168,6 @@ _How to structure the Redux store like a database for best performance_
   https://medium.com/@adamrackis/normalizing-redux-stores-for-maximum-code-reuse-ae6e3844ae95  
   Thoughts on how normalized Redux stores enable some useful data handling approaches, with examples of using selector functions to denormalize hierarchical data.
 
-- **Redux Normalizr: Improve your State Management**  
-  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux-normalizr/  
-  A tutorial describing how to use Normalizr for improved data management of nested data in Redux
-
 - **Advanced Redux Entity Normalization**  
   https://medium.com/@dcousineau/advanced-redux-entity-normalization-f5f1fe2aefc5  
   Describes a "keyWindow" concept for tracking subsets of entities in state, similar to an SQL "view". A useful extension to the idea of normalized data.
@@ -356,6 +352,10 @@ _Patterns and practices for structuring larger Redux applications_
 - **The Complete Redux Book**  
   https://leanpub.com/redux-book  
   How do I manage a large state in production? Why do I need store enhancers? What is the best way to handle form validations? Get the answers to all these questions and many more using simple terms and sample code. Learn everything you need to use Redux to build complex and production-ready web applications. (Note: now permanently free!)
+
+- **Taming the State in React**  
+  https://www.robinwieruch.de/learn-react-redux-mobx-state-management/  
+  If you have learned React with the previous book of the author called The Road to learn React, Taming the State in React will be the perfect blend to learn about basic and advanced state management in React. You will start out with learning only Redux without React. Afterward, the book shows you how to connect Redux to your React application. The advanced chapters will teach you about normalization, naming, selectors and asynchronous actions. In the end, you will set up and build a real world application with React and Redux.
 
 ## Courses
 


### PR DESCRIPTION
Just went through the Redux resources page and saw an outdated link from my website. It shows how to use normalizr, but I feel guilty because I really need to update it. 

A better resource for learning Redux in React would be Taming the State in React though :) Would love to get it into the books section.