### PR TITLE
Add import statement to visibilityFilter example

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -92,6 +92,13 @@ function todoApp(state = initialState, action) {
 Now let's handle `SET_VISIBILITY_FILTER`. All it needs to do is to change `visibilityFilter` on the state. Easy:
 
 ```js
+import {
+  SET_VISIBILITY_FILTER,
+  VisibilityFilters
+} from './actions'
+
+...
+
 function todoApp(state = initialState, action) {
   switch (action.type) {
     case SET_VISIBILITY_FILTER:


### PR DESCRIPTION
In this code example, SET_VISIBILITY_FILTER is used in a switch case, but it is never imported first. It is imported in the subsequent example code block in the docs. This is confusing, especially for users who aren't familiar with switch statements.