### PR TITLE
fix import inside enhancers typescript test

### DIFF
--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -1,5 +1,11 @@
-import { PreloadedState } from '../../index'
-import { StoreEnhancer, Action, AnyAction, Reducer, createStore } from 'redux'
+import {
+  StoreEnhancer,
+  Action,
+  AnyAction,
+  Reducer,
+  createStore,
+  PreloadedState
+} from 'redux'
 
 interface State {
   someField: 'string'


### PR DESCRIPTION
This is a subtle problem. If we import `PreloadedState` from `../../index`, and `createStore` from `redux`, we end up with different versions of the declared `$CombinedState` symbol, and so the types never match.

Also, we should be consistent about always loading the types from our aliased `redux`