### PR TITLE
isPlainObject better performance

### DIFF
--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -5,10 +5,7 @@
 export default function isPlainObject(obj) {
   if (typeof obj !== 'object' || obj === null) return false
 
-  let proto = obj
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
-  }
+  let proto = Object.getPrototypeOf(obj)
 
-  return Object.getPrototypeOf(obj) === proto
+  return proto !== null && Object.getPrototypeOf(proto) === null
 }


### PR DESCRIPTION
There is no need to go through an object's entire prototypal chain to see if the first `proto` is equal to the last non-null `proto` in the chain.  Just check that the object's  prototypal chain has only one non-null `proto` in its chain.