### PR TITLE
Optimize memory consumption in combineReducers

### DIFF
--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -209,6 +209,8 @@ export default function combineReducers(reducers: ReducersMapObject) {
         }
 
         nextState[key] = nextStateForKey
+      } else if (nextState !== null) {
+        nextState[key] = previousStateForKey
       }
     }
     if (nextState === null) {


### PR DESCRIPTION
Current version:
combineReducers allocate object every time on its call even when total state not changed
Patched version:
combineReducers allocate new object if state or reducers' count changed