### PR TITLE
Bugfix: Real world example RepoPage Component was broken due to calli…

### DIFF
--- a/examples/real-world/src/containers/RepoPage.js
+++ b/examples/real-world/src/containers/RepoPage.js
@@ -33,7 +33,7 @@ class RepoPage extends Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.fullName !== this.props.fullName) {
-      loadData(this.props.fullName)
+      loadData(this.props)
     }
   }
 


### PR DESCRIPTION
Real world example, RepoPage Component was broken due to calling loadData with props.fullName rather than props