### PR TITLE
Simplify applyMiddleware

### DIFF
--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -1,8 +1,10 @@
 import compose from './compose'
 import { Middleware, MiddlewareAPI } from './types/middleware'
-import { AnyAction } from './types/actions'
-import { StoreEnhancer, StoreCreator, Dispatch } from './types/store'
-import { Reducer } from './types/reducers'
+import {
+  Dispatch,
+  StoreEnhancer,
+  StoreEnhancerStoreCreator
+} from './types/store'
 
 /**
  * Creates a store enhancer that applies middleware to the dispatch method
@@ -23,40 +25,17 @@ import { Reducer } from './types/reducers'
  * @template Ext Dispatch signature added by a middleware.
  * @template S The type of the state supported by a middleware.
  */
-export default function applyMiddleware(): StoreEnhancer
-export default function applyMiddleware<Ext1, S>(
-  middleware1: Middleware<Ext1, S, any>
-): StoreEnhancer<{ dispatch: Ext1 }>
-export default function applyMiddleware<Ext1, Ext2, S>(
-  middleware1: Middleware<Ext1, S, any>,
-  middleware2: Middleware<Ext2, S, any>
-): StoreEnhancer<{ dispatch: Ext1 & Ext2 }>
-export default function applyMiddleware<Ext1, Ext2, Ext3, S>(
-  middleware1: Middleware<Ext1, S, any>,
-  middleware2: Middleware<Ext2, S, any>,
-  middleware3: Middleware<Ext3, S, any>
-): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 }>
-export default function applyMiddleware<Ext1, Ext2, Ext3, Ext4, S>(
-  middleware1: Middleware<Ext1, S, any>,
-  middleware2: Middleware<Ext2, S, any>,
-  middleware3: Middleware<Ext3, S, any>,
-  middleware4: Middleware<Ext4, S, any>
-): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 & Ext4 }>
-export default function applyMiddleware<Ext1, Ext2, Ext3, Ext4, Ext5, S>(
-  middleware1: Middleware<Ext1, S, any>,
-  middleware2: Middleware<Ext2, S, any>,
-  middleware3: Middleware<Ext3, S, any>,
-  middleware4: Middleware<Ext4, S, any>,
-  middleware5: Middleware<Ext5, S, any>
-): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 & Ext4 & Ext5 }>
-export default function applyMiddleware<Ext, S = any>(
-  ...middlewares: Middleware<any, S, any>[]
-): StoreEnhancer<{ dispatch: Ext }>
-export default function applyMiddleware(
-  ...middlewares: Middleware[]
-): StoreEnhancer<any> {
-  return (createStore: StoreCreator) => <S, A extends AnyAction>(
-    reducer: Reducer<S, A>,
+export default function applyMiddleware<
+  S = any,
+  M extends Middleware = Middleware
+>(
+  ...middlewares: M[]
+): StoreEnhancer<
+  M extends Middleware<any, any, infer D> ? { dispatch: D } : never,
+  S
+> {
+  return (createStore: StoreEnhancerStoreCreator<any>) => (
+    reducer,
     ...args: any[]
   ) => {
     const store = createStore(reducer, ...args)


### PR DESCRIPTION
Breaking up #3566 into smaller pieces.

This PR simplifies the types of `applyMiddleware` by replacing all the overloads with a single generic function signature that _infers_ the union of any/all `Dispatch` types provided into a single `StoreEnhancer`. This implementation has the added benefit that you can provide as many middlewares as you want w/o maxing out at just 5.