### PR TITLE
convert the createStore test to typescript - and run the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     ]
   },
   "jest": {
-    "testRegex": "(/test/.*\\.spec\\.js)$"
+    "testRegex": "(/test/.*\\.spec\\.[tj]s)$"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
Funny story: the package.json regex for jest did not select `.ts` tests. So this PR does 2 things:

enable the ts tests, and convert `createStore` test to typescript