### PR TITLE
Fix documentation container alignment

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -12,10 +12,6 @@ header.postHeader:empty + article h1 {
   padding-bottom: 1em;
 }
 
-.mainContainer {
-  padding-bottom: 24px;
-}
-
 .post article a {
   /* add underlines to links in blocks of text for a11y */
   color: $primaryColor;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -13,7 +13,6 @@ header.postHeader:empty + article h1 {
 }
 
 .mainContainer {
-  padding-top: 24px;
   padding-bottom: 24px;
 }
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -9,7 +9,7 @@ header.postHeader:empty + article h1 {
 }
 
 .homeContainer .homeWrapper {
-  padding-bottom: 1em;
+  padding: 4em 10px 1em;
 }
 
 .post article a {


### PR DESCRIPTION
## Before 

Note that the "Learning Resources" is off alignment from the left and right columns. There's custom CSS which changes the default top padding which messes with the alignment especially on mobile view:

<img width="1552" alt="screen shot 2019-01-27 at 11 17 26 am" src="https://user-images.githubusercontent.com/1315101/51805816-ee158480-2226-11e9-904c-f17ab6bba29f.png">
<img width="512" alt="screen shot 2019-01-27 at 11 17 30 am" src="https://user-images.githubusercontent.com/1315101/51805817-eeae1b00-2226-11e9-87c1-2ada08bef663.png">

## After

On mobile view, the header doesn't get hidden behind the navigation.

<img width="1552" alt="screen shot 2019-01-27 at 11 17 48 am" src="https://user-images.githubusercontent.com/1315101/51805818-eeae1b00-2226-11e9-8047-7e9a08c0b733.png">
<img width="512" alt="screen shot 2019-01-27 at 11 17 52 am" src="https://user-images.githubusercontent.com/1315101/51805819-eeae1b00-2226-11e9-8d27-ea7cf52f06a9.png">
