### PR TITLE
test(typescript): fix invalid tsconfig.json

### DIFF
--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     "strict": true,
     "baseUrl": "../..",
     "paths": {
-      "redux": "index.d.ts"
+      "redux": ["index.d.ts"]
     }
   }
 }


### PR DESCRIPTION
The entries in `paths` should be arrays. See the [schema](http://json.schemastore.org/tsconfig).