### PR TITLE
extract action types from index.d.ts

### DIFF
--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,0 +1,61 @@
+/**
+ * An *action* is a plain object that represents an intention to change the
+ * state. Actions are the only way to get data into the store. Any data,
+ * whether from UI events, network callbacks, or other sources such as
+ * WebSockets needs to eventually be dispatched as actions.
+ *
+ * Actions must have a `type` field that indicates the type of action being
+ * performed. Types can be defined as constants and imported from another
+ * module. It's better to use strings for `type` than Symbols because strings
+ * are serializable.
+ *
+ * Other than `type`, the structure of an action object is really up to you.
+ * If you're interested, check out Flux Standard Action for recommendations on
+ * how actions should be constructed.
+ *
+ * @template T the type of the action's `type` tag.
+ */
+export interface Action<T = any> {
+  type: T
+}
+
+/**
+ * An Action type which accepts any other properties.
+ * This is mainly for the use of the `Reducer` type.
+ * This is not part of `Action` itself to prevent types that extend `Action` from
+ * having an index signature.
+ */
+export interface AnyAction extends Action {
+  // Allows any extra properties to be defined in an action.
+  [extraProps: string]: any
+}
+
+/* action creators */
+
+/**
+ * An *action creator* is, quite simply, a function that creates an action. Do
+ * not confuse the two terms—again, an action is a payload of information, and
+ * an action creator is a factory that creates an action.
+ *
+ * Calling an action creator only produces an action, but does not dispatch
+ * it. You need to call the store's `dispatch` function to actually cause the
+ * mutation. Sometimes we say *bound action creators* to mean functions that
+ * call an action creator and immediately dispatch its result to a specific
+ * store instance.
+ *
+ * If an action creator needs to read the current state, perform an API call,
+ * or cause a side effect, like a routing transition, it should return an
+ * async action instead of an action.
+ *
+ * @template A Returned action type.
+ */
+export interface ActionCreator<A> {
+  (...args: any[]): A
+}
+
+/**
+ * Object whose values are action creator functions.
+ */
+export interface ActionCreatorsMapObject<A = any> {
+  [key: string]: ActionCreator<A>
+}

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,4 +1,6 @@
-import { Action, Reducer, AnyAction, Dispatch, PreloadedState } from '../..'
+/// <reference types="symbol-observable" />
+import { Reducer, Dispatch, PreloadedState } from '../..'
+import { Action, AnyAction } from './actions'
 
 /**
  * Function to remove listener added by `Store.subscribe()`.


### PR DESCRIPTION
Extract all things action types from `index.d.ts`

Note: this PR also fixes an oversight in the extraction of store-related types, which is the declaration of observable in `types/store.ts`