### PR TITLE
Fix chat action creators in UsageWithTypescript

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -86,10 +86,10 @@ With these types declared we can now also type check chat's action creators. In 
 ```ts
 // src/store/chat/actions.ts
 
-import { Message, SEND_MESSAGE, DELETE_MESSAGE } from './types'
+import { Message, SEND_MESSAGE, DELETE_MESSAGE, ChatActionTypes } from './types'
 
 // TypeScript infers that this function is returning SendMessageAction
-export function sendMessage(newMessage: Message) {
+export function sendMessage(newMessage: Message): ChatActionTypes {
   return {
     type: SEND_MESSAGE,
     payload: newMessage
@@ -97,7 +97,7 @@ export function sendMessage(newMessage: Message) {
 }
 
 // TypeScript infers that this function is returning DeleteMessageAction
-export function deleteMessage(timestamp: number) {
+export function deleteMessage(timestamp: number): ChatActionTypes {
   return {
     type: DELETE_MESSAGE,
     meta: {
@@ -126,9 +126,9 @@ With these types we can now also type check system's action creators:
 ```ts
 // src/store/system/actions.ts
 
-import { SystemState, UPDATE_SESSION } from './types'
+import { SystemState, UPDATE_SESSION, SystemActionTypes } from './types'
 
-export function updateSession(newSession: SystemState) {
+export function updateSession(newSession: SystemState): SystemActionTypes {
   return {
     type: UPDATE_SESSION,
     payload: newSession


### PR DESCRIPTION
The comments in the chat action creators imply that `TypeScript infers that this function is returning DeleteMessageAction`, while the returned union type is not defined.

If the return type is not manually linked to the Union Type, I have no idea how the inference based on just the constant should work.