### PR TITLE
Docs: Fix `React Redux API: connect()` link

### DIFF
--- a/docs/faq/ReactRedux.md
+++ b/docs/faq/ReactRedux.md
@@ -142,7 +142,7 @@ If you do not provide your own `mapDispatchToProps` function when calling `conne
 
 **Documentation**
 
-- [React Redux API: connect()](https://react-redux.js.org/api#connect)
+- [React Redux API: connect()](https://react-redux.js.org/api/connect)
 
 **Discussions**
 


### PR DESCRIPTION
The link to `connect()` API is not working
https://redux.js.org/faq/react-redux#further-information-4