### PR TITLE
fix warning in replaceReducer test

### DIFF
--- a/test/replaceReducers.spec.ts
+++ b/test/replaceReducers.spec.ts
@@ -7,7 +7,7 @@ describe('replaceReducers test', () => {
       bar: (state = 2, _action) => state
     })
     const store = createStore((state, action) => {
-      if (state === undefined) return 5
+      if (state === undefined) return { type: 5 }
       return action
     })
 


### PR DESCRIPTION
The `replaceReducer` new reducer in the test was only returning `5`, which is almost certainly an error in the real world. This PR changes the test so that it returns a more realistic object, removing the warning