### PR TITLE
Removed unnecessary semicolon

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -38,7 +38,7 @@ You'll often find that you need to store some data, as well as some UI state, in
 Now that we've decided what our state object looks like, we're ready to write a reducer for it. The reducer is a pure function that takes the previous state and an action, and returns the next state.
 
 ```js
-;(previousState, action) => newState
+(previousState, action) => newState
 ```
 
 It's called a reducer because it's the type of function you would pass to [`Array.prototype.reduce(reducer, ?initialValue)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce). It's very important that the reducer stays pure. Things you should **never** do inside a reducer:


### PR DESCRIPTION
Removed unnecessary semicolon in the docs [(Basics > Reducers#handling-actions)](https://redux.js.org/basics/reducers#handling-actions)