### PR TITLE
Update UsingObjectSpreadOperator.md

### DIFF
--- a/docs/recipes/UsingObjectSpreadOperator.md
+++ b/docs/recipes/UsingObjectSpreadOperator.md
@@ -64,3 +64,6 @@ While the object spread syntax is a [Stage 4](https://github.com/tc39/proposal-o
   "plugins": ["transform-object-rest-spread"]
 }
 ```
+> ##### Note on Object Spread Operator
+
+> Like the Array Spread Operator, the Object Spread Operator creates a [shallow clone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) of the original object. In other words, for multidimensional source objects, elements in the copied object at a depth greater than one are mere references to the source object (with the exception of [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), which are copied). Thus, you cannot reliably use the  Object Spread Operator (`...`) for deep cloning objects.


### PR DESCRIPTION
I think this warning on using the Object spread operator to clone objects is important. While, good style would encourage the use of flat objects in the reducer, not everyone is going to do that. Using the spread syntax in a reducer on a multidimensional data structure is opening up the door to state mutation.