### PR TITLE
Remove superfluous "automatically" from style guide

### DIFF
--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -363,7 +363,7 @@ Many libraries in the Redux ecosystem have adopted the FSA convention, and Redux
 
 However, using action creators provides consistency, especially in cases where some kind of preparation or additional logic is needed to fill in the contents of the action (such as generating a unique ID).
 
-**Prefer using action creators for dispatching any actions**. However, rather than writing action creators by hand, **we recommend using the `createSlice` function from Redux Toolkit, which will automatically generate action creators and action types automatically**.
+**Prefer using action creators for dispatching any actions**. However, rather than writing action creators by hand, **we recommend using the `createSlice` function from Redux Toolkit, which will generate action creators and action types automatically**.
 
 ### Use Thunks for Async Logic
 


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:  Style Guide
- **Page**:  Style Guide

## What is the problem?
The word "automatically" is used twice in a sentence.

## What changes does this PR make to fix the problem?
Removes one of the "automatically"s.