### PR TITLE
add a new test to verify replaceReducer typings work

### DIFF
--- a/test/typescript/replaceReducer.ts
+++ b/test/typescript/replaceReducer.ts
@@ -1,0 +1,26 @@
+import { combineReducers, createStore } from 'redux'
+
+/**
+ * verify that replaceReducer maintains strict typing if the new types change
+ */
+const bar = (state = { value: 'bar' }) => state
+const baz = (state = { value: 'baz' }) => state
+const ACTION = {
+  type: 'action'
+}
+
+const originalCompositeReducer = combineReducers({ bar })
+const store = createStore(originalCompositeReducer)
+store.dispatch(ACTION)
+
+const firstState = store.getState()
+firstState.bar.value
+// typings:expect-error
+firstState.baz.value
+
+const nextStore = store.replaceReducer(combineReducers({ baz })) // returns ->  { baz: { value: 'baz' }}
+
+const nextState = nextStore.getState()
+// typings:expect-error
+nextState.bar.value
+nextState.baz.value


### PR DESCRIPTION
There was some concern that the fix for #3482 in the `ts-conversion` branch does not strongly type the reducer returned from `replaceReducer`.

This PR adds a test to prove it does.