### PR TITLE
#2979 Add strict type inference overload for combineReducers.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,44 @@ export type ReducersMapObject<S = any, A extends Action = Action> = {
 }
 
 /**
+ * Infer a combined state shape from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+export type StateFromReducersMapObject<M> = M extends ReducersMapObject
+  ? { [P in keyof M]: M[P] extends Reducer<infer S, any> ? S : never }
+  : never
+
+/**
+ * Infer reducer union type from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+export type ReducerFromReducersMapObject<M> = M extends {
+  [P in keyof M]: infer R
+}
+  ? R extends Reducer<any, any>
+    ? R
+    : never
+  : never
+
+/**
+ * Infer action type from a reducer function.
+ *
+ * @template R Type of reducer.
+ */
+export type ActionFromReducer<R> = R extends Reducer<any, infer A> ? A : never
+
+/**
+ * Infer action union type from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+export type ActionFromReducersMapObject<M> = M extends ReducersMapObject
+  ? ActionFromReducer<ReducerFromReducersMapObject<M>>
+  : never
+
+/**
  * Turns an object whose values are different reducer functions, into a single
  * reducer function. It will call every child reducer, and gather their results
  * into a single state object, whose keys correspond to the keys of the passed
@@ -96,6 +134,9 @@ export function combineReducers<S>(
 export function combineReducers<S, A extends Action = AnyAction>(
   reducers: ReducersMapObject<S, A>
 ): Reducer<S, A>
+export function combineReducers<O extends ReducersMapObject<any, any>>(
+  reducers: O
+): Reducer<StateFromReducersMapObject<O>, ActionFromReducersMapObject<O>>
 
 /* store */
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,10 @@ export type ReducersMapObject<S = any, A extends Action = Action> = {
  *
  * @template M Object map of reducers as provided to `combineReducers(map: M)`.
  */
-export type StateFromReducersMapObject<M> = M extends ReducersMapObject
+export type StateFromReducersMapObject<M> = M extends ReducersMapObject<
+  any,
+  any
+>
   ? { [P in keyof M]: M[P] extends Reducer<infer S, any> ? S : never }
   : never
 
@@ -106,7 +109,10 @@ export type ActionFromReducer<R> = R extends Reducer<any, infer A> ? A : never
  *
  * @template M Object map of reducers as provided to `combineReducers(map: M)`.
  */
-export type ActionFromReducersMapObject<M> = M extends ReducersMapObject
+export type ActionFromReducersMapObject<M> = M extends ReducersMapObject<
+  any,
+  any
+>
   ? ActionFromReducer<ReducerFromReducersMapObject<M>>
   : never
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -134,9 +134,9 @@ export function combineReducers<S>(
 export function combineReducers<S, A extends Action = AnyAction>(
   reducers: ReducersMapObject<S, A>
 ): Reducer<S, A>
-export function combineReducers<O extends ReducersMapObject<any, any>>(
-  reducers: O
-): Reducer<StateFromReducersMapObject<O>, ActionFromReducersMapObject<O>>
+export function combineReducers<M extends ReducersMapObject<any, any>>(
+  reducers: M
+): Reducer<StateFromReducersMapObject<M>, ActionFromReducersMapObject<M>>
 
 /* store */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Predictable state container for JavaScript apps",
   "license": "MIT",
   "homepage": "http://redux.js.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux",
-  "version": "4.0.5",
+  "version": "4.0.4",
   "description": "Predictable state container for JavaScript apps",
   "license": "MIT",
   "homepage": "http://redux.js.org",

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -68,10 +68,21 @@ function discriminated() {
     count?: number
   }
 
-  // Union of all actions in the app.
-  type MyAction = IncrementAction | DecrementAction
+  interface MultiplyAction {
+    type: 'MULTIPLY'
+    count?: number
+  }
 
-  const reducer: Reducer<State, MyAction> = (state = 0, action) => {
+  interface DivideAction {
+    type: 'DIVIDE'
+    count?: number
+  }
+
+  // Union of all actions in the app.
+  type MyAction0 = IncrementAction | DecrementAction
+  type MyOther1 = MultiplyAction | DivideAction
+
+  const reducer0: Reducer<State, MyAction0> = (state = 0, action) => {
     if (action.type === 'INCREMENT') {
       // Action shape is determined by `type` discriminator.
       // typings:expect-error
@@ -94,37 +105,65 @@ function discriminated() {
     return state
   }
 
+  const reducer1: Reducer<State, MyOther1> = (state = 0, action) => {
+    if (action.type === 'MULTIPLY') {
+      // typings:expect-error
+      action.wrongField
+
+      const { count = 1 } = action
+
+      return state * count
+    }
+
+    if (action.type === 'DIVIDE') {
+      // typings:expect-error
+      action.wrongField
+
+      const { count = 1 } = action
+
+      return state / count
+    }
+
+    return state
+  }
+
   // Reducer state is initialized by Redux using Init action which is private.
   // To initialize manually (e.g. in tests) we have to type cast init action
   // or add a custom init action to MyAction union.
-  let s: State = reducer(undefined, { type: 'init' } as any)
-  s = reducer(s, { type: 'INCREMENT' })
-  s = reducer(s, { type: 'INCREMENT', count: 10 })
+  let s: State = reducer0(undefined, { type: 'init' } as any)
+  s = reducer0(s, { type: 'INCREMENT' })
+  s = reducer0(s, { type: 'INCREMENT', count: 10 })
   // Known actions are strictly checked.
   // typings:expect-error
-  s = reducer(s, { type: 'DECREMENT', coun: 10 })
-  s = reducer(s, { type: 'DECREMENT', count: 10 })
+  s = reducer0(s, { type: 'DECREMENT', coun: 10 })
+  s = reducer0(s, { type: 'DECREMENT', count: 10 })
   // Unknown actions are rejected.
   // typings:expect-error
-  s = reducer(s, { type: 'SOME_OTHER_TYPE' })
+  s = reducer0(s, { type: 'SOME_OTHER_TYPE' })
   // typings:expect-error
-  s = reducer(s, { type: 'SOME_OTHER_TYPE', someField: 'value' })
+  s = reducer0(s, { type: 'SOME_OTHER_TYPE', someField: 'value' })
 
-  // Combined reducer accepts any action by default which allows to include
-  // third-party reducers without the need to add their actions to the union.
-  const combined = combineReducers({ sub: reducer })
+  // Combined reducer infers state and actions by default which maintains type
+  // safety and still allows inclusion of third-party reducers without the need
+  // to explicitly add their state and actions to the union.
+  const combined = combineReducers({ sub0: reducer0, sub1: reducer1 })
 
-  let cs: { sub: State } = combined(undefined, { type: 'init' })
-  cs = combined(cs, { type: 'SOME_OTHER_TYPE' })
+  const cs = combined(undefined, { type: 'INCREMENT' })
+  combined(cs, { type: 'MULTIPLY' })
+  // typings:expect-error
+  combined(cs, { type: 'init' })
+  // typings:expect-error
+  combined(cs, { type: 'SOME_OTHER_TYPE' })
 
   // Combined reducer can be made to only accept known actions.
-  const strictCombined = combineReducers<{ sub: State }, MyAction>({
-    sub: reducer
+  const strictCombined = combineReducers<{ sub: State }, MyAction0>({
+    sub: reducer0
   })
 
-  strictCombined(cs, { type: 'INCREMENT' })
+  const scs = strictCombined(undefined, { type: 'INCREMENT' })
+  strictCombined(scs, { type: 'DECREMENT' })
   // typings:expect-error
-  strictCombined(cs, { type: 'SOME_OTHER_TYPE' })
+  strictCombined(scs, { type: 'SOME_OTHER_TYPE' })
 }
 
 /**

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -80,7 +80,7 @@ function discriminated() {
 
   // Union of all actions in the app.
   type MyAction0 = IncrementAction | DecrementAction
-  type MyOther1 = MultiplyAction | DivideAction
+  type MyAction1 = MultiplyAction | DivideAction
 
   const reducer0: Reducer<State, MyAction0> = (state = 0, action) => {
     if (action.type === 'INCREMENT') {
@@ -105,7 +105,7 @@ function discriminated() {
     return state
   }
 
-  const reducer1: Reducer<State, MyOther1> = (state = 0, action) => {
+  const reducer1: Reducer<State, MyAction1> = (state = 0, action) => {
     if (action.type === 'MULTIPLY') {
       // typings:expect-error
       action.wrongField


### PR DESCRIPTION
* Strictly infers state shape and actions from the reducers object map.
* Updated tests and comments to match new strict type inference.
* Tested and working in typescript 2.8.