### PR TITLE
remove "obviously"

### DIFF
--- a/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
+++ b/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
@@ -140,7 +140,7 @@ The example is a bit long, because it's showing how all the different slice redu
 
 ### Task-Based Updates
 
-Since reducers are just functions, there's an infinite number of ways to split up this logic. While using slice reducers is obviously the most common, it's also possible to organize behavior in a more task-oriented structure. Because this will often involve more nested updates, you may want to use an immutable update utility library like [dot-prop-immutable](https://github.com/debitoor/dot-prop-immutable) or [object-path-immutable](https://github.com/mariocasciaro/object-path-immutable) to simplify the update statements. Here's an example of what that might look like:
+Since reducers are just functions, there's an infinite number of ways to split up this logic. While using slice reducers is the most common, it's also possible to organize behavior in a more task-oriented structure. Because this will often involve more nested updates, you may want to use an immutable update utility library like [dot-prop-immutable](https://github.com/debitoor/dot-prop-immutable) or [object-path-immutable](https://github.com/mariocasciaro/object-path-immutable) to simplify the update statements. Here's an example of what that might look like:
 
 ```js
 import posts from "./postsReducer";


### PR DESCRIPTION
inspired by #2950 - I think using "obviously" here can be confusing by assuming a reader knows it's obvious (and why), vs just stating that it's the most common.