### PR TITLE
fix: isPlainObject compatible Object.create(null)

### DIFF
--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -4,6 +4,7 @@
  */
 export default function isPlainObject(obj) {
   if (typeof obj !== 'object' || obj === null) return false
+  if (Object.getPrototypeOf(obj) === null) return true
 
   let proto = obj
   while (Object.getPrototypeOf(proto) !== null) {

--- a/test/utils/isPlainObject.spec.js
+++ b/test/utils/isPlainObject.spec.js
@@ -18,5 +18,6 @@ describe('isPlainObject', () => {
     expect(isPlainObject(null)).toBe(false)
     expect(isPlainObject()).toBe(false)
     expect(isPlainObject({ x: 1, y: 2 })).toBe(true)
+    expect(isPlainObject(Object.create(null))).toBe(true)
   })
 })


### PR DESCRIPTION
Compatibility of isPlainObject methods Object.create(null) like [lodash.isPlainObject](https://github.com/lodash/lodash/blob/master/isPlainObject.js)