### PR TITLE
Website: keep header searchbar background consistent on mobile

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -266,6 +266,12 @@ header.postHeader:empty + article h1 {
   }
 }
 
+@media only screen and (max-width: 1024px) {
+  .reactNavSearchWrapper input#search_input_react {
+    background: rgba(0, 0, 0, 0.2);
+  }
+}
+
 @media only screen and (max-width: 1023px) {
   .reactNavSearchWrapper input#search_input_react {
     padding-left: 38px;


### PR DESCRIPTION
Resolves https://twitter.com/acemarke/status/1134315647427440642

It does feel weird to have a media rule for both 1023px and 1024px but with 1023px we could observe the wrong color for an instant when resizing the window.

It might be better to enforce the rule on any resolution so it won't break if docusaurus changes the way it handles this?