### PR TITLE
[Website] Increased search input spacing on mobile and desktop

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -254,9 +254,34 @@ header.postHeader:empty + article h1 {
 }
 
 @media only screen and (min-width: 1024px) {
+  .reactNavSearchWrapper input#search_input_react {
+    height: 100%;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 38px;
+  }
+
+  .navSearchWrapper:before {
+    left: 24px;
+  }
+
+  .navSearchWrapper:after {
+    left: 35px;
+  }
 }
 
 @media only screen and (max-width: 1023px) {
+  .reactNavSearchWrapper input#search_input_react {
+    padding-left: 38px;
+  }
+
+  .navSearchWrapper:before {
+    left: 24px;
+  }
+
+  .navSearchWrapper:after {
+    left: 35px;
+  }
 
   .libsContainer {
     flex-direction: column;


### PR DESCRIPTION
The default Docosaurus spacing felt a little restricted and awkward, so I increased it for both mobile and desktop versions of the website.

I'll make identical PRs for the `react-redux` and `redux-starter-kit` once this one gets approved so that website styles are mirrored for all websites.