### PR TITLE
Add opt-out - with deprecation warnings - to the bans on getState, subscription Handling and dispatch in the reducers

### DIFF
--- a/docs/api/createStore.md
+++ b/docs/api/createStore.md
@@ -18,6 +18,8 @@ There should only be a single store in your app.
 
 3. [`enhancer`] _(Function)_: The store enhancer. You may optionally specify it to enhance the store with third-party capabilities such as middleware, time travel, persistence, etc. The only store enhancer that ships with Redux is [`applyMiddleware()`](./applyMiddleware.md).
 
+4. ['options'] _(object)_: Optional object with further configuration of redux. Currently allows for opt out of the ban on getState, dispatch and subscriptionhandling in the reducer via the boolean parameters `rules.allowDispatch`, `rules.allowGetState` and `rules.allowSubscriptionHandling`. Keep in mind though that this ban is there for a reason, and this opt-out is meant for compatibility with legacy-code. Using these functions in the reducer is an antipattern that makes the reducer impure, and support for this might be removed in the future.
+
 #### Returns
 
 ([_`Store`_](Store.md)): An object that holds the complete state of your app. The only way to change its state is by [dispatching actions](Store.md#dispatch). You may also [subscribe](Store.md#subscribe) to the changes to its state to update the UI.

--- a/index.d.ts
+++ b/index.d.ts
@@ -251,6 +251,17 @@ export interface Store<S = any, A extends Action = AnyAction> {
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K]
 }
+                    
+type ReduxOptions = {
+  rules?: {
+    /** @deprecated Allow the dispatch of actions in the reducer. Antipattern, this opt-out is for legacy-reasons */
+    allowDispatch?: boolean | undefined;
+    /** @deprecated Allow the usage of getState in the reducer. Antipattern, this opt-out is for legacy-reasons */
+    allowGetState?: boolean | undefined;
+    /** @deprecated Allow the usage of subscribe and unsibscribe in the reducer. Antipattern, this opt-out is for legacy-reasons */
+    allowSubscriptionHandling?: boolean | undefined;
+  } | undefined
+}
 
 /**
  * A store creator is a function that creates a Redux store. Like with
@@ -266,12 +277,14 @@ export type DeepPartial<T> = {
 export interface StoreCreator {
   <S, A extends Action, Ext, StateExt>(
     reducer: Reducer<S, A>,
-    enhancer?: StoreEnhancer<Ext, StateExt>
+    enhancer?: StoreEnhancer<Ext, StateExt>,
+    options?: ReduxOptions,
   ): Store<S & StateExt, A> & Ext
   <S, A extends Action, Ext, StateExt>(
     reducer: Reducer<S, A>,
     preloadedState?: DeepPartial<S>,
     enhancer?: StoreEnhancer<Ext>
+    options?: ReduxOptions,
   ): Store<S & StateExt, A> & Ext
 }
 
@@ -299,6 +312,15 @@ export interface StoreCreator {
  *   enhance the store with third-party capabilities such as middleware, time
  *   travel, persistence, etc. The only store enhancer that ships with Redux
  *   is `applyMiddleware()`.
+ *
+ * @param {Object} [options] Optional object with further configuration of redux. 
+ * Currently allows for opt out of the ban on getState, dispatch and 
+ * subscriptionhandling in the reducer via the boolean parameters 
+ * `rules.allowDispatch`, `rules.allowGetState` and `rules.allowSubscriptionHandling`.
+ * Keep in mind though that this ban is there for a reason, 
+ * and this opt-out is meant for legacy-reasons. Using these functions in the reducer
+ * is an antipattern that makes the reducer impure, and support for this
+ * might be removed in the future.
  *
  * @returns A Redux store that lets you read the state, dispatch actions and
  *   subscribe to changes.

--- a/index.d.ts
+++ b/index.d.ts
@@ -283,7 +283,7 @@ export interface StoreCreator {
   <S, A extends Action, Ext, StateExt>(
     reducer: Reducer<S, A>,
     preloadedState?: DeepPartial<S>,
-    enhancer?: StoreEnhancer<Ext>
+    enhancer?: StoreEnhancer<Ext>,
     options?: ReduxOptions,
   ): Store<S & StateExt, A> & Ext
 }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -3,7 +3,7 @@ import $$observable from 'symbol-observable'
 import ActionTypes from './utils/actionTypes'
 import isPlainObject from './utils/isPlainObject'
 
-let defaultOptions = {rules: {}}
+let defaultOptions = { rules: {} }
 
 /**
  * Creates a Redux store that holds the state tree.
@@ -46,20 +46,13 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
   ) {
     throw new Error(
       'It looks like you are passing several store enhancers to ' +
-        'createStore(). This is not supported. Instead, compose them ' +
-        'together to a single function.'
+      'createStore(). This is not supported. Instead, compose them ' +
+      'together to a single function.'
     )
   }
 
   if (typeof preloadedState === 'function') {
-    if (
-      (typeof enhancer === 'object') ||
-      (typeof enhancer === 'undefined')
-    ) {
-      options = enhancer
-      enhancer = preloadedState
-      preloadedState = undefined
-    }
+    return createStore(reducer, undefined, preloadedState, enhancer)
   }
 
   if (typeof enhancer !== 'undefined') {
@@ -67,16 +60,14 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
       throw new Error('Expected the enhancer to be a function.')
     }
 
-    return enhancer(createStore)(reducer, preloadedState)
+    return enhancer(createStore)(reducer, preloadedState, undefined, options)
   }
 
   if (typeof reducer !== 'function') {
     throw new Error('Expected the reducer to be a function.')
   }
-  
-  options = options || {};
-  
-  options = {...defaultOptions, ...options} // @todo find good supported option
+
+  options = { ...defaultOptions, ...options } // @todo find good supported option
   
   let banDispatch = !options.rules.allowDispatch
   let banGetState = !options.rules.allowGetState
@@ -110,8 +101,8 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
     if (banGetState && isDispatching) {
       throw new Error(
         'You may not call store.getState() while the reducer is executing. ' +
-          'The reducer has already received the state as an argument. ' +
-          'Pass it down from the top reducer instead of reading it from the store.'
+        'The reducer has already received the state as an argument. ' +
+        'Pass it down from the top reducer instead of reading it from the store.'
       )
     }
 
@@ -149,9 +140,9 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
     if (banSubscriptionHandling && isDispatching) {
       throw new Error(
         'You may not call store.subscribe() while the reducer is executing. ' +
-          'If you would like to be notified after the store has been updated, subscribe from a ' +
-          'component and invoke store.getState() in the callback to access the latest state. ' +
-          'See https://redux.js.org/api-reference/store#subscribe(listener) for more details.'
+        'If you would like to be notified after the store has been updated, subscribe from a ' +
+        'component and invoke store.getState() in the callback to access the latest state. ' +
+        'See https://redux.js.org/api-reference/store#subscribe(listener) for more details.'
       )
     }
 
@@ -168,7 +159,7 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
       if (banSubscriptionHandling && isDispatching) {
         throw new Error(
           'You may not unsubscribe from a store listener while the reducer is executing. ' +
-            'See https://redux.js.org/api-reference/store#subscribe(listener) for more details.'
+          'See https://redux.js.org/api-reference/store#subscribe(listener) for more details.'
         )
       }
 
@@ -209,14 +200,14 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
     if (!isPlainObject(action)) {
       throw new Error(
         'Actions must be plain objects. ' +
-          'Use custom middleware for async actions.'
+        'Use custom middleware for async actions.'
       )
     }
 
     if (typeof action.type === 'undefined') {
       throw new Error(
         'Actions may not have an undefined "type" property. ' +
-          'Have you misspelled a constant?'
+        'Have you misspelled a constant?'
       )
     }
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -67,7 +67,7 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
     throw new Error('Expected the reducer to be a function.')
   }
 
-  options = { ...defaultOptions, ...options } // @todo find good supported option
+  options = { ...defaultOptions, ...options }
   
   let banDispatch = !options.rules.allowDispatch
   let banGetState = !options.rules.allowGetState

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -32,7 +32,7 @@ let defaultOptions = { rules: {} }
  * subscriptionhandling in the reducer via the boolean parameters 
  * `rules.allowDispatch`, `rules.allowGetState` and `rules.allowSubscriptionHandling`.
  * Keep in mind though that this ban is there for a reason, 
- * and this opt-out is meant for legacy-reasons. Using these functions in the reducer
+ * and this opt-out is meant for compatibility with legacy-code. Using these functions in the reducer
  * is an antipattern that makes the reducer impure, and support for this
  * might be removed in the future.
  *
@@ -68,10 +68,14 @@ export default function createStore(reducer, preloadedState, enhancer, options) 
   }
 
   options = { ...defaultOptions, ...options }
-  
+
   let banDispatch = !options.rules.allowDispatch
   let banGetState = !options.rules.allowGetState
   let banSubscriptionHandling = !options.rules.allowSubscriptionHandling
+
+  if (!(banDispatch && banGetState && banSubscriptionHandling)) {
+    console.warn('The usage of dispatch, getState or subscriber-logic in the reducer is an antipattern and support might be removed in the future.')
+  }
 
   let currentReducer = reducer
   let currentState = preloadedState

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -466,13 +466,14 @@ describe('createStore', () => {
   })
 
   it('does allow dispatch() from within a reducer if configured accordingly', () => {
+    console.log('-------------------NOW---------------------');
     const store = createStore(reducers.dispatchInTheMiddleOfReducer, identity, {rules: { allowDispatch: true } })
 
     expect(() =>
       store.dispatch(
         dispatchInMiddle(store.dispatch.bind(store, unknownAction()))
       )
-    ).not.toThrow(/may not dispatch/)
+    ).not.toThrow()
   })
 
   it('does not allow getState() from within a reducer', () => {
@@ -484,11 +485,12 @@ describe('createStore', () => {
   })
 
   it('does allow getState() from within a reducer if configured accordingly', () => {
+    console.log('-------------------NOW---------------------');
     const store = createStore(reducers.getStateInTheMiddleOfReducer, identity, {rules: { allowGetState: true } })
 
     expect(() =>
       store.dispatch(getStateInMiddle(store.getState.bind(store)))
-    ).not.toThrow(/You may not call store.getState()/)
+    ).not.toThrow()
   })
 
   it('does not allow subscribe() from within a reducer', () => {
@@ -500,11 +502,12 @@ describe('createStore', () => {
   })
 
   it('does allow subscribe() from within a reducer if configured accordingly', () => {
+    console.log('-------------------NOW---------------------');
     const store = createStore(reducers.subscribeInTheMiddleOfReducer, identity, {rules: { allowSubscriptionHandling: true } })
 
     expect(() =>
       store.dispatch(subscribeInMiddle(store.subscribe.bind(store, () => {})))
-    ).not.toThrow(/You may not call store.subscribe()/)
+    ).not.toThrow()
   })
 
   it('does not allow unsubscribe from subscribe() from within a reducer', () => {
@@ -522,7 +525,7 @@ describe('createStore', () => {
 
     expect(() =>
       store.dispatch(unsubscribeInMiddle(unsubscribe.bind(store)))
-    ).not.toThrow(/You may not unsubscribe from a store/)
+    ).not.toThrow()
   })
 
   it('recovers from an error within a reducer', () => {
@@ -559,7 +562,7 @@ describe('createStore', () => {
     const spyEnhancer = vanillaCreateStore => (...args) => {
       expect(args[0]).toBe(reducers.todos)
       expect(args[1]).toBe(emptyArray)
-      expect(args.length).toBe(2)
+      expect(args[2]).toBe(undefined)
       const vanillaStore = vanillaCreateStore(...args)
       return {
         ...vanillaStore,
@@ -583,7 +586,7 @@ describe('createStore', () => {
     const spyEnhancer = vanillaCreateStore => (...args) => {
       expect(args[0]).toBe(reducers.todos)
       expect(args[1]).toBe(undefined)
-      expect(args.length).toBe(2)
+      expect(args[2]).toBe(undefined)
       const vanillaStore = vanillaCreateStore(...args)
       return {
         ...vanillaStore,

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -466,7 +466,6 @@ describe('createStore', () => {
   })
 
   it('does allow dispatch() from within a reducer if configured accordingly', () => {
-    console.log('-------------------NOW---------------------');
     const store = createStore(reducers.dispatchInTheMiddleOfReducer, identity, {rules: { allowDispatch: true } })
 
     expect(() =>
@@ -485,7 +484,6 @@ describe('createStore', () => {
   })
 
   it('does allow getState() from within a reducer if configured accordingly', () => {
-    console.log('-------------------NOW---------------------');
     const store = createStore(reducers.getStateInTheMiddleOfReducer, identity, {rules: { allowGetState: true } })
 
     expect(() =>
@@ -502,7 +500,6 @@ describe('createStore', () => {
   })
 
   it('does allow subscribe() from within a reducer if configured accordingly', () => {
-    console.log('-------------------NOW---------------------');
     const store = createStore(reducers.subscribeInTheMiddleOfReducer, identity, {rules: { allowSubscriptionHandling: true } })
 
     expect(() =>

--- a/test/utils/others.js
+++ b/test/utils/others.js
@@ -1,0 +1,1 @@
+export const identity = (arg) => arg


### PR DESCRIPTION
Its not always easy to convert legacy code you may not even have written yourself, and as long as the continued acceptance of these antipatterns doesnt hurt other efforts I'd suggest the option for an opt-out of these bans, so that we dont force people to use older versions just because they feel like theres higher priorities than just completely revamping their applications state management right now.

This brings no breaking changes and the 'options' object may be expanded to allow for further configuration in the future. The documentation is riddled with warnings, and a console.error is set off every time a store gets created with one of these bans lifted. @timdorr this should COMPLETELY satisfy your apparent need to remove this behavior, as long as you dont provide a better reason I can accept or everyone else tells me they dont want to enable other people with legacy code to use the new features of Redux 4, just because these people think that using these functions in the reducer, while very bad, isnt the worst issue their app has currently and doesnt legitimize immediate complete workover of their potentially huge application.

This options object has been purposefully coded in a way that allows for expansion in the future, thus this does NOT prevent future expansions of arguments. I'd reccomend putting these in that options-object, as theyre unlikely to get used frequently and in that way - because of the non-sequential nature of the object-parameters - dont worsen the already bad situation currently where you have a headache with allowing different configurations without horrible syntax like passing in multiple `undefined`.

If this gets accepted and people are interested in that I might bring another merge request later which would allow a 3rd parameter in reducers which is passed the global state - thats also mentioned in the issue #1568 mentioned by @timdorr, the thing is THATS CURRENTLY INCOMPATIBLE WITH YOUR OWN COMBINEREDUCERS - allowing for in-pattern usage of the global state without having to revert to store.getState, which makes store-injection in testing very hard. This too would not break normal usage of redux, and when you use object destructuring in the argument to limit the scope of parameters you inject from the global state it also shouldnt lead to a to large state potentially influencing the reducer.