### PR TITLE
fixed undefined id when adding a new todo item

### DIFF
--- a/examples/todos/src/reducers/todos.js
+++ b/examples/todos/src/reducers/todos.js
@@ -4,7 +4,7 @@ const todos = (state = [], action) => {
       return [
         ...state,
         {
-          id: action.id,
+          id: state.length + 1,
           text: action.text,
           completed: false
         }


### PR DESCRIPTION
the action `addTodo` only passes `text`. So the `action.id` in reducer gets `undefined`. Fixed by set `id` to `state.length+1` inside reducer.