### PR TITLE
Fix links to some headings with special chars

### DIFF
--- a/docs/faq/Performance.md
+++ b/docs/faq/Performance.md
@@ -10,7 +10,7 @@ hide_title: true
 ## Table of Contents
 
 - [How well does Redux “scale” in terms of performance and architecture?](#how-well-does-redux-scale-in-terms-of-performance-and-architecture)
-- [Won't calling “all my reducers” for each action be slow?](#won-t-calling-all-my-reducers-for-each-action-be-slow)
+- [Won't calling “all my reducers” for each action be slow?](#wont-calling-all-my-reducers-for-each-action-be-slow)
 - [Do I have to deep-clone my state in a reducer? Isn't copying my state going to be slow?](#do-i-have-to-deep-clone-my-state-in-a-reducer-isnt-copying-my-state-going-to-be-slow)
 - [How can I reduce the number of store update events?](#how-can-i-reduce-the-number-of-store-update-events)
 - [Will having “one state tree” cause memory problems? Will dispatching many actions take up memory?](#will-having-one-state-tree-cause-memory-problems-will-dispatching-many-actions-take-up-memory)

--- a/docs/faq/ReactRedux.md
+++ b/docs/faq/ReactRedux.md
@@ -13,7 +13,7 @@ hide_title: true
 - [Why isn't my component re-rendering, or my mapStateToProps running?](#why-isnt-my-component-re-rendering-or-my-mapstatetoprops-running)
 - [Why is my component re-rendering too often?](#why-is-my-component-re-rendering-too-often)
 - [How can I speed up my mapStateToProps?](#how-can-i-speed-up-my-mapstatetoprops)
-- [Why don't I have this.props.dispatch available in my connected component?](#why-dont-i-have-this-props-dispatch-available-in-my-connected-component)
+- [Why don't I have this.props.dispatch available in my connected component?](#why-dont-i-have-thispropsdispatch-available-in-my-connected-component)
 - [Should I only connect my top component, or can I connect multiple components in my tree?](#should-i-only-connect-my-top-component-or-can-i-connect-multiple-components-in-my-tree)
 - [How does Redux compare to the React Context API?](#how-does-redux-compare-to-the-react-context-api)
 


### PR DESCRIPTION
A couple of links in tables of contents were broken.

These were links where the URL fragment in the target was
auto-generated. When that happens, most special characters are removed
from the heading.

When the links in the tables of contents were written, the ones I am
fixing replaced some of the special characters with `-`, instead of
stripping them.

I tested the links on my fork on the [Performance](https://github.com/douglasnaphas/redux/blob/broken-links-quotes-in-headings/docs/faq/Performance.md) and [React Redux](https://github.com/douglasnaphas/redux/blob/broken-links-quotes-in-headings/docs/faq/ReactRedux.md) pages.

These screenshots show that the currently live auto-generated URLs
match what I am changing the links to:

<img width="813" alt="Screen Shot 2019-08-01 at 8 58 09 PM" src="https://user-images.githubusercontent.com/5433410/62336739-b8847900-b49f-11e9-94e6-9fd1d1528b82.png">

<img width="695" alt="Screen Shot 2019-08-01 at 8 59 46 PM" src="https://user-images.githubusercontent.com/5433410/62336745-bd492d00-b49f-11e9-8bb5-de18cc44622a.png">
