### PR TITLE
Rewrite `compose` utility function

### DIFF
--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -72,7 +72,7 @@ export default function applyMiddleware(
       dispatch: (action, ...args) => dispatch(action, ...args)
     }
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
-    dispatch = compose<typeof dispatch>(...chain)(store.dispatch)
+    dispatch = compose(...chain)(store.dispatch as typeof dispatch)
 
     return {
       ...store,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -4,13 +4,23 @@
  */
 interface Fn extends Function {
   <A extends unknown[]>(...args: A): unknown
+  <A>(...args: A[]): unknown
 }
 
 /**
- * A type-level utility that extracts the type of a function's input params as
- * a tuple, inferring `unknown` for any input params assigned to generics
+ * A type-level utility function to
  */
-// type Params<F> = F extends (...args: infer A) => unknown ? A : never
+type Tail<Fns extends Fn[]> = Fns extends <A>(
+  a: A,
+  ...rest: infer Rest
+) => unknown
+  ? Rest
+  : never
+
+/**
+ * A type-level utility function to
+ */
+type Last<Fns extends Fn[]> = Fns[Tail<Fns>['length']]
 
 /**
  * Composes single-argument functions from right to left. The rightmost
@@ -102,6 +112,10 @@ export default function compose<
   fbc: (...b: B) => C[0],
   fab: (...args: A) => B[0]
 ): (...args: A) => F
+// generic type signature for any number of functions
+export default function compose<Fns extends Fn[]>(
+  ...funcs: Fns
+): (...args: Parameters<Last<Fns>>) => ReturnType<Fns[0]>
 // generic base case type signature and function body implementation
 export default function compose<Fns extends Fn[]>(...fns: Fns): Fn {
   const len = fns.length

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -10,7 +10,7 @@ interface Fn extends Function {
  * A type-level utility that extracts the type of a function's input params as
  * a tuple, inferring `unknown` for any input params assigned to generics
  */
-type Params<F> = F extends (...args: infer A) => unknown ? A : never
+// type Params<F> = F extends (...args: infer A) => unknown ? A : never
 
 /**
  * Composes single-argument functions from right to left. The rightmost
@@ -114,7 +114,7 @@ export default function compose<Fns extends Fn[]>(...fns: Fns): Fn {
     return fns[0]
   }
 
-  // `Params<typeof b>` is equal to `unknown[]` in the below type signature,
-  // but, `Params<typeof b>`, arguably, more clearly conveys intent
-  return fns.reduce((a, b) => (...args: Params<typeof b>) => a(b(...args)))
+  // `Parameters<typeof b>` is equalavelnt to `unknown[]` in the below type,
+  // signature, but `Parameters<typeof b>` more clearly conveys intent
+  return fns.reduce((a, b) => (...args: Parameters<typeof b>) => a(b(...args)))
 }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -8,19 +8,27 @@ interface Fn extends Function {
 }
 
 /**
- * A type-level utility function to
+ * A type-level utility to get the type of the tail of a tuple of functions
  */
-type Tail<Fns extends Fn[]> = Fns extends <A>(
-  a: A,
-  ...rest: infer Rest
-) => unknown
-  ? Rest
-  : never
+type Tail<Fns extends Fn[]> = (
+  ...fns: Fns
+) => unknown extends <A>(a: A, ...rest: infer Rest) => unknown ? Rest : never
 
 /**
- * A type-level utility function to
+ * A type-level utility to get the type of the last function from a tuple of
+ * functions
  */
-type Last<Fns extends Fn[]> = Fns[Tail<Fns>['length']]
+type Last<Fns extends Fn[]> = Fns['length'] extends 0
+  ? never
+  : Fns[Tail<Fns>['length']]
+
+/**
+ * A type-level utility to get the return type of the composition of a tuple of
+ * functions
+ */
+type Composed<Fns extends Fn[]> = (
+  ...args: Parameters<Last<Fns>>
+) => ReturnType<Fns[0]>
 
 /**
  * Composes single-argument functions from right to left. The rightmost
@@ -113,9 +121,7 @@ export default function compose<
   fab: (...args: A) => B[0]
 ): (...args: A) => F
 // generic type signature for any number of functions
-export default function compose<Fns extends Fn[]>(
-  ...funcs: Fns
-): (...args: Parameters<Last<Fns>>) => ReturnType<Fns[0]>
+export default function compose<Fns extends Fn[]>(...funcs: Fns): Composed<Fns>
 // generic base case type signature and function body implementation
 export default function compose<Fns extends Fn[]>(...fns: Fns): Fn {
   const len = fns.length

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -104,7 +104,8 @@ describe('Utils', () => {
     })
 
     it('returns the first given argument if given no functions', () => {
-      expect(compose<number>()(1, 2)).toBe(1)
+      expect(compose<[number, number]>()(1, 2)).toBe(1)
+      expect(compose()('zero', 1, 2)).toBe('zero')
       expect(compose()(3)).toBe(3)
       expect(compose()(undefined)).toBe(undefined)
     })


### PR DESCRIPTION
I saw you discussing pulling in `ts-toolbelt` to rewrite the `compose` utility in https://github.com/reduxjs/redux/pull/3563 and asking for alternative solutions on Twitter. I don't think you need to pull in a utility library to do so this, and `ts-toolbelt`'s solution seemed more complex than necessary, utilizing a bunch of custom type-level helper utilities. So, I decided to take a shot at rewriting `compose` from scratch, using no external dependencies & avoiding `any` entirely. This is what I came up with.

Important notes:
- There are no behavior changes other than a change to the generic type params used in various overloads. When explicitly providing generic params for overloads accepting multi-arg functions, you must now pass in a tuple of types for the generic instead of only the type. This is accomplished via the combination of `A extends unknown[]` & `(...args: A)`. This actually fixes a bug that was present before which (accidentally, I believe) restricted these multi-arg functions to take in arguments all of the same type, which isn't necessary. You can see the changes I'm talking about reflected in the updated test.

- I did not change the actual logic in the implementation body of the function. We could rewrite it without `reduce` in a potentially more performant way, but I wanted to keep the changes in this PR restricted to how the types work so that it would be easier to review. Note: There are some changes in the implementation, but they are just related to type signatures. Also, we could use `Function` where I'm using `Fn` and `unknown[]` where I'm using `Parameters<typeof b>` if you don't like what I did with these. It would still work the same way.

- I think what's in the PR now is an improvement and could be merged as is (after fixing the line passing `...chain` to `compose` that's currently causing the build to fail), but, while I kept the actual functionality/behavior the same in this PR, I think it's worth considering making some further changes beyond what's been done so far in order to simplify what's required to properly type this function. I'll add more info on this in a followup comment.
