### PR TITLE
Use correct name for middleware

### DIFF
--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -56,7 +56,7 @@ npm install --save redux-thunk
 #### middleware/logger.js
 
 ```js
-const logger = store => next => action => {
+const loggerMiddleware = store => next => action => {
   console.group(action.type)
   console.info('dispatching', action)
   let result = next(action)
@@ -65,7 +65,7 @@ const logger = store => next => action => {
   return result
 }
 
-export default logger
+export default loggerMiddleware
 ```
 
 #### enhancers/monitorReducer.js


### PR DESCRIPTION
`loggerMiddleware` can't be imported in the `configureStore` function example.
https://github.com/reduxjs/redux/pull/3405/commits/8c2e936efd11838027adf4519c3995477b99f636#diff-178bc9a75ee1d44e782570fb9152d5a0L115