### PR TITLE
Fix wrong anchor in Store documentation

### DIFF
--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -15,7 +15,7 @@ To create it, pass your root [reducing function](../Glossary.md#reducer) to [`cr
 - [`getState()`](#getState)
 - [`dispatch(action)`](#dispatch)
 - [`subscribe(listener)`](#subscribe)
-- [`replaceReducer(nextReducer)`](#replacereducer)
+- [`replaceReducer(nextReducer)`](#replaceReducer)
 
 ## Store Methods
 


### PR DESCRIPTION
The anchor wasn't matching the target element so it wasn't scrolling.