### PR TITLE
Convert applyMiddleware.js to typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -211,7 +211,7 @@ export function combineReducers<M extends ReducersMapObject<any, any>>(
  *   dispatched.
  */
 export interface Dispatch<A extends Action = AnyAction> {
-  <T extends A>(action: T): T
+  <T extends A>(action: T, ...extraArgs: any[]): T
 }
 
 /**

--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -3,8 +3,10 @@ import {
   Middleware,
   StoreEnhancer,
   StoreCreator,
+  AnyAction,
+  Reducer,
   Dispatch,
-  AnyAction
+  MiddlewareAPI
 } from '..'
 
 /**
@@ -26,7 +28,10 @@ import {
 export default function applyMiddleware(
   ...middlewares: Middleware[]
 ): StoreEnhancer {
-  return (createStore: StoreCreator) => (reducer: any, ...args) => {
+  return (createStore: StoreCreator) => <S, A extends AnyAction>(
+    reducer: Reducer<S, A>,
+    ...args: any[]
+  ) => {
     const store = createStore(reducer, ...args)
     let dispatch: Dispatch = () => {
       throw new Error(
@@ -35,10 +40,9 @@ export default function applyMiddleware(
       )
     }
 
-    const middlewareAPI = {
+    const middlewareAPI: MiddlewareAPI = {
       getState: store.getState,
-      dispatch: (action: AnyAction, ...args: any[]) =>
-        (dispatch as any)(action, ...args)
+      dispatch: (action, ...args) => dispatch(action, ...args)
     }
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)

--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -1,4 +1,11 @@
 import compose from './compose'
+import {
+  Middleware,
+  StoreEnhancer,
+  StoreCreator,
+  Dispatch,
+  AnyAction
+} from '..'
 
 /**
  * Creates a store enhancer that applies middleware to the dispatch method
@@ -16,10 +23,12 @@ import compose from './compose'
  * @param {...Function} middlewares The middleware chain to be applied.
  * @returns {Function} A store enhancer applying the middleware.
  */
-export default function applyMiddleware(...middlewares) {
-  return createStore => (...args) => {
-    const store = createStore(...args)
-    let dispatch = () => {
+export default function applyMiddleware(
+  ...middlewares: Middleware[]
+): StoreEnhancer {
+  return (createStore: StoreCreator) => (reducer: any, ...args) => {
+    const store = createStore(reducer, ...args)
+    let dispatch: Dispatch = () => {
       throw new Error(
         'Dispatching while constructing your middleware is not allowed. ' +
           'Other middleware would not be applied to this dispatch.'
@@ -28,7 +37,8 @@ export default function applyMiddleware(...middlewares) {
 
     const middlewareAPI = {
       getState: store.getState,
-      dispatch: (...args) => dispatch(...args)
+      dispatch: (action: AnyAction, ...args: any[]) =>
+        (dispatch as any)(action, ...args)
     }
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)


### PR DESCRIPTION
This converts `applyMiddleware` to typescript. In order to do this, there is a bug in the type definition of `Dispatch` that needs to be fixed to reflect the changes introduced in the fix for #2501.

In addition, this conversion makes more explicit the reducer passed to `createStore` and the action passed to `dispatch`. This supplants part of #3520 and is a step on the path to #3500