### PR TITLE
fix typescript config for rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ dist
 lib
 es
 coverage
-# used by rollup-plugin-typescript2
-.rpt2_cache/
 
 website/translated_docs
 website/build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist
 lib
 es
 coverage
+# used by rollup-plugin-typescript2
+.rpt2_cache/
 
 website/translated_docs
 website/build/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3378,6 +3378,17 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -5144,6 +5155,15 @@
         }
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6762,6 +6782,18 @@
         "terser": "^4.1.0"
       }
     },
+    "rollup-plugin-typescript2": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.22.1.tgz",
+      "integrity": "sha512-SQEHr1s0kDWrNV3UKySZtYKFIcWCJh2PQ4ZtLNj18pf50SrxeRDlUksOOeLPyodJ7bVLaKwWDbiobF2a6gfKyg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "8.1.0",
+        "resolve": "1.11.1",
+        "rollup-pluginutils": "2.8.1",
+        "tslib": "1.10.0"
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
@@ -7632,6 +7664,12 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.1.1",
+    "rollup-plugin-typescript2": "^0.22.1",
     "rxjs": "^6.5.2",
     "typescript": "^3.5.3",
     "typings-tester": "^0.3.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import nodeResolve from 'rollup-plugin-node-resolve'
 import babel from 'rollup-plugin-babel'
 import replace from 'rollup-plugin-replace'
+import typescript from 'rollup-plugin-typescript2'
 import { terser } from 'rollup-plugin-terser'
 
 import pkg from './package.json'
@@ -18,6 +19,7 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
+      typescript(),
       babel()
     ]
   },
@@ -34,6 +36,7 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
+      typescript(),
       babel()
     ]
   },
@@ -49,6 +52,7 @@ export default [
       replace({
         'process.env.NODE_ENV': JSON.stringify('production')
       }),
+      typescript(),
       babel({
         exclude: 'node_modules/**'
       }),
@@ -76,6 +80,7 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
+      typescript(),
       babel({
         exclude: 'node_modules/**'
       }),
@@ -98,6 +103,7 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
+      typescript(),
       babel({
         exclude: 'node_modules/**'
       }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import nodeResolve from 'rollup-plugin-node-resolve'
 import babel from 'rollup-plugin-babel'
 import replace from 'rollup-plugin-replace'
@@ -19,7 +20,9 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
-      typescript(),
+      typescript({
+        cacheRoot: path.resolve('./node_modules/.cache')
+      }),
       babel()
     ]
   },
@@ -36,7 +39,9 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
-      typescript(),
+      typescript({
+        cacheRoot: path.resolve('./node_modules/.cache')
+      }),
       babel()
     ]
   },
@@ -52,7 +57,9 @@ export default [
       replace({
         'process.env.NODE_ENV': JSON.stringify('production')
       }),
-      typescript(),
+      typescript({
+        cacheRoot: path.resolve('./node_modules/.cache')
+      }),
       babel({
         exclude: 'node_modules/**'
       }),
@@ -80,7 +87,9 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
-      typescript(),
+      typescript({
+        cacheRoot: path.resolve('./node_modules/.cache')
+      }),
       babel({
         exclude: 'node_modules/**'
       }),
@@ -103,7 +112,9 @@ export default [
       nodeResolve({
         extensions: ['.ts']
       }),
-      typescript(),
+      typescript({
+        cacheRoot: path.resolve('./node_modules/.cache')
+      }),
       babel({
         exclude: 'node_modules/**'
       }),


### PR DESCRIPTION
It turns out that even with the `nodeResolve` fixes, we still need the `typescript` plugin to build with rollup. This PR fixes that