### PR TITLE
fix replaceReducer with a store enhancer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -260,7 +260,7 @@ export type Observer<T> = {
 export interface Store<
   S = any,
   A extends Action = AnyAction,
-  StateExt = S,
+  StateExt = S extends {} ? {} : S extends [] ? [] : S,
   Ext = {}
 > {
   /**
@@ -362,11 +362,21 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <S, A extends Action, Ext = {}, StateExt = S>(
+  <
+    S,
+    A extends Action,
+    Ext = {},
+    StateExt = S extends {} ? {} : S extends [] ? [] : S
+  >(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S & StateExt, A, StateExt, Ext> & Ext
-  <S, A extends Action, Ext = {}, StateExt = S>(
+  <
+    S,
+    A extends Action,
+    Ext = {},
+    StateExt = S extends {} ? {} : S extends [] ? [] : S
+  >(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>

--- a/index.d.ts
+++ b/index.d.ts
@@ -362,11 +362,11 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <S, A extends Action, Ext extends {}, StateExt>(
+  <S, A extends Action, Ext, StateExt>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S & StateExt, A, StateExt, Ext> & Ext
-  <S, A extends Action, Ext extends {}, StateExt>(
+  <S, A extends Action, Ext, StateExt>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>

--- a/index.d.ts
+++ b/index.d.ts
@@ -260,7 +260,7 @@ export type Observer<T> = {
 export interface Store<
   S = any,
   A extends Action = AnyAction,
-  StateExt = {},
+  StateExt = S,
   Ext = {}
 > {
   /**
@@ -362,11 +362,11 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <S, A extends Action, Ext = {}, StateExt = {}>(
+  <S, A extends Action, Ext = {}, StateExt = S>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S & StateExt, A, StateExt, Ext> & Ext
-  <S, A extends Action, Ext = {}, StateExt = {}>(
+  <S, A extends Action, Ext = {}, StateExt = S>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>

--- a/index.d.ts
+++ b/index.d.ts
@@ -362,11 +362,11 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <S, A extends Action, Ext, StateExt>(
+  <S, A extends Action, Ext = {}, StateExt = {}>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S & StateExt, A, StateExt, Ext> & Ext
-  <S, A extends Action, Ext, StateExt>(
+  <S, A extends Action, Ext = {}, StateExt = {}>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>

--- a/index.d.ts
+++ b/index.d.ts
@@ -362,11 +362,11 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <S, A extends Action, Ext extends {}, StateExt extends {}>(
+  <S, A extends Action, Ext extends {}, StateExt>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S & StateExt, A, StateExt, Ext> & Ext
-  <S, A extends Action, Ext extends {}, StateExt extends {}>(
+  <S, A extends Action, Ext extends {}, StateExt>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>

--- a/index.d.ts
+++ b/index.d.ts
@@ -254,8 +254,15 @@ export type Observer<T> = {
  *
  * @template S The type of state held by this store.
  * @template A the type of actions which may be dispatched by this store.
+ * @template StateExt any extension to state from store enhancers
+ * @template Ext any extensions to the store from store enhancers
  */
-export interface Store<S = any, A extends Action = AnyAction> {
+export interface Store<
+  S = any,
+  A extends Action = AnyAction,
+  StateExt = {},
+  Ext = {}
+> {
   /**
    * Dispatches an action. It is the only way to trigger a state change.
    *
@@ -328,7 +335,7 @@ export interface Store<S = any, A extends Action = AnyAction> {
    */
   replaceReducer<NewState = S, NewActions extends A = A>(
     nextReducer: Reducer<NewState, NewActions>
-  ): Store<NewState, NewActions>
+  ): Store<NewState & StateExt, NewActions, StateExt, Ext> & Ext
 
   /**
    * Interoperability point for observable/reactive libraries.
@@ -355,15 +362,15 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <S, A extends Action, Ext, StateExt>(
+  <S, A extends Action, Ext extends {}, StateExt extends {}>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
-  ): Store<S & StateExt, A> & Ext
-  <S, A extends Action, Ext, StateExt>(
+  ): Store<S & StateExt, A, StateExt, Ext> & Ext
+  <S, A extends Action, Ext extends {}, StateExt extends {}>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>
-  ): Store<S & StateExt, A> & Ext
+  ): Store<S & StateExt, A, StateExt, Ext> & Ext
 }
 
 /**
@@ -418,15 +425,16 @@ export const createStore: StoreCreator
  * @template StateExt State extension that is mixed into the state type.
  */
 export type StoreEnhancer<Ext = {}, StateExt = {}> = (
-  next: StoreEnhancerStoreCreator
+  next: StoreEnhancerStoreCreator<Ext, StateExt>
 ) => StoreEnhancerStoreCreator<Ext, StateExt>
+
 export type StoreEnhancerStoreCreator<Ext = {}, StateExt = {}> = <
   S = any,
   A extends Action = AnyAction
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>
-) => Store<S & StateExt, A> & Ext
+) => Store<S & StateExt, A, StateExt, Ext> & Ext
 
 /* middleware */
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -342,7 +342,7 @@ export interface Store<
    *
    * @param nextReducer The reducer for the store to use instead.
    */
-  replaceReducer<NewState = S, NewActions extends A = A>(
+  replaceReducer<NewState, NewActions extends Action>(
     nextReducer: Reducer<NewState, NewActions>
   ): Store<NewState & StateExt, NewActions, StateExt, Ext> & Ext
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -248,6 +248,15 @@ export type Observer<T> = {
 }
 
 /**
+ * returns the most basic type that will not interfere with the existing type
+ *
+ * Note that for non-object stuff, this will mess with replaceReducer. The
+ * assumption is that root reducers that only return a basic type (string, number, null, symbol) probably won't
+ * be using replaceReducer anyways.
+ */
+export type BaseType<S> = S extends {} ? {} : S
+
+/**
  * A store is an object that holds the application's state tree.
  * There should only be a single store in a Redux app, as the composition
  * happens on the reducer level.
@@ -260,7 +269,7 @@ export type Observer<T> = {
 export interface Store<
   S = any,
   A extends Action = AnyAction,
-  StateExt = S extends {} ? {} : S extends [] ? [] : S,
+  StateExt = BaseType<S>,
   Ext = {}
 > {
   /**
@@ -362,21 +371,11 @@ export type DeepPartial<T> = {
  * @template StateExt State extension that is mixed into the state type.
  */
 export interface StoreCreator {
-  <
-    S,
-    A extends Action,
-    Ext = {},
-    StateExt = S extends {} ? {} : S extends [] ? [] : S
-  >(
+  <S, A extends Action, Ext = {}, StateExt = BaseType<S>>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S & StateExt, A, StateExt, Ext> & Ext
-  <
-    S,
-    A extends Action,
-    Ext = {},
-    StateExt = S extends {} ? {} : S extends [] ? [] : S
-  >(
+  <S, A extends Action, Ext = {}, StateExt = BaseType<S>>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>

--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -51,7 +51,7 @@ export default function applyMiddleware<Ext, S = any>(
 ): StoreEnhancer<{ dispatch: Ext }>
 export default function applyMiddleware(
   ...middlewares: Middleware[]
-): StoreEnhancer {
+): StoreEnhancer<any> {
   return (createStore: StoreCreator) => <S, A extends AnyAction>(
     reducer: Reducer<S, A>,
     ...args: any[]

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -6,7 +6,7 @@ import {
   StoreEnhancer,
   Dispatch,
   Observer,
-  BaseType
+  ExtendState
 } from './types/store'
 import { Action } from './types/actions'
 import { Reducer } from './types/reducers'
@@ -42,31 +42,31 @@ export default function createStore<
   S,
   A extends Action,
   Ext = {},
-  StateExt = BaseType<S>
+  StateExt = never
 >(
   reducer: Reducer<S, A>,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S & StateExt, A, StateExt, Ext> & Ext
+): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 export default function createStore<
   S,
   A extends Action,
   Ext = {},
-  StateExt = BaseType<S>
+  StateExt = never
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
   enhancer?: StoreEnhancer<Ext>
-): Store<S & StateExt, A, StateExt, Ext> & Ext
+): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 export default function createStore<
   S,
   A extends Action,
   Ext = {},
-  StateExt = BaseType<S>
+  StateExt = never
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S & StateExt, A, StateExt, Ext> & Ext {
+): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext {
   if (
     (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
     (typeof enhancer === 'function' && typeof arguments[3] === 'function')
@@ -90,7 +90,7 @@ export default function createStore<
 
     return enhancer(createStore)(reducer, preloadedState as PreloadedState<
       S
-    >) as Store<S & StateExt, A, StateExt, Ext> & Ext
+    >) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
   }
 
   if (typeof reducer !== 'function') {
@@ -268,7 +268,7 @@ export default function createStore<
    */
   function replaceReducer<NewState, NewActions extends A>(
     nextReducer: Reducer<NewState, NewActions>
-  ): Store<NewState, NewActions> {
+  ): Store<ExtendState<NewState, StateExt>, NewActions, StateExt, Ext> & Ext {
     if (typeof nextReducer !== 'function') {
       throw new Error('Expected the nextReducer to be a function.')
     }
@@ -285,7 +285,13 @@ export default function createStore<
     // the new state tree with any relevant data from the old one.
     dispatch({ type: ActionTypes.REPLACE } as A)
     // change the type of the store by casting it to the new store
-    return (store as unknown) as Store<NewState, NewActions>
+    return (store as unknown) as Store<
+      ExtendState<NewState, StateExt>,
+      NewActions,
+      StateExt,
+      Ext
+    > &
+      Ext
   }
 
   /**
@@ -339,6 +345,6 @@ export default function createStore<
     getState,
     replaceReducer,
     [$$observable]: observable
-  } as unknown) as Store<S & StateExt, A, StateExt, Ext> & Ext
+  } as unknown) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
   return store
 }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -333,12 +333,12 @@ export default function createStore<
   // the initial state tree.
   dispatch({ type: ActionTypes.INIT } as A)
 
-  const store: Store<S & StateExt, A> & Ext = ({
+  const store = ({
     dispatch: dispatch as Dispatch<A>,
     subscribe,
     getState,
     replaceReducer,
     [$$observable]: observable
-  } as unknown) as Store<S & StateExt, A> & Ext
+  } as unknown) as Store<S & StateExt, A, StateExt, Ext> & Ext
   return store
 }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -55,7 +55,7 @@ export default function createStore<
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
-  enhancer?: StoreEnhancer<Ext>
+  enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 export default function createStore<
   S,

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -90,7 +90,7 @@ export default function createStore<
 
     return enhancer(createStore)(reducer, preloadedState as PreloadedState<
       S
-    >) as Store<S & StateExt, A> & Ext
+    >) as Store<S & StateExt, A, StateExt, Ext> & Ext
   }
 
   if (typeof reducer !== 'function') {

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -5,7 +5,8 @@ import {
   PreloadedState,
   StoreEnhancer,
   Dispatch,
-  Observer
+  Observer,
+  BaseType
 } from './types/store'
 import { Action } from './types/actions'
 import { Reducer } from './types/reducers'
@@ -37,20 +38,35 @@ import isPlainObject from './utils/isPlainObject'
  * @returns {Store} A Redux store that lets you read the state, dispatch actions
  * and subscribe to changes.
  */
-export default function createStore<S, A extends Action, Ext, StateExt>(
+export default function createStore<
+  S,
+  A extends Action,
+  Ext = {},
+  StateExt = BaseType<S>
+>(
   reducer: Reducer<S, A>,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S & StateExt, A> & Ext
-export default function createStore<S, A extends Action, Ext, StateExt>(
+): Store<S & StateExt, A, StateExt, Ext> & Ext
+export default function createStore<
+  S,
+  A extends Action,
+  Ext = {},
+  StateExt = BaseType<S>
+>(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
   enhancer?: StoreEnhancer<Ext>
-): Store<S & StateExt, A> & Ext
-export default function createStore<S, A extends Action, Ext, StateExt>(
+): Store<S & StateExt, A, StateExt, Ext> & Ext
+export default function createStore<
+  S,
+  A extends Action,
+  Ext = {},
+  StateExt = BaseType<S>
+>(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
-  enhancer?: StoreEnhancer<Ext>
-): Store<S & StateExt, A> & Ext {
+  enhancer?: StoreEnhancer<Ext, StateExt>
+): Store<S & StateExt, A, StateExt, Ext> & Ext {
   if (
     (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
     (typeof enhancer === 'function' && typeof arguments[3] === 'function')

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ export {
   Store,
   StoreCreator,
   StoreEnhancer,
-  StoreEnhancerStoreCreator
+  StoreEnhancerStoreCreator,
+  ExtendState
 } from './types/store'
 // reducers
 export {

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -8,6 +8,9 @@ import { Reducer } from './reducers'
  * This is used by store enhancers and store creators to extend state.
  * If there is no state extension, it just returns the state, as is, otherwise
  * it returns the state joined with its extension.
+ *
+ * Reference for future devs:
+ * https://github.com/microsoft/TypeScript/issues/31751#issuecomment-498526919
  */
 export type ExtendState<State, Extension> = [Extension] extends [never]
   ? State

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -254,10 +254,10 @@ export interface StoreCreator {
  * @template Ext Store extension that is mixed into the Store type.
  * @template StateExt State extension that is mixed into the state type.
  */
-export type StoreEnhancer<Ext = {}, StateExt = {}> = (
+export type StoreEnhancer<Ext = {}, StateExt = never> = (
   next: StoreEnhancerStoreCreator<Ext, StateExt>
 ) => StoreEnhancerStoreCreator<Ext, StateExt>
-export type StoreEnhancerStoreCreator<Ext = {}, StateExt = {}> = <
+export type StoreEnhancerStoreCreator<Ext = {}, StateExt = never> = <
   S = any,
   A extends Action = AnyAction
 >(

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -80,10 +80,10 @@ function replaceReducerExtender() {
     extraField: 'extra'
   }
 
-  const enhancer: StoreEnhancer<{}, ExtraState> = createStore => <
-    S,
-    A extends Action = AnyAction
-  >(
+  const enhancer: StoreEnhancer<
+    { method(): string },
+    ExtraState
+  > = createStore => <S, A extends Action = AnyAction>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>
   ) => {
@@ -104,4 +104,8 @@ function replaceReducerExtender() {
   store.getState().extraField
   // typings:expect-error
   store.getState().wrongField
+
+  const res: string = store.method()
+  // typings:expect-error
+  store.wrongMethod()
 }

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -131,18 +131,43 @@ function mhelmersonExample() {
       A extends Action = AnyAction
     >(
       reducer: Reducer<S, A>,
-      preloadedState?: PreloadedState<S>
+      preloadedState?: any
     ) => {
-      const wrappedReducer: Reducer<S & ExtraState, A> = null as any
-      const wrappedPreloadedState: PreloadedState<S & ExtraState> = null as any
+      const wrappedReducer = (state: S & ExtraState | undefined, action: A) => {
+        const newState = reducer(state, action)
+        return {
+          ...newState,
+          extraField: 'extra'
+        } as S & ExtraState
+      }
+      const wrappedPreloadedState = preloadedState
+        ? {
+            ...preloadedState,
+            extraField: 'extra'
+          }
+        : undefined
       const store = createStore(wrappedReducer, wrappedPreloadedState)
       return {
         ...store,
-        replaceReducer: (nextReducer: Reducer<S, A>) => {
-          const nextWrappedReducer: Reducer<S & ExtraState, A> = null as any
+        replaceReducer<NS, NA extends Action = AnyAction>(
+          nextReducer: (
+            state: NS & ExtraState | undefined,
+            action: NA
+          ) => NS & ExtraState
+        ) {
+          const nextWrappedReducer: Reducer<NS & ExtraState, NA> = (
+            state,
+            action
+          ) => {
+            const newState = nextReducer(state, action)
+            return {
+              ...newState,
+              extraField: 'extra'
+            }
+          }
           return store.replaceReducer(nextWrappedReducer)
         }
-      } as Store<S & ExtraState, A, ExtraState>
+      }
     }
 
     const store = createStore(reducer, enhancer)

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -71,3 +71,37 @@ function extraMethods() {
   // typings:expect-error
   store.wrongMethod()
 }
+
+/**
+ * replaceReducer with a store enhancer
+ */
+function replaceReducerExtender() {
+  interface ExtraState {
+    extraField: 'extra'
+  }
+
+  const enhancer: StoreEnhancer<{}, ExtraState> = createStore => <
+    S,
+    A extends Action = AnyAction
+  >(
+    reducer: Reducer<S, A>,
+    preloadedState?: PreloadedState<S>
+  ) => {
+    const wrappedReducer: Reducer<S & ExtraState, A> = null as any
+    const wrappedPreloadedState: PreloadedState<S & ExtraState> = null as any
+    return createStore(wrappedReducer, wrappedPreloadedState)
+  }
+
+  const store = createStore(reducer, enhancer)
+
+  const newReducer = (
+    state: { test: boolean } = { test: true },
+    _: AnyAction
+  ) => state
+
+  const newStore = store.replaceReducer(newReducer)
+  newStore.getState().test
+  store.getState().extraField
+  // typings:expect-error
+  store.getState().wrongField
+}

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -214,3 +214,34 @@ function mhelmersonExample() {
     store.replaceReducer(reducer)
   }
 }
+
+function finalHelmersonExample() {
+  function persistReducer<S>(config: any, reducer: S): S {
+    return reducer
+  }
+
+  function persistStore<S>(store: S) {
+    return store
+  }
+
+  function createPersistEnhancer(persistConfig: any): StoreEnhancer {
+    return createStore => <S, A extends Action = AnyAction>(
+      reducer: Reducer<S, A>,
+      preloadedState?: any
+    ) => {
+      const persistedReducer = persistReducer(persistConfig, reducer)
+      const store = createStore(persistedReducer, preloadedState)
+      const persistor = persistStore(store)
+
+      return {
+        ...store,
+        replaceReducer: nextReducer => {
+          return store.replaceReducer(
+            persistReducer(persistConfig, nextReducer)
+          )
+        },
+        persistor
+      }
+    }
+  }
+}

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -109,3 +109,43 @@ function replaceReducerExtender() {
   // typings:expect-error
   store.wrongMethod()
 }
+
+function mhelmersonExample() {
+  interface State {
+    someField: 'string'
+  }
+
+  interface ExtraState {
+    extraField: 'extra'
+  }
+
+  const reducer: Reducer<State> = null as any
+
+  function stateExtensionExpectedToWork() {
+    interface ExtraState {
+      extraField: 'extra'
+    }
+
+    const enhancer: StoreEnhancer<{}, ExtraState> = createStore => <
+      S,
+      A extends Action = AnyAction
+    >(
+      reducer: Reducer<S, A>,
+      preloadedState?: PreloadedState<S>
+    ) => {
+      const wrappedReducer: Reducer<S & ExtraState, A> = null as any
+      const wrappedPreloadedState: PreloadedState<S & ExtraState> = null as any
+      const store = createStore(wrappedReducer, wrappedPreloadedState)
+      return {
+        ...store,
+        replaceReducer: (nextReducer: Reducer<S, A>) => {
+          const nextWrappedReducer: Reducer<S & ExtraState, A> = null as any
+          return store.replaceReducer(nextWrappedReducer)
+        }
+      } as Store<S & ExtraState, A, ExtraState>
+    }
+
+    const store = createStore(reducer, enhancer)
+    store.replaceReducer(reducer)
+  }
+}

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -56,6 +56,9 @@ const funcWithStore = (store: Store<State, DerivedAction>) => {}
 
 const store: Store<State> = createStore(reducer)
 
+// ensure that an array-based state works
+const arrayReducer = (state = []) => state
+const storeWithArrayState: Store<[]> = createStore(arrayReducer)
 const storeWithPreloadedState: Store<State> = createStore(reducer, {
   a: 'a',
   b: { c: 'c', d: 'd' }

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -7,7 +7,8 @@ import {
   StoreCreator,
   StoreEnhancerStoreCreator,
   Unsubscribe,
-  Observer
+  Observer,
+  ExtendState
 } from 'redux'
 import 'symbol-observable'
 
@@ -15,6 +16,41 @@ type State = {
   a: 'a'
   b: {
     c: 'c'
+    d: 'd'
+  }
+}
+
+/* extended state */
+const noExtend: ExtendState<State, never> = {
+  a: 'a',
+  b: {
+    c: 'c',
+    d: 'd'
+  }
+}
+// typings:expect-error
+const noExtendError: ExtendState<State, never> = {
+  a: 'a',
+  b: {
+    c: 'c',
+    d: 'd'
+  },
+  e: 'oops'
+}
+
+const yesExtend: ExtendState<State, { yes: 'we can' }> = {
+  a: 'a',
+  b: {
+    c: 'c',
+    d: 'd'
+  },
+  yes: 'we can'
+}
+// typings:expect-error
+const yesExtendError: ExtendState<State, { yes: 'we can' }> = {
+  a: 'a',
+  b: {
+    c: 'c',
     d: 'd'
   }
 }

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -57,8 +57,8 @@ const funcWithStore = (store: Store<State, DerivedAction>) => {}
 const store: Store<State> = createStore(reducer)
 
 // ensure that an array-based state works
-const arrayReducer = (state = []) => state
-const storeWithArrayState: Store<[]> = createStore(arrayReducer)
+const arrayReducer = (state: any[] = []) => state || []
+const storeWithArrayState: Store<any[]> = createStore(arrayReducer)
 const storeWithPreloadedState: Store<State> = createStore(reducer, {
   a: 'a',
   b: { c: 'c', d: 'd' }


### PR DESCRIPTION
This fixes #3482 (replaceReducer typing fails for store enhancers that update the state or extend the store) without requiring any change to the use of existing types (fully typing backwards compatible).

It adds 2 new templates to the generic for defining a `Store`, the extension to state, and the extension to the store definition.

By adding these 2 template parameters, we can mix them with the new reducer state from `replaceReducer`:

```ts
  replaceReducer<NewState = S, NewActions extends A = A>(
    nextReducer: Reducer<NewState, NewActions>
  ): Store<NewState & StateExt, NewActions, StateExt, Ext> & Ext
```

and return a store that has the correct typings for both state and the store extension.

To enable this functionality for store enhancers, it requires these 3 related changes:

1. the definition for `createStore()` needs to be augmented to pass these values to the return type `Store`. Since this is an overloaded function, the `StoreCreator` interface that defines `createStore` is updated for both of the overloads. See the note below about the default value for `StateExt` and `Ext`.
2. the `StoreEnhancer` type needs to re-define the first `createStore` parameter passed to it. It now uses, and thus requires the `StateExt` and `Ext`, otherwise it expects the returned store *not* to have these properties. The point of a store enhancer is to return the enhanced store from `createStore`. The only reason this didn't fail in the past was because we didn't pass the store enhancer extension values to `createStore`.
3. The returned `Store` from `StoreEnhancer` needs to have the `StateExt` and `Ext` extensions passed to it to enable the fix in `replaceReducer`.

One other crucial note:

~~By default, the `StateExt` is defined to be the initial state. Originally, the PR had `{}` as the default value for `StateExt`, but this will fail if the state is defined as an array, or any other non-object value. By using `S`, this allows the default case to work for all possible values of the state shape~~. `Ext` is defined as `{}` because the store definition mixed with `{}` cancels out the `{}`.

I also added a test for store enhancer with `replaceReducer`, to verify correctness of the new typing, and a test for a non-object store value to the `store` test.

_UPDATE:_
It turns out using `StateExt = S` causes `replaceReducer` to fail. Instead, I changed it to check the base type. If it extends an object, `{}` will be a no-op. Otherwise, we return the type `S`, which will be one of the primitive types. There is no easy way to guarantee the type won't interfere with `replaceReducer`, but the assumption I am making is that if someone's root reducer isn't returning an object, it probably isn't going to call `replaceReducer` either.