### PR TITLE
Fixed combineReducers changeDetection logic(#3488)

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -173,6 +173,7 @@ export default function combineReducers(reducers) {
       nextState[key] = nextStateForKey
       hasChanged = hasChanged || nextStateForKey !== previousStateForKey
     }
+    hasChanged = hasChanged || finalReducerKeys.length !== Object.keys(state).length;
     return hasChanged ? nextState : state
   }
 }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -281,5 +281,57 @@ describe('Utils', () => {
       spy.mockClear()
       console.error = preSpy
     })
+
+    describe('With Replace Reducers', function() {
+      const foo = (state = {}) => state
+      const bar = (state = {}) => state
+      const ACTION = { type: 'ACTION' };
+
+      it('should return an updated state when additional reducers are passed to combineReducers', function() {
+        const originalCompositeReducer = combineReducers({ foo })
+        const store = createStore(originalCompositeReducer)
+        store.dispatch(ACTION)
+        const initialState = store.getState()
+        store.replaceReducer(combineReducers({ foo, bar }))
+        store.dispatch(ACTION)
+        const nextState = store.getState()
+        expect(nextState).not.toBe(initialState)
+      })
+
+      it('should return an updated state when reducers passed to combineReducers are changed', function() {
+        const baz = (state = {}) => state
+
+        const originalCompositeReducer = combineReducers({ foo, bar })
+        const store = createStore(originalCompositeReducer)
+        store.dispatch(ACTION)
+        const initialState = store.getState()
+        store.replaceReducer(combineReducers({ baz, bar }))
+        store.dispatch(ACTION)
+        const nextState = store.getState()
+        expect(nextState).not.toBe(initialState)
+      })
+
+      it('should return the same state when reducers passed to combineReducers not changed', function() {
+        const originalCompositeReducer = combineReducers({ foo, bar })
+        const store = createStore(originalCompositeReducer)
+        store.dispatch(ACTION)
+        const initialState = store.getState()
+        store.replaceReducer(combineReducers({ foo, bar }))
+        store.dispatch(ACTION)
+        const nextState = store.getState()
+        expect(nextState).toBe(initialState)
+      })
+
+      it('should return an updated state when one of more reducers passed to the combineReducers are removed', function() {
+        const originalCompositeReducer = combineReducers({ foo, bar })
+        const store = createStore(originalCompositeReducer)
+        store.dispatch(ACTION)
+        const initialState = store.getState()
+        store.replaceReducer(combineReducers({ bar }))
+        const nextState = store.getState()
+        expect(nextState).not.toBe(initialState)
+      })
+
+    })
   })
 })


### PR DESCRIPTION
## Fixes following issue:
State doesn't update when replaceReducers is called with combineReducers and one of the reducers passed to it is removed.(https://github.com/reduxjs/redux/issues/3488)
