### PR TITLE
compose: use identity function as a default argument for reduce

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -10,13 +10,9 @@
  */
 
 export default function compose(...funcs) {
-  if (funcs.length === 0) {
-    return arg => arg
-  }
-
   if (funcs.length === 1) {
     return funcs[0]
   }
 
-  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+  return funcs.reduce((a, b) => (...args) => a(b(...args)), x => x)
 }


### PR DESCRIPTION
Minor improvement of the functional style for `compose` definition: 
- replaced an `if` block with an identity function as default argument for `reduce`.

Even though `compose` can be defined as one line using the identity function, but one-function case optimization still makes sense.