### PR TITLE
expose bindActionCreator function

### DIFF
--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -1,4 +1,14 @@
-function bindActionCreator(actionCreator, dispatch) {
+/**
+ * Creates a dispatch wrapped function.
+ * 
+ * @param {Function} actionCreator action creator function.
+ * 
+ * @param {Function} dispatch The `dispatch` function available on your Redux
+ * store.
+ * 
+ * @returns {Function} binded actionCreator function.
+ */
+export function bindActionCreator(actionCreator, dispatch) {
   return function() {
     return dispatch(actionCreator.apply(this, arguments))
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import createStore from './createStore'
 import combineReducers from './combineReducers'
-import bindActionCreators from './bindActionCreators'
+import bindActionCreators, { bindActionCreator } from './bindActionCreators'
 import applyMiddleware from './applyMiddleware'
 import compose from './compose'
 import warning from './utils/warning'
@@ -29,6 +29,7 @@ if (
 export {
   createStore,
   combineReducers,
+  bindActionCreator,
   bindActionCreators,
   applyMiddleware,
   compose,


### PR DESCRIPTION
Hi,
I have made a small change to expose `bindActionCreator` function. Although the existing `bindActionCreators` function accepts a function as first argument. I feel it's nice to have `bindActionCreator` function for readability when using a single dispatcher.