### PR TITLE
changed headerLinks type to page for stylings to be used properly

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -30,9 +30,9 @@ const siteConfig = {
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
-    { doc: "introduction/getting-started", label: "Getting Started" },
-    { doc : "api/api-reference", label : "API"},
-    { doc : "faq", label : "FAQ"},
+    { page: "introduction/getting-started", label: "Getting Started" },
+    { page : "api/api-reference", label : "API"},
+    { page : "faq", label : "FAQ"},
     { href : "https://www.github.com/reduxjs/redux", label : "Github"},
     { href: "/introduction/getting-started#help-and-discussion", label: "Need help?" },
   ],


### PR DESCRIPTION
Went through the docusaurus docs and realized no css changes were necessary. Changed the headerLink type to page so that we are only using the `siteNavItemActive `class rather than both `siteNavItemActive` and `siteNavGroupActive`.