### PR TITLE
Simplify isPlainObject better performance

### DIFF
--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -3,12 +3,5 @@
  * @returns {boolean} True if the argument appears to be a plain object.
  */
 export default function isPlainObject(obj) {
-  if (typeof obj !== 'object' || obj === null) return false
-
-  let proto = obj
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
-  }
-
-  return Object.getPrototypeOf(obj) === proto
+  return obj != null && Object.getPrototypeOf(obj) === Object.prototype
 }


### PR DESCRIPTION
There is no need to go through the entire prototypal chain to see if `obj`'s prototype is equal to `Object.prototype`.