### PR TITLE
(docs) minor correction

### DIFF
--- a/docs/recipes/CodeSplitting.md
+++ b/docs/recipes/CodeSplitting.md
@@ -54,7 +54,7 @@ export default function configureStore(initialState) {
   // This function adds the async reducer, and creates a new combined reducer
   store.injectReducer = (key, asyncReducer) => {
     store.asyncReducers[key] = asyncReducer
-    store.replaceReducer(createReducer(this.asyncReducers))
+    store.replaceReducer(createReducer(store.asyncReducers))
   }
 
   // Return the modified store


### PR DESCRIPTION
`this.` does not work in this scenario.

Proof: https://codesandbox.io/s/w07qqwlkq5 --> replace store.asyncReducers with this.asyncReducers. In utils/createStore