### PR TITLE
Remove outdated rule on single quotes in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,7 @@ npm run test:watch
 
 ### Docs
 
-Improvements to the documentation are always welcome. In the docs we abide by typographic rules for double quotes and dashes, so you should use “ ” instead of " " and — instead of --. These rules only apply to the text, not to code blocks.
-
-The docs are published automatically when the `master` branch is updated.
+Improvements to the documentation are always welcome. You can find them in the [`docs`](/docs) path. We use [Docusaurus](https://docusaurus.io/) to build our documentation website. The website is published automatically whenever the `master` branch is updated.
 
 ### Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ npm run test:watch
 
 ### Docs
 
-Improvements to the documentation are always welcome. In the docs we abide by typographic rules, so instead of ' you should use '. Same goes for “ ” and dashes (—) where appropriate. These rules only apply to the text, not to code blocks.
+Improvements to the documentation are always welcome. In the docs we abide by typographic rules for double quotes and dashes, so you should use “ ” instead of " " and — instead of --. These rules only apply to the text, not to code blocks.
 
 The docs are published automatically when the `master` branch is updated.
 


### PR DESCRIPTION
In PR #1874, a mass replacement of angled single quotes ’ with ASCII
single quotes ' was approved. Since then, the docs have contained a
mixture of angled and ASCII single quotes:

```
$ git log -S’ --since="Mon Aug 1 16:45:58 2016 -0400" --pretty=oneline | wc -l
17
```

so it does not make sense to state a rule on them.