### PR TITLE
More links to docs sites instead of repo markdown

### DIFF
--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -132,7 +132,7 @@ render(<Root store={store} />, document.getElementById('root'))
 
 ## Navigating with React Router
 
-React Router comes with a [`<Link />`](https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#link) component that lets you navigate around your application. If you want to add some styles, `react-router-dom` has another special `<Link />` called [`<NavLink />`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md), which accepts styling props. For instance, the `activeStyle` property lets us apply a style on the active state.
+React Router comes with a [`<Link />`](https://reacttraining.com/react-router/web/api/Link) component that lets you navigate around your application. If you want to add some styles, `react-router-dom` has another special `<Link />` called [`<NavLink />`](https://reacttraining.com/react-router/web/api/NavLink), which accepts styling props. For instance, the `activeStyle` property lets us apply a style on the active state.
 
 In our example, we can wrap `<NavLink />` with a new container component `<FilterLink />` so as to dynamically change the URL.
 

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -418,7 +418,7 @@ export default App
 
 All container components need access to the Redux store so they can subscribe to it. One option would be to pass it as a prop to every container component. However it gets tedious, as you have to wire `store` even through presentational components just because they happen to render a container deep in the component tree.
 
-The option we recommend is to use a special React Redux component called [`<Provider>`](https://github.com/reduxjs/react-redux/blob/master/docs/api.md#provider-store) to [magically](https://facebook.github.io/react/docs/context.html) make the store available to all container components in the application without passing it explicitly. You only need to use it once when you render the root component:
+The option we recommend is to use a special React Redux component called [`<Provider>`](https://react-redux.js.org/api/provider) to [magically](https://facebook.github.io/react/docs/context.html) make the store available to all container components in the application without passing it explicitly. You only need to use it once when you render the root component:
 
 #### `index.js`
 

--- a/docs/faq/DesignDecisions.md
+++ b/docs/faq/DesignDecisions.md
@@ -34,7 +34,7 @@ A potential use-case for using the action inside a subscriber -- which is an uns
 1. the [shouldComponentUpdate](https://facebook.github.io/react/docs/react-component.html#shouldcomponentupdate) lifecycle method
 2. the [virtual DOM equality check (vDOMEq)](https://facebook.github.io/react/docs/optimizing-performance.html#avoid-reconciliation)
 3. [React.PureComponent](https://facebook.github.io/react/docs/optimizing-performance.html#examples)
-4. Using React-Redux: use [mapStateToProps](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) to subscribe components to only the parts of the store that they need.
+4. Using React-Redux: use [mapStateToProps](https://react-redux.js.org/api#connect) to subscribe components to only the parts of the store that they need.
 
 #### Further Information
 

--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -134,7 +134,7 @@ This is worth emphasizing: _If the reducers all return the same `state` object p
 
 React-Redux uses shallow equality checking to determine whether the component it’s wrapping needs to be re-rendered.
 
-To do this, it assumes that the wrapped component is pure; that is, that the component will produce the [same results given the same props and state](https://github.com/reduxjs/react-redux/blob/f4d55840a14601c3a5bdc0c3d741fc5753e87f66/docs/troubleshooting.md#my-views-arent-updating-when-something-changes-outside-of-redux).
+To do this, it assumes that the wrapped component is pure; that is, that the component will produce the [same results given the same props and state](https://react-redux.js.org/troubleshooting#my-views-aren-t-updating-when-something-changes-outside-of-redux).
 
 By assuming the wrapped component is pure, it need only check whether the root state object or the values returned from `mapStateToProps` have changed. If they haven’t, the wrapped component does not need re-rendering.
 
@@ -289,7 +289,7 @@ Because React-Redux performs a shallow check on the root state object to determi
 
 **Documentation**
 
-- [Troubleshooting: My views aren’t updating when something changes outside of Redux](https://github.com/reduxjs/react-redux/blob/f4d55840a14601c3a5bdc0c3d741fc5753e87f66/docs/troubleshooting.md#my-views-arent-updating-when-something-changes-outside-of-redux)
+- [Troubleshooting: My views aren’t updating when something changes outside of Redux](https://react-redux.js.org/troubleshooting#my-views-aren-t-updating-when-something-changes-outside-of-redux)
 
 ### Why does a selector mutating and returning a persistent object to `mapStateToProps` prevent React-Redux from re-rendering a wrapped component?
 

--- a/docs/faq/ReactRedux.md
+++ b/docs/faq/ReactRedux.md
@@ -34,7 +34,7 @@ Note that “updating data immutably” does _not_ mean that you must use [Immut
 **Documentation**
 
 - [Troubleshooting](../Troubleshooting.md)
-- [React Redux: Troubleshooting](https://github.com/reduxjs/react-redux/blob/master../troubleshooting.md)
+- [React Redux: Troubleshooting](https://react-redux.js.org/troubleshooting)
 - [Recipes: Using the Object Spread Operator](../recipes/UsingObjectSpreadOperator.md)
 - [Recipes: Structuring Reducers - Prerequisite Concepts](../recipes/structuring-reducers/PrerequisiteConcepts.md)
 - [Recipes: Structuring Reducers - Immutable Update Patterns](../recipes/structuring-reducers/ImmutableUpdatePatterns.md)
@@ -121,7 +121,7 @@ If you do not provide your own `mapDispatchToProps` function when calling `conne
 
 **Documentation**
 
-- [React Redux API: connect()](https://github.com/reduxjs/react-redux/blob/master../api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
+- [React Redux API: connect()](https://react-redux.js.org/api#connect)
 
 **Discussions**
 

--- a/docs/introduction/Installation.md
+++ b/docs/introduction/Installation.md
@@ -21,7 +21,7 @@ Most commonly, people consume Redux as a collection of [CommonJS](http://webpack
 
 If you don't use a module bundler, it's also fine. The `redux` npm package includes precompiled production and development [UMD](https://github.com/umdjs/umd) builds in the [`dist` folder](https://unpkg.com/redux/dist/). They can be used directly without a bundler and are thus compatible with many popular JavaScript module loaders and environments. For example, you can drop a UMD build as a [`<script>` tag](https://unpkg.com/redux/dist/redux.js) on the page, or [tell Bower to install it](https://github.com/reduxjs/redux/pull/1181#issuecomment-167361975). The UMD builds make Redux available as a `window.Redux` global variable.
 
-The Redux source code is written in ES2015 but we precompile both CommonJS and UMD builds to ES5 so they work in [any modern browser](http://caniuse.com/#feat=es5). You don't need to use Babel or a module bundler to [get started with Redux](https://github.com/reduxjs/redux/blob/master/examples/counter-vanilla/index.html).
+The Redux source code is written in ES2015 but we precompile both CommonJS and UMD builds to ES5 so they work in [any modern browser](http://caniuse.com/#feat=es5). You don't need to use Babel or a module bundler to [get started with Redux](https://redux.js.org/introduction/examples#counter-vanilla).
 
 ## Complementary Packages
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -359,7 +359,7 @@ describe('components', () => {
 
 ### Connected Components
 
-If you use a library like [React Redux](https://github.com/reduxjs/react-redux), you might be using [higher-order components](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) like [`connect()`](https://github.com/reduxjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options). This lets you inject Redux state into a regular React component.
+If you use a library like [React Redux](https://github.com/reduxjs/react-redux), you might be using [higher-order components](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) like [`connect()`](https://react-redux.js.org/api#connect). This lets you inject Redux state into a regular React component.
 
 Consider the following `App` component:
 
@@ -379,7 +379,7 @@ In a unit test, you would normally import the `App` component like this:
 import App from './App'
 ```
 
-However, when you import it, you're actually holding the wrapper component returned by `connect()`, and not the `App` component itself. If you want to test its interaction with Redux, this is good news: you can wrap it in a [`<Provider>`](https://github.com/reduxjs/react-redux/blob/master/docs/api.md#provider-store) with a store created specifically for this unit test. But sometimes you want to test just the rendering of the component, without a Redux store.
+However, when you import it, you're actually holding the wrapper component returned by `connect()`, and not the `App` component itself. If you want to test its interaction with Redux, this is good news: you can wrap it in a [`<Provider>`](https://react-redux.js.org/api/provider) with a store created specifically for this unit test. But sometimes you want to test just the rendering of the component, without a Redux store.
 
 In order to be able to test the App component itself without having to deal with the decorator, we recommend you to also export the undecorated component:
 


### PR DESCRIPTION
Actual API docs are a little nicer to read than a file in the repository