### PR TITLE
Add explicit mention of Redux ES build

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ To specify how the actions transform the state tree, you write pure _reducers_.
 That's it!
 
 ```js
+// This assumes you are running in a Node environment. If you are running in a browser environment,
+// import from 'redux/es/redux.mjs' instead.
 import { createStore } from 'redux'
 
 /**

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -47,6 +47,8 @@ To specify how the actions transform the state tree, you write pure _reducers_.
 That's it!
 
 ```js
+// This assumes you are running in a Node environment. If you are running in a browser environment,
+// import from 'redux/es/redux.mjs' instead.
 import { createStore } from 'redux'
 
 /**

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -47,8 +47,8 @@ To specify how the actions transform the state tree, you write pure _reducers_.
 That's it!
 
 ```js
-// This assumes you are running in a Node environment. If you are running in a browser environment,
-// import from 'redux/es/redux.mjs' instead.
+// This assumes you are running in a Node environment. If you are running in a browser
+// environment, import from 'redux/es/redux.mjs' instead.
 import { createStore } from 'redux'
 
 /**


### PR DESCRIPTION
For new users who want to consume Redux using ES modules in a browser,
the current import directs them to the Node-compatible build.

Therefore, add an explicit comment in the README pointing these users to
the `redux/es/redux.mjs` build that does work in a browser environment.