### PR TITLE
TypeScript: `Reducer`: allow extra parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,11 +58,11 @@ export interface AnyAction extends Action {
  * @template S The type of state consumed and produced by this reducer.
  * @template A The type of actions the reducer can potentially respond to.
  */
-export type Reducer<S = any, A extends Action = AnyAction, R extends unknown[] = []> = (
-  state: S | undefined,
-  action: A,
-  ...rest: R
-) => S
+export type Reducer<
+  S = any,
+  A extends Action = AnyAction,
+  R extends unknown[] = []
+> = (state: S | undefined, action: A, ...rest: R) => S
 
 /**
  * Object whose values correspond to different reducer functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,9 +58,10 @@ export interface AnyAction extends Action {
  * @template S The type of state consumed and produced by this reducer.
  * @template A The type of actions the reducer can potentially respond to.
  */
-export type Reducer<S = any, A extends Action = AnyAction> = (
+export type Reducer<S = any, A extends Action = AnyAction, R extends unknown[] = []> = (
   state: S | undefined,
-  action: A
+  action: A,
+  ...rest: R
 ) => S
 
 /**


### PR DESCRIPTION
This is sometimes necessary, e.g.:

> … pass a custom third argument from a parent reducer if a child reducer needs additional data to calculate its next state.

https://redux.js.org/faq/reducers#how-do-i-share-state-between-two-reducers-do-i-have-to-use-combinereducers