### PR TITLE
fix replaceReducer type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -669,9 +669,3 @@ export function compose<R>(
 ): (...args: any[]) => R
 
 export function compose<R>(...funcs: Function[]): (...args: any[]) => R
-
-export const __DO_NOT_USE__ActionTypes: {
-  INIT: string
-  REPLACE: string
-  PROBE_UNKNOWN_ACTION: () => string
-}

--- a/index.d.ts
+++ b/index.d.ts
@@ -326,7 +326,9 @@ export interface Store<S = any, A extends Action = AnyAction> {
    *
    * @param nextReducer The reducer for the store to use instead.
    */
-  replaceReducer(nextReducer: Reducer<S, A>): void
+  replaceReducer<NewState = S, NewActions extends A = A>(
+    nextReducer: Reducer<NewState, NewActions>
+  ): Store<NewState, NewActions>
 
   /**
    * Interoperability point for observable/reactive libraries.
@@ -667,3 +669,9 @@ export function compose<R>(
 ): (...args: any[]) => R
 
 export function compose<R>(...funcs: Function[]): (...args: any[]) => R
+
+export const __DO_NOT_USE__ActionTypes: {
+  INIT: string
+  REPLACE: string
+  PROBE_UNKNOWN_ACTION: () => string
+}

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -224,7 +224,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
    * implement a hot reloading mechanism for Redux.
    *
    * @param {Function} nextReducer The reducer for the store to use instead.
-   * @returns {void}
+   * @returns {Store} The same store instance with a new reducer in place.
    */
   function replaceReducer(nextReducer) {
     if (typeof nextReducer !== 'function') {

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -238,6 +238,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     // will receive the previous state. This effectively populates
     // the new state tree with any relevant data from the old one.
     dispatch({ type: ActionTypes.REPLACE })
+    return store
   }
 
   /**
@@ -284,11 +285,12 @@ export default function createStore(reducer, preloadedState, enhancer) {
   // the initial state tree.
   dispatch({ type: ActionTypes.INIT })
 
-  return {
+  const store = {
     dispatch,
     subscribe,
     getState,
     replaceReducer,
     [$$observable]: observable
   }
+  return store
 }

--- a/test/replaceReducers.spec.ts
+++ b/test/replaceReducers.spec.ts
@@ -1,0 +1,18 @@
+import { createStore, combineReducers } from '..'
+
+describe('replaceReducers test', () => {
+  it('returns the original store', () => {
+    const nextReducer = combineReducers({
+      foo: (state = 1, _action) => state,
+      bar: (state = 2, _action) => state
+    })
+    const store = createStore((state, action) => {
+      if (state === undefined) return 5
+      return action
+    })
+
+    const nextStore = store.replaceReducer(nextReducer)
+
+    expect(nextStore).toBe(store)
+  })
+})


### PR DESCRIPTION
Currently, the `replaceReducer` function assumes that the reducer state stays in the same shape. This does not make sense, as the purpose of `replaceReducer` is to change the store state.

However, typescript types are static, and replaceReducer changes the type at run-time.

To solve this issue, we either need to cast the existing store to the new store type, or transform the store.

As it turns out, a simple solution is to modify the signature for `replaceReducer` to return the existing store, and this gives us the ability to typecast to the new reducer type in a graceful way.

With this change, the `combineReducers` test passes when converted to typescript with minimal changes.

This *may* also fix #3482