### PR TITLE
fix(docs): Fixes navigation for shortcode headings

### DIFF
--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -26,7 +26,7 @@ To create it, pass your root [reducing function](../Glossary.md#reducer) to [`cr
 
 ## Store Methods
 
-### <a id='getState'></a>[`getState()`](#getState)
+### <a id='getState' class='anchor'></a>[`getState()`](#getState)
 
 Returns the current state tree of your application.
 It is equal to the last value returned by the store's reducer.
@@ -37,7 +37,7 @@ _(any)_: The current state tree of your application.
 
 <hr>
 
-### <a id='dispatch'></a>[`dispatch(action)`](#dispatch)
+### <a id='dispatch' class='anchor'></a>[`dispatch(action)`](#dispatch)
 
 Dispatches an action. This is the only way to trigger a state change.
 
@@ -86,7 +86,7 @@ store.dispatch(addTodo('Read about the middleware'))
 
 <hr>
 
-### <a id='subscribe'></a>[`subscribe(listener)`](#subscribe)
+### <a id='subscribe' class='anchor'></a>[`subscribe(listener)`](#subscribe)
 
 Adds a change listener. It will be called any time an action is dispatched, and some part of the state tree may potentially have changed. You may then call [`getState()`](#getState) to read the current state tree inside the callback.
 
@@ -138,7 +138,7 @@ unsubscribe()
 
 <hr>
 
-### <a id='replaceReducer'></a>[`replaceReducer(nextReducer)`](#replaceReducer)
+### <a id='replaceReducer' class='anchor'></a>[`replaceReducer(nextReducer)`](#replaceReducer)
 
 Replaces the reducer currently used by the store to calculate the state.
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -92,6 +92,7 @@ header.postHeader:empty + article h1 {
   color: $accentColor1;
   transition: outline-offset 0.2s ease-in-out;
   opacity: 1;
+  position: absolute;
 }
 
 .post article .hash-link:hover,


### PR DESCRIPTION
When accessing to docs of API methods such as [`store.dispatch()`](https://redux.js.org/api/store#dispatch), the title gets cover by the navbar, but clicking on the anchor shortcut, gets rendered without problems. This PR adds the class used by the anchor, in order to have the same behavior.