### PR TITLE
 remove distinctState() filter from example

### DIFF
--- a/examples/todos-with-undo/src/reducers/todos.js
+++ b/examples/todos-with-undo/src/reducers/todos.js
@@ -1,4 +1,4 @@
-import undoable, { distinctState } from 'redux-undo'
+import undoable from 'redux-undo'
 
 const todo = (state, action) => {
   switch (action.type) {
@@ -38,6 +38,6 @@ const todos = (state = [], action) => {
   }
 }
 
-const undoableTodos = undoable(todos, { filter: distinctState() })
+const undoableTodos = undoable(todos)
 
 export default undoableTodos


### PR DESCRIPTION
distinctState() filter, which is deprecated, is now auto applied.