### PR TITLE
fix overflow bug, centre align footer on mobile

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -147,6 +147,8 @@ header.postHeader:empty + article h1 {
 .nav-footer .sitemap a {
   /* increase link contrast */
   color: white;
+  margin: 0;
+  padding: 9px 5px;
 }
 
 .button.hero {
@@ -257,6 +259,17 @@ header.postHeader:empty + article h1 {
 }
 
 @media only screen and (max-width: 1023px) {
+	.nav-footer {
+		text-align: center;
+	}
+
+	.nav-footer .copyright {
+		padding: 20px;
+	}
+
+	.nav-footer .sitemap .nav-home {
+		margin: 0 auto;
+	}
 
   .libsContainer {
     flex-direction: column;


### PR DESCRIPTION
overflow bug: you should no longer see a horizontal scroll bar for no reason

see footer on mobile/narrow screen for other change