### PR TITLE
Iterate using for in instead of Object.keys and minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "11.10.1"
 install:
   - npm i -g npm@5.8.0
   - npm ci

--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -21,8 +21,8 @@ export default function applyMiddleware(...middlewares) {
     const store = createStore(...args)
     let dispatch = () => {
       throw new Error(
-        `Dispatching while constructing your middleware is not allowed. ` +
-          `Other middleware would not be applied to this dispatch.`
+        'Dispatching while constructing your middleware is not allowed. ' +
+          'Other middleware would not be applied to this dispatch.'
       )
     }
 

--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -39,10 +39,8 @@ export default function bindActionCreators(actionCreators, dispatch) {
     )
   }
 
-  const keys = Object.keys(actionCreators)
   const boundActionCreators = {}
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i]
+  for (const key in actionCreators) {
     const actionCreator = actionCreators[key]
     if (typeof actionCreator === 'function') {
       boundActionCreators[key] = bindActionCreator(actionCreator, dispatch)

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -36,7 +36,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     throw new Error(
       'It looks like you are passing several store enhancers to ' +
         'createStore(). This is not supported. Instead, compose them ' +
-        'together to a single function'
+        'together to a single function.'
     )
   }
 


### PR DESCRIPTION
Even though this code has no impact on the overall performance of the application `for in` is faster in modern browsers (https://jsperf.com/object-keys-vs-for-in-with-closure/138). 
I propose this change only as readability improvement.