### PR TITLE
Use the gitlab link of combine-section-reducers project as it has beenmoved to gitlab

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -70,7 +70,7 @@ Redux bindings for custom elements
 
 #### Reducer Combination
 
-**[ryo33/combineSectionReducers](https://github.com/ryo33/combine-section-reducers)**  
+**[ryo33/combineSectionReducers](https://gitlab.com/ryo33/combine-section-reducers)**  
 An expanded version of `combineReducers`, which allows passing `state` as a third argument to all slice reducers.
 
 **[KodersLab/topologically-combine-reducers](https://github.com/KodersLab/topologically-combine-reducers)**  


### PR DESCRIPTION
[combine-section-reducers](https://github.com/ryo33/combine-section-reducers) project has been moved to [gitlab](https://gitlab.com/ryo33/combine-section-reducers) from github. We need to update  doc too.