### PR TITLE
add overloads to compose.ts and applyMiddleware.ts

### DIFF
--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -20,6 +20,35 @@ import { Reducer } from './types/reducers'
  * @param {...Function} middlewares The middleware chain to be applied.
  * @returns {Function} A store enhancer applying the middleware.
  */
+export default function applyMiddleware(): StoreEnhancer
+export default function applyMiddleware<Ext1, S>(
+  middleware1: Middleware<Ext1, S, any>
+): StoreEnhancer<{ dispatch: Ext1 }>
+export default function applyMiddleware<Ext1, Ext2, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 }>
+export default function applyMiddleware<Ext1, Ext2, Ext3, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+  middleware3: Middleware<Ext3, S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 }>
+export default function applyMiddleware<Ext1, Ext2, Ext3, Ext4, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+  middleware3: Middleware<Ext3, S, any>,
+  middleware4: Middleware<Ext4, S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 & Ext4 }>
+export default function applyMiddleware<Ext1, Ext2, Ext3, Ext4, Ext5, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+  middleware3: Middleware<Ext3, S, any>,
+  middleware4: Middleware<Ext4, S, any>,
+  middleware5: Middleware<Ext5, S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 & Ext4 & Ext5 }>
+export default function applyMiddleware<Ext, S = any>(
+  ...middlewares: Middleware<any, S, any>[]
+): StoreEnhancer<{ dispatch: Ext }>
 export default function applyMiddleware(
   ...middlewares: Middleware[]
 ): StoreEnhancer {
@@ -40,7 +69,7 @@ export default function applyMiddleware(
       dispatch: (action, ...args) => dispatch(action, ...args)
     }
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
-    dispatch = compose(...chain)(store.dispatch)
+    dispatch = compose<typeof dispatch>(...chain)(store.dispatch)
 
     return {
       ...store,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,13 +1,92 @@
+type Func0<R> = () => R
+type Func1<T1, R> = (a1: T1) => R
+type Func2<T1, T2, R> = (a1: T1, a2: T2) => R
+type Func3<T1, T2, T3, R> = (a1: T1, a2: T2, a3: T3, ...args: any[]) => R
+
 /**
  * Composes single-argument functions from right to left. The rightmost
- * function can take multiple arguments as it provides the signature for
- * the resulting composite function.
+ * function can take multiple arguments as it provides the signature for the
+ * resulting composite function.
  *
- * @param {...Function} funcs The functions to compose.
- * @returns {Function} A function obtained by composing the argument functions
- * from right to left. For example, compose(f, g, h) is identical to doing
- * (...args) => f(g(h(...args))).
+ * @param funcs The functions to compose.
+ * @returns R function obtained by composing the argument functions from right
+ *   to left. For example, `compose(f, g, h)` is identical to doing
+ *   `(...args) => f(g(h(...args)))`.
  */
+export default function compose(): <R>(a: R) => R
+
+export default function compose<F extends Function>(f: F): F
+
+/* two functions */
+export default function compose<A, R>(f1: (b: A) => R, f2: Func0<A>): Func0<R>
+export default function compose<A, T1, R>(
+  f1: (b: A) => R,
+  f2: Func1<T1, A>
+): Func1<T1, R>
+export default function compose<A, T1, T2, R>(
+  f1: (b: A) => R,
+  f2: Func2<T1, T2, A>
+): Func2<T1, T2, R>
+export default function compose<A, T1, T2, T3, R>(
+  f1: (b: A) => R,
+  f2: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>
+
+/* three functions */
+export default function compose<A, B, R>(
+  f1: (b: B) => R,
+  f2: (a: A) => B,
+  f3: Func0<A>
+): Func0<R>
+export default function compose<A, B, T1, R>(
+  f1: (b: B) => R,
+  f2: (a: A) => B,
+  f3: Func1<T1, A>
+): Func1<T1, R>
+export default function compose<A, B, T1, T2, R>(
+  f1: (b: B) => R,
+  f2: (a: A) => B,
+  f3: Func2<T1, T2, A>
+): Func2<T1, T2, R>
+export default function compose<A, B, T1, T2, T3, R>(
+  f1: (b: B) => R,
+  f2: (a: A) => B,
+  f3: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>
+
+/* four functions */
+export default function compose<A, B, C, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func0<A>
+): Func0<R>
+export default function compose<A, B, C, T1, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func1<T1, A>
+): Func1<T1, R>
+export default function compose<A, B, C, T1, T2, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func2<T1, T2, A>
+): Func2<T1, T2, R>
+export default function compose<A, B, C, T1, T2, T3, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>
+
+/* rest */
+export default function compose<R>(
+  f1: (b: any) => R,
+  ...funcs: Function[]
+): (...args: any[]) => R
+
+export default function compose<R>(...funcs: Function[]): (...args: any[]) => R
 
 export default function compose(...funcs: Function[]) {
   if (funcs.length === 0) {


### PR DESCRIPTION
Because `applyMiddleware` relies upon `compose`, these two need to be committed at the same time. The comment changes in `compose.ts` are because of subtle differences between the comments in `index.d.ts` and `compose.ts`. Where there was a conflict I chose the `index.d.ts` version