### PR TITLE
convert compose to typescript

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -9,14 +9,15 @@
  * (...args) => f(g(h(...args))).
  */
 
-export default function compose(...funcs) {
+export default function compose(...funcs: Function[]) {
   if (funcs.length === 0) {
-    return arg => arg
+    // infer the argument type so it is usable in inference down the line
+    return <T>(arg: T) => arg
   }
 
   if (funcs.length === 1) {
     return funcs[0]
   }
 
-  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+  return funcs.reduce((a, b) => (...args: any) => a(b(...args)))
 }


### PR DESCRIPTION
This converts `compose.js` to typescript, supplanting #3520 and a step on the path to #3500