### PR TITLE
Fix AnyAction comment in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,8 @@ export interface Action<T = any> {
 /**
  * An Action type which accepts any other properties.
  * This is mainly for the use of the `Reducer` type.
- * This is not part of `Action` itself to prevent users who are extending `Action.
+ * This is not part of `Action` itself to prevent types that extend `Action` from
+ * having an index signature.
  */
 export interface AnyAction extends Action {
   // Allows any extra properties to be defined in an action.


### PR DESCRIPTION
This PR replaces an accidentally incomplete comment above the `AnyAction` which was previously accidentally merged.