### PR TITLE
[DOCS]: Fixing small typo

### DIFF
--- a/docs/recipes/CodeSplitting.md
+++ b/docs/recipes/CodeSplitting.md
@@ -84,7 +84,7 @@ export function createReducerManager(initialReducers) {
   let combinedReducer = combineReducers(reducers)
 
   // An array which is used to delete state keys when reducers are removed
-  const keysToRemove = []
+  let keysToRemove = []
 
   return {
     getReducerMap: () => reducers,


### PR DESCRIPTION
The docs have the `keysToRemove` array set to a const but then later in the code try to reassign the variable to another array.