### PR TITLE
Added currentState arg in listener function

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ let store = createStore(counter)
 // Normally you'd use a view binding library (e.g. React Redux) rather than subscribe() directly.
 // However it can also be handy to persist the current state in the localStorage.
 
-store.subscribe(() => console.log(store.getState()))
+store.subscribe(currentState => console.log(currentState))
 
 // The only way to mutate the internal state is to dispatch an action.
 // The actions can be serialized, logged or stored and later replayed.

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -103,7 +103,7 @@ See [`applyMiddleware(...middlewares)`](./api/applyMiddleware.md) for a detailed
 type Store = {
   dispatch: Dispatch
   getState: () => State
-  subscribe: (listener: () => void) => () => void
+  subscribe: (listener: (currentState: State) => void) => () => void
   replaceReducer: (reducer: Reducer) => void
 }
 ```

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -88,7 +88,7 @@ store.dispatch(addTodo('Read about the middleware'))
 
 ### subscribe(listener)
 
-Adds a change listener. It will be called any time an action is dispatched, and some part of the state tree may potentially have changed. You may then call [`getState()`](#getState) to read the current state tree inside the callback.
+Adds a change listener. It will be called any time an action is dispatched, and some part of the state tree may potentially have changed. You may then call [`getState()`](#getState) to read the current state tree inside the callback or get current state from first argument in `listener`.
 
 You may call [`dispatch()`](#dispatchaction) from a change listener, with the following caveats:
 
@@ -118,8 +118,10 @@ function select(state) {
 }
 
 let currentValue
-function handleChange() {
+function handleChange(currentState) {
   let previousValue = currentValue
+  currentValue = select(currentState)
+  //or
   currentValue = select(store.getState())
 
   if (previousValue !== currentValue) {

--- a/docs/basics/DataFlow.md
+++ b/docs/basics/DataFlow.md
@@ -100,7 +100,7 @@ While [`combineReducers()`](../api/combineReducers.md) is a handy helper utility
 
 4. **The Redux store saves the complete state tree returned by the root reducer.**
 
-This new tree is now the next state of your app! Every listener registered with [`store.subscribe(listener)`](../api/Store.md#subscribelistener) will now be invoked; listeners may call [`store.getState()`](../api/Store.md#getState) to get the current state.
+This new tree is now the next state of your app! Every listener registered with [`store.subscribe(listener)`](../api/Store.md#subscribelistener) will now be invoked; listeners may call [`store.getState()`](../api/Store.md#getState) to get the current state or get current state from first argument in `listener`.
 
 Now, the UI can be updated to reflect the new state. If you use bindings like [React Redux](https://github.com/gaearon/react-redux), this is the point at which `component.setState(newState)` is called.
 

--- a/docs/basics/Store.md
+++ b/docs/basics/Store.md
@@ -50,7 +50,7 @@ console.log(store.getState())
 
 // Every time the state changes, log it
 // Note that subscribe() returns a function for unregistering the listener
-const unsubscribe = store.subscribe(() => console.log(store.getState()))
+const unsubscribe = store.subscribe(currentState => console.log(currentState))
 
 // Dispatch some actions
 store.dispatch(addTodo('Learn about actions'))

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -80,7 +80,7 @@ let store = createStore(counter)
 // Normally you'd use a view binding library (e.g. React Redux) rather than subscribe() directly.
 // However it can also be handy to persist the current state in the localStorage.
 
-store.subscribe(() => console.log(store.getState()))
+store.subscribe(currentState => console.log(currentState))
 
 // The only way to mutate the internal state is to dispatch an action.
 // The actions can be serialized, logged or stored and later replayed.

--- a/docs/introduction/PriorArt.md
+++ b/docs/introduction/PriorArt.md
@@ -55,7 +55,7 @@ Does it make sense to use Redux together with RxJS? Sure! They work great togeth
 function toObservable(store) {
   return {
     subscribe({ next }) {
-      const unsubscribe = store.subscribe(() => next(store.getState()))
+      const unsubscribe = store.subscribe(currentState => next(currentState))
       next(store.getState())
       return { unsubscribe }
     }

--- a/examples/counter-vanilla/index.html
+++ b/examples/counter-vanilla/index.html
@@ -33,33 +33,37 @@
       var store = Redux.createStore(counter)
       var valueEl = document.getElementById('value')
 
-      function render() {
-        valueEl.innerHTML = store.getState().toString()
+      function render(currentState) {
+        valueEl.innerHTML = (currentState || store.getState()).toString()
       }
 
       render()
       store.subscribe(render)
 
-      document.getElementById('increment')
-        .addEventListener('click', function () {
+      document
+        .getElementById('increment')
+        .addEventListener('click', function() {
           store.dispatch({ type: 'INCREMENT' })
         })
 
-      document.getElementById('decrement')
-        .addEventListener('click', function () {
+      document
+        .getElementById('decrement')
+        .addEventListener('click', function() {
           store.dispatch({ type: 'DECREMENT' })
         })
 
-      document.getElementById('incrementIfOdd')
-        .addEventListener('click', function () {
+      document
+        .getElementById('incrementIfOdd')
+        .addEventListener('click', function() {
           if (store.getState() % 2 !== 0) {
             store.dispatch({ type: 'INCREMENT' })
           }
         })
 
-      document.getElementById('incrementAsync')
-        .addEventListener('click', function () {
-          setTimeout(function () {
+      document
+        .getElementById('incrementAsync')
+        .addEventListener('click', function() {
+          setTimeout(function() {
             store.dispatch({ type: 'INCREMENT' })
           }, 1000)
         })

--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -7,14 +7,15 @@ import counter from './reducers'
 const store = createStore(counter)
 const rootEl = document.getElementById('root')
 
-const render = () => ReactDOM.render(
-  <Counter
-    value={store.getState()}
-    onIncrement={() => store.dispatch({ type: 'INCREMENT' })}
-    onDecrement={() => store.dispatch({ type: 'DECREMENT' })}
-  />,
-  rootEl
-)
+const render = (currentState = store.getState()) =>
+  ReactDOM.render(
+    <Counter
+      value={currentState}
+      onIncrement={() => store.dispatch({ type: 'INCREMENT' })}
+      onDecrement={() => store.dispatch({ type: 'DECREMENT' })}
+    />,
+    rootEl
+  )
 
 render()
 store.subscribe(render)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4133,9 +4133,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -7373,13 +7373,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
+      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -99,7 +99,7 @@ export default function createStore<
 
   let currentReducer = reducer
   let currentState = preloadedState as S
-  let currentListeners: (() => void)[] | null = []
+  let currentListeners: ((currentState: S) => void)[] | null = []
   let nextListeners = currentListeners
   let isDispatching = false
 
@@ -250,7 +250,7 @@ export default function createStore<
     const listeners = (currentListeners = nextListeners)
     for (let i = 0; i < listeners.length; i++) {
       const listener = listeners[i]
-      listener()
+      listener(currentState)
     }
 
     return action

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -189,7 +189,7 @@ export interface Store<
    * @param listener A callback to be invoked on every dispatch.
    * @returns A function to remove this change listener.
    */
-  subscribe(listener: () => void): Unsubscribe
+  subscribe(listener: (currentState: S) => void): Unsubscribe
 
   /**
    * Replaces the reducer currently used by the store to calculate the state.

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -405,8 +405,8 @@ describe('createStore', () => {
 
   it('provides an up-to-date state when a subscriber is notified', done => {
     const store = createStore(reducers.todos)
-    store.subscribe(() => {
-      expect(store.getState()).toEqual([
+    store.subscribe(currentState => {
+      expect(currentState).toEqual([
         {
           id: 1,
           text: 'Hello'
@@ -447,9 +447,8 @@ describe('createStore', () => {
 
     const store = createStore(combineReducers({ foo, bar }))
 
-    store.subscribe(function kindaComponentDidUpdate() {
-      const state = store.getState()
-      if (state.bar === 0) {
+    store.subscribe(function kindaComponentDidUpdate(currentState) {
+      if (currentState.bar === 0) {
         store.dispatch({ type: 'bar' })
       }
     })

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -153,8 +153,8 @@ const state: State = store.getState()
 
 /* subscribe / unsubscribe */
 
-const unsubscribe: Unsubscribe = store.subscribe(() => {
-  console.log('Current state:', store.getState())
+const unsubscribe: Unsubscribe = store.subscribe((currentState: State) => {
+  console.log('Current state:', currentState)
 })
 
 unsubscribe()


### PR DESCRIPTION
We can get current state from listener function:

```js
//log.js
function log(currentState){
  console.log(currentState);
}
export default log

//index.js
import log from 'log';

store.subscribe(log);
```

And we don't need import `store` in `log.js` file