### PR TITLE
add strict action creator typing as an option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -527,10 +527,44 @@ export function applyMiddleware<Ext, S = any>(
  * async action instead of an action.
  *
  * @template A Returned action type.
+ * @template TypeCheckArgs if set to true, then the arguments to the action creator will be strictly typed
+ * @template T1 if set to any value other than never, the action creator will expect 1 argument
+ * @template T2 if set to any value other than never, the action creator will expect 2 arguments
+ * @template T3 if set to any value other than never, the action creator will expect 3 arguments
+ * @template T4 if set to any value other than never, the action creator will expect 4 arguments
+ * @template T5 if set to any value other than never, the action creator will expect 5 arguments
  */
-export interface ActionCreator<A> {
-  (...args: any[]): A
-}
+export type ActionCreator<
+  A,
+  TypeCheckArgs extends true | false = false,
+  T1 = never,
+  T2 = never,
+  T3 = never,
+  T4 = never,
+  T5 = never
+> = TypeCheckArgs extends false
+  ? {
+      (...args: any[]): A
+    }
+  : // the syntax below is needed when checking whether a type is never
+    // see https://stackoverflow.com/a/57642208/577218
+    ([T1] extends [never]
+      ? () => A
+      : ([T2] extends [never]
+          ? (arg1: T1) => A
+          : ([T3] extends [never]
+              ? (arg1: T1, arg2: T2) => A
+              : ([T4] extends [never]
+                  ? (arg1: T1, arg2: T2, arg3: T3) => A
+                  : ([T5] extends [never]
+                      ? (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => A
+                      : (
+                          arg1: T1,
+                          arg2: T2,
+                          arg3: T3,
+                          arg4: T4,
+                          arg5: T5
+                        ) => A)))))
 
 /**
  * Object whose values are action creator functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -531,10 +531,9 @@ export function applyMiddleware<Ext, S = any>(
  */
 export type ActionCreator<A, Types extends any[] = never> = [Types] extends [
   never
-] // no type checking
-  ? (...args: any[]) => A
-  : // strict type checking
-    (...args: Types) => A
+]
+  ? (...args: any[]) => A // no type checking
+  : (...args: Types) => A // strict type checking
 
 /**
  * Object whose values are action creator functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -527,44 +527,14 @@ export function applyMiddleware<Ext, S = any>(
  * async action instead of an action.
  *
  * @template A Returned action type.
- * @template TypeCheckArgs if set to true, then the arguments to the action creator will be strictly typed
- * @template T1 if set to any value other than never, the action creator will expect 1 argument
- * @template T2 if set to any value other than never, the action creator will expect 2 arguments
- * @template T3 if set to any value other than never, the action creator will expect 3 arguments
- * @template T4 if set to any value other than never, the action creator will expect 4 arguments
- * @template T5 if set to any value other than never, the action creator will expect 5 arguments
+ * @template Types if set to any tuple, it will use the values to type check the arguments (up to 6)
  */
-export type ActionCreator<
-  A,
-  TypeCheckArgs extends true | false = false,
-  T1 = never,
-  T2 = never,
-  T3 = never,
-  T4 = never,
-  T5 = never
-> = TypeCheckArgs extends false
-  ? {
-      (...args: any[]): A
-    }
-  : // the syntax below is needed when checking whether a type is never
-    // see https://stackoverflow.com/a/57642208/577218
-    ([T1] extends [never]
-      ? () => A
-      : ([T2] extends [never]
-          ? (arg1: T1) => A
-          : ([T3] extends [never]
-              ? (arg1: T1, arg2: T2) => A
-              : ([T4] extends [never]
-                  ? (arg1: T1, arg2: T2, arg3: T3) => A
-                  : ([T5] extends [never]
-                      ? (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => A
-                      : (
-                          arg1: T1,
-                          arg2: T2,
-                          arg3: T3,
-                          arg4: T4,
-                          arg5: T5
-                        ) => A)))))
+export type ActionCreator<A, Types extends any[] = never> = [Types] extends [
+  never
+] // no type checking
+  ? (...args: any[]) => A
+  : // strict type checking
+    (...args: Types) => A
 
 /**
  * Object whose values are action creator functions.

--- a/test/typescript/actionCreators.ts
+++ b/test/typescript/actionCreators.ts
@@ -10,16 +10,61 @@ interface AddTodoAction extends Action {
   text: string
 }
 
-const addTodo: ActionCreator<AddTodoAction, true, string> = (text: string) => ({
+// test strict typing of action creators
+// no arguments
+const addTodoNoArgs: ActionCreator<AddTodoAction, []> = () => ({
+  type: 'ADD_TODO',
+  text: 'something'
+})
+
+const AddTodoNoneArgs: AddTodoAction = addTodoNoArgs()
+// typings:expect-error
+addTodoNoArgs('test')
+
+// 1 argument
+const addTodo: ActionCreator<AddTodoAction, [string]> = (text: string) => ({
   type: 'ADD_TODO',
   text
 })
 
 const addTodoAction: AddTodoAction = addTodo('test')
 // typings:expect-error
-const oops: AddTodoAction = addTodo(false)
+addTodo(false)
 // typings:expect-error
-const oops2: AddTodoAction = addTodo('hi', 'too many arguments')
+addTodo('hi', 'too many arguments')
+
+// many arguments
+const addTodoManyArgs: ActionCreator<
+  AddTodoAction,
+  [string, 'hi', 5, boolean, number, 6, 7, 8]
+> = (
+  text: string,
+  other: 'hi',
+  third: 5,
+  fourth: boolean,
+  fifth: number,
+  sixth: 6
+) => ({
+  type: 'ADD_TODO',
+  text: text + other + third + fourth
+})
+
+const addTodoActionMany: AddTodoAction = addTodoManyArgs(
+  'hello',
+  'hi',
+  5,
+  false,
+  234,
+  6,
+  7,
+  8
+)
+// typings:expect-error
+addTodoManyArgs('hello')
+// typings:expect-error
+addTodoManyArgs('hi', 'hi', 5, true, 234, 6, 7, 8, 'too many')
+// typings:expect-error
+addTodoManyArgs('string', 'hi', 5, false, 234, 6, 7, 'oops')
 
 // non-strictly typed action creator
 const looseAddTodo: ActionCreator<AddTodoAction> = (text: string) => ({

--- a/test/typescript/actionCreators.ts
+++ b/test/typescript/actionCreators.ts
@@ -10,12 +10,28 @@ interface AddTodoAction extends Action {
   text: string
 }
 
-const addTodo: ActionCreator<AddTodoAction> = (text: string) => ({
+const addTodo: ActionCreator<AddTodoAction, true, string> = (text: string) => ({
   type: 'ADD_TODO',
   text
 })
 
 const addTodoAction: AddTodoAction = addTodo('test')
+// typings:expect-error
+const oops: AddTodoAction = addTodo(false)
+// typings:expect-error
+const oops2: AddTodoAction = addTodo('hi', 'too many arguments')
+
+// non-strictly typed action creator
+const looseAddTodo: ActionCreator<AddTodoAction> = (text: string) => ({
+  type: 'ADD_TODO',
+  text
+})
+
+const noOops: AddTodoAction = looseAddTodo(false)
+const noOops2: AddTodoAction = looseAddTodo(
+  'hi',
+  'too many arguments, but not strictly typed'
+)
 
 type AddTodoThunk = (dispatch: Dispatch) => AddTodoAction
 


### PR DESCRIPTION
This fixes #3455 

Basically, it modifies `ActionCreator` to accept a new, optional second template parameter. This parameter is a tuple, whose types will define the required parameters for the action creator.

Note that there is no support for optional parameters. Additionally, this will enforce on the calling side only, not the declaration side, so if the action creator does not define all of the required parameters, it will not complain. It will complain if any specified parameters's types don't match.