### PR TITLE
increase test cov of reducers test helpers and observable return

### DIFF
--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -470,9 +470,7 @@ describe('createStore', () => {
       )
     ).toThrow(/may not dispatch/)
 
-    expect(() =>
-      store.dispatch(dispatchInMiddle(() => {}))
-    ).not.toThrow(/may not dispatch/)
+    expect(() => store.dispatch(dispatchInMiddle(() => {}))).not.toThrow()
   })
 
   it('does not allow getState() from within a reducer', () => {
@@ -482,9 +480,7 @@ describe('createStore', () => {
       store.dispatch(getStateInMiddle(store.getState.bind(store)))
     ).toThrow(/You may not call store.getState()/)
 
-    expect(() =>
-      store.dispatch(getStateInMiddle(() => {}))
-    ).not.toThrow(/You may not call store.getState()/)
+    expect(() => store.dispatch(getStateInMiddle(() => {}))).not.toThrow()
   })
 
   it('does not allow subscribe() from within a reducer', () => {
@@ -494,9 +490,7 @@ describe('createStore', () => {
       store.dispatch(subscribeInMiddle(store.subscribe.bind(store, () => {})))
     ).toThrow(/You may not call store.subscribe()/)
 
-    expect(() =>
-      store.dispatch(subscribeInMiddle(() => {}))
-    ).not.toThrow(/You may not call store.subscribe()/)
+    expect(() => store.dispatch(subscribeInMiddle(() => {}))).not.toThrow()
   })
 
   it('does not allow unsubscribe from subscribe() from within a reducer', () => {
@@ -507,9 +501,7 @@ describe('createStore', () => {
       store.dispatch(unsubscribeInMiddle(unsubscribe.bind(store)))
     ).toThrow(/You may not unsubscribe from a store/)
 
-    expect(() =>
-      store.dispatch(unsubscribeInMiddle(() => {}))
-    ).not.toThrow(/You may not unsubscribe from a store/)
+    expect(() => store.dispatch(unsubscribeInMiddle(() => {}))).not.toThrow()
   })
 
   it('recovers from an error within a reducer', () => {

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -651,6 +651,12 @@ describe('createStore', () => {
         expect(typeof obs.subscribe).toBe('function')
       })
 
+      it('may be used to retrieve itself', () => {
+        const store = createStore(() => {})
+        const obs = store[$$observable]()
+        expect(obs[$$observable]()).toBe(obs)
+      })
+
       it('should throw a TypeError if an observer object is not supplied to subscribe', () => {
         const store = createStore(() => {})
         const obs = store[$$observable]()

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -469,6 +469,10 @@ describe('createStore', () => {
         dispatchInMiddle(store.dispatch.bind(store, unknownAction()))
       )
     ).toThrow(/may not dispatch/)
+
+    expect(() =>
+      store.dispatch(dispatchInMiddle(() => {}))
+    ).not.toThrow(/may not dispatch/)
   })
 
   it('does not allow getState() from within a reducer', () => {
@@ -477,6 +481,10 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch(getStateInMiddle(store.getState.bind(store)))
     ).toThrow(/You may not call store.getState()/)
+
+    expect(() =>
+      store.dispatch(getStateInMiddle(() => {}))
+    ).not.toThrow(/You may not call store.getState()/)
   })
 
   it('does not allow subscribe() from within a reducer', () => {
@@ -485,6 +493,10 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch(subscribeInMiddle(store.subscribe.bind(store, () => {})))
     ).toThrow(/You may not call store.subscribe()/)
+
+    expect(() =>
+      store.dispatch(subscribeInMiddle(() => {}))
+    ).not.toThrow(/You may not call store.subscribe()/)
   })
 
   it('does not allow unsubscribe from subscribe() from within a reducer', () => {
@@ -494,6 +506,10 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch(unsubscribeInMiddle(unsubscribe.bind(store)))
     ).toThrow(/You may not unsubscribe from a store/)
+
+    expect(() =>
+      store.dispatch(unsubscribeInMiddle(() => {}))
+    ).not.toThrow(/You may not unsubscribe from a store/)
   })
 
   it('recovers from an error within a reducer', () => {

--- a/test/helpers/reducers.ts
+++ b/test/helpers/reducers.ts
@@ -8,7 +8,7 @@ import {
 } from './actionTypes'
 import { AnyAction } from '../..'
 
-function id(state: { id: number }[] = []) {
+function id(state: { id: number }[]) {
   return (
     state.reduce((result, item) => (item.id > result ? item.id : result), 0) + 1
   )


### PR DESCRIPTION
### summary

not so important, but I was running some tests and saw these warnings.

- for some tests, like for `dispatchInMiddle`, I saw some helpers unreachable lines (cause exceptions were being tested) and led to these uncovered warning.
- another helper, `id`, was function with an unused branch, that was an unused default value for a param
- and finally, there was an uncovered function on store `observable` return

### before

![Screenshot from 2019-10-08 14-12-25](https://user-images.githubusercontent.com/6237270/66419130-e3c4a080-e9d9-11e9-9999-edae9542fc33.png)

### now

![Screenshot from 2019-10-08 14-41-10](https://user-images.githubusercontent.com/6237270/66419127-e32c0a00-e9d9-11e9-84e9-eedc6a8f1f21.png)

(there's still an uncovered line for a warning shown on redux.js bundle)
