### PR TITLE
Allow Redux to be imported as `type="module"`

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -118,7 +118,10 @@ export default function combineReducers(reducers) {
   for (let i = 0; i < reducerKeys.length; i++) {
     const key = reducerKeys[i]
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (
+      typeof process !== 'undefined' &&
+      process.env.NODE_ENV !== 'production'
+    ) {
       if (typeof reducers[key] === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
       }
@@ -133,7 +136,7 @@ export default function combineReducers(reducers) {
   // This is used to make sure we don't warn about the same
   // keys multiple times.
   let unexpectedKeyCache
-  if (process.env.NODE_ENV !== 'production') {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
     unexpectedKeyCache = {}
   }
 
@@ -149,7 +152,10 @@ export default function combineReducers(reducers) {
       throw shapeAssertionError
     }
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (
+      typeof process !== 'undefined' &&
+      process.env.NODE_ENV !== 'production'
+    ) {
       const warningMessage = getUnexpectedStateShapeWarningMessage(
         state,
         finalReducers,

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,7 +1,7 @@
-import $$observable from 'symbol-observable'
-
 import ActionTypes from './utils/actionTypes'
 import isPlainObject from './utils/isPlainObject'
+
+const $$observable = Symbol.observable || require('symbol-observable')
 
 /**
  * Creates a Redux store that holds the state tree.

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import __DO_NOT_USE__ActionTypes from './utils/actionTypes'
 function isCrushed() {}
 
 if (
+  typeof process !== 'undefined' &&
   process.env.NODE_ENV !== 'production' &&
   typeof isCrushed.name === 'string' &&
   isCrushed.name !== 'isCrushed'

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -11,7 +11,8 @@ import {
 import * as reducers from './helpers/reducers'
 import { from } from 'rxjs'
 import { map } from 'rxjs/operators'
-import $$observable from 'symbol-observable'
+
+const $$observable = Symbol.observable || require('symbol-observable')
 
 describe('createStore', () => {
   it('exposes the public API', () => {


### PR DESCRIPTION
We'd all love to import Redux as `type="module"` natively in the browser, however the `process.env` and the `symbol-observable` ponyfill make that problematic.

By checking for the existence of `symbol-observable` ourselves &mdash; rather than delegating it to a module unless we really need to &mdash; as well as checking for `typeof process` we can make it happen.

Redux is a simple enough library. Let's all be standards compliant, friends (or as close as we can at this point)! 🍻 

Discuss...