### PR TITLE
Expand docs for using Immutable.js with selectors

### DIFF
--- a/docs/recipes/UsingImmutableJS.md
+++ b/docs/recipes/UsingImmutableJS.md
@@ -232,7 +232,11 @@ Do not, however, use Immutable.JS in your dumb components.
 
 ### Your selectors should return Immutable.JS objects
 
-Always.
+Always. This practice has several advantages:
+
+- It avoids unnecessary rerenders caused by calling `.toJS()` in selectors (since `.toJS()` will always return a new object).
+    - It is possible to memoize selectors where you call `.toJS()`, but it’s redundant when just returning Immutable.js objects without memoizing will suffice.
+- It establishes a consistent interface for selectors; you won’t have to keep track of whether an Immutable.js object or plain JavaScript object will be returned.
 
 ### Use Immutable.JS objects in your Smart Components
 
@@ -282,7 +286,7 @@ Such a dependency renders the component impure, makes testing the component more
 
 Something needs to map the Immutable.JS props in your Smart Component to the pure JavaScript props used in your Dumb Component. That something is a Higher Order Component (HOC) that simply takes the Immutable.JS props from your Smart Component, and converts them using `toJS()` to plain JavaScript props, which are then passed to your Dumb Component.
 
-Here is an example of such a HOC:
+An example of such a HOC follows. A similar HOC is available as an NPM package for your convenience: [with-immutable-props-to-js](https://www.npmjs.com/package/with-immutable-props-to-js).
 
 ```js
 import React from 'react'

--- a/docs/recipes/UsingImmutableJS.md
+++ b/docs/recipes/UsingImmutableJS.md
@@ -235,7 +235,7 @@ Do not, however, use Immutable.JS in your dumb components.
 Always. This practice has several advantages:
 
 - It avoids unnecessary rerenders caused by calling `.toJS()` in selectors (since `.toJS()` will always return a new object).
-    - It is possible to memoize selectors where you call `.toJS()`, but it’s redundant when just returning Immutable.js objects without memoizing will suffice.
+  - It is possible to memoize selectors where you call `.toJS()`, but it’s redundant when just returning Immutable.js objects without memoizing will suffice.
 - It establishes a consistent interface for selectors; you won’t have to keep track of whether an Immutable.js object or plain JavaScript object will be returned.
 
 ### Use Immutable.JS objects in your Smart Components


### PR DESCRIPTION
You can view the compiled markdown [here](https://github.com/msrose/redux/blob/2ed8ca5b7602fcdac78010079ea2a175ae1847d2/docs/recipes/UsingImmutableJS.md#your-selectors-should-return-immutablejs-objects).

The info on this doc page was really helpful for us standardizing our usage of selectors with Immutable.js at Top Hat, so I just wanted to expand on some of the points already made to afford a bit more clarity. 

We have also been using the suggested HOC for converting Immutable.js props to plain JS objects to avoid polluting our presentational components; we found the same HOC cropping up in various incarnations in our front-end projects, so we've released the NPM package [with-immutable-props-to-js](https://www.npmjs.com/package/with-immutable-props-to-js). Hoping other may find it useful so I've linked it in the docs as well.