### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/docs/introduction/Installation.md
+++ b/docs/introduction/Installation.md
@@ -10,7 +10,7 @@ hide_title: true
 To install the stable version:
 
 ```bash
-npm install --save redux
+npm install redux
 ```
 
 This assumes you are using [npm](https://www.npmjs.com/) as your package manager.
@@ -28,7 +28,7 @@ The Redux source code is written in ES2015 but we precompile both CommonJS and U
 Most likely, you'll also need [the React bindings](https://github.com/reduxjs/react-redux) and [the developer tools](https://github.com/reduxjs/redux-devtools).
 
 ```bash
-npm install --save react-redux
+npm install react-redux
 npm install --save-dev redux-devtools
 ```
 


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358