### PR TITLE
fix(docs): Fix header anchor link positioning

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -31,7 +31,6 @@ header.postHeader:empty + article h1 {
   outline: none;
   text-decoration: underline;
   overflow: hidden;
-  position: relative;
   transition: outline-offset 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
What does this PR do?
---
Fixes #3427

So I've dug a bit more around the header anchor. There are four `<a />`s here: 
<img width="846" alt="image" src="https://user-images.githubusercontent.com/2055384/58769694-f66a3b80-85db-11e9-94a4-43656383ecf7.png">

The first and the third are not shown because there is no content inside.

The second one, one with class name `.hash-link`, is the anchor for the icon. And the fourth one, one without any class name, is the one for the header.

Here are the two CSS rules involved, both in custom.css:

```css
.post article blockquote a:hover,
.post article blockquote a:focus,
.post article blockquote a:active {
  position: relative;
}
```

and 

```css
.post article .hash-link {
  position: absolute
}
```

The `.hash-link` has `position: absolute` which give it the desired positioning. It gets broken when the first rule is in action because it has higher CSS specificity.