### PR TITLE
Update compose implmentation

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -10,13 +10,5 @@
  */
 
 export default function compose(...funcs) {
-  if (funcs.length === 0) {
-    return arg => arg
-  }
-
-  if (funcs.length === 1) {
-    return funcs[0]
-  }
-
-  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+  return funcs.reduce((a, b) => (...args) => a(b(...args)), arg => arg)
 }

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -108,10 +108,11 @@ describe('Utils', () => {
       expect(compose()()).toBe(undefined)
     })
 
-    it('returns the first function if given only one', () => {
-      const fn = () => {}
+    it('returns an identical function if given only one', () => {
+      const randomNumber = Math.random()
+      const square = x => x * x
 
-      expect(compose(fn)).toBe(fn)
+      expect(compose(square)(randomNumber)).toBe(square(randomNumber))
     })
   })
 })


### PR DESCRIPTION
I found that there are many different type of implementations of `compose` function in different libraries, and the most condensed version is [recompose version].(https://github.com/acdlite/recompose/blob/master/src/packages/recompose/compose.js)

It use an identity function as default value for `Array.reduce` so that we don't need to worry about arguments length.

But I found that a test checks if `compose` return the argument function, on which this implementation will fail. 
Consider `compose(f)`, the new method actually returns `f(arg => arg)` instead of `f`, which are identical, but it's impossible to test 2 functions are identical 🤔, I'm not sure how to write the test right.