### PR TITLE
updated compose types to use tuple types

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,7 +1,4 @@
-type Func0<R> = () => R
-type Func1<T1, R> = (a1: T1) => R
-type Func2<T1, T2, R> = (a1: T1, a2: T2) => R
-type Func3<T1, T2, T3, R> = (a1: T1, a2: T2, a3: T3, ...args: any[]) => R
+type Func<T extends any[], R> = (...a: T) => R
 
 /**
  * Composes single-argument functions from right to left. The rightmost
@@ -18,71 +15,26 @@ export default function compose(): <R>(a: R) => R
 export default function compose<F extends Function>(f: F): F
 
 /* two functions */
-export default function compose<A, R>(f1: (b: A) => R, f2: Func0<A>): Func0<R>
-export default function compose<A, T1, R>(
-  f1: (b: A) => R,
-  f2: Func1<T1, A>
-): Func1<T1, R>
-export default function compose<A, T1, T2, R>(
-  f1: (b: A) => R,
-  f2: Func2<T1, T2, A>
-): Func2<T1, T2, R>
-export default function compose<A, T1, T2, T3, R>(
-  f1: (b: A) => R,
-  f2: Func3<T1, T2, T3, A>
-): Func3<T1, T2, T3, R>
+export default function compose<A, T extends any[], R>(f1: (a: A) => R, f2: Func<T, A>): Func<T, R>
 
 /* three functions */
-export default function compose<A, B, R>(
+export default function compose<A, B, T extends any[], R>(
   f1: (b: B) => R,
   f2: (a: A) => B,
-  f3: Func0<A>
-): Func0<R>
-export default function compose<A, B, T1, R>(
-  f1: (b: B) => R,
-  f2: (a: A) => B,
-  f3: Func1<T1, A>
-): Func1<T1, R>
-export default function compose<A, B, T1, T2, R>(
-  f1: (b: B) => R,
-  f2: (a: A) => B,
-  f3: Func2<T1, T2, A>
-): Func2<T1, T2, R>
-export default function compose<A, B, T1, T2, T3, R>(
-  f1: (b: B) => R,
-  f2: (a: A) => B,
-  f3: Func3<T1, T2, T3, A>
-): Func3<T1, T2, T3, R>
+  f3: Func<T, A>
+): Func<T, R>
 
 /* four functions */
-export default function compose<A, B, C, R>(
-  f1: (b: C) => R,
-  f2: (a: B) => C,
+export default function compose<A, B, C, T extends any[], R>(
+  f1: (c: C) => R,
+  f2: (b: B) => C,
   f3: (a: A) => B,
-  f4: Func0<A>
-): Func0<R>
-export default function compose<A, B, C, T1, R>(
-  f1: (b: C) => R,
-  f2: (a: B) => C,
-  f3: (a: A) => B,
-  f4: Func1<T1, A>
-): Func1<T1, R>
-export default function compose<A, B, C, T1, T2, R>(
-  f1: (b: C) => R,
-  f2: (a: B) => C,
-  f3: (a: A) => B,
-  f4: Func2<T1, T2, A>
-): Func2<T1, T2, R>
-export default function compose<A, B, C, T1, T2, T3, R>(
-  f1: (b: C) => R,
-  f2: (a: B) => C,
-  f3: (a: A) => B,
-  f4: Func3<T1, T2, T3, A>
-): Func3<T1, T2, T3, R>
+  f4: Func<T, A>
+): Func<T, R>
 
 /* rest */
 export default function compose<R>(
-  f1: (b: any) => R,
+  f1: (a: any) => R,
   ...funcs: Function[]
 ): (...args: any[]) => R
 


### PR DESCRIPTION
This makes the function signature a bit easier to read and will handle more arguments beyond 4 for the last function.

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html for more info on tuple types usage with spread in typescript.