### PR TITLE
Dropping symbol-observable dependency, realizing internal implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7102,11 +7102,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "examples:test": "cross-env CI=true babel-node examples/testAll.js"
   },
   "dependencies": {
-    "loose-envify": "^1.4.0",
-    "symbol-observable": "^1.2.0"
+    "loose-envify": "^1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -88,9 +88,10 @@ export default function createStore<
       throw new Error('Expected the enhancer to be a function.')
     }
 
-    return enhancer(createStore)(reducer, preloadedState as PreloadedState<
-      S
-    >) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+    return enhancer(createStore)(
+      reducer,
+      preloadedState as PreloadedState<S>
+    ) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
   }
 
   if (typeof reducer !== 'function') {

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -1,4 +1,4 @@
-import $$observable from 'symbol-observable'
+import $$observable from './utils/symbol-observable'
 
 import {
   Store,

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -88,10 +88,9 @@ export default function createStore<
       throw new Error('Expected the enhancer to be a function.')
     }
 
-    return enhancer(createStore)(
-      reducer,
-      preloadedState as PreloadedState<S>
-    ) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+    return enhancer(createStore)(reducer, preloadedState as PreloadedState<
+      S
+    >) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
   }
 
   if (typeof reducer !== 'function') {

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,4 +1,3 @@
-/// <reference types="symbol-observable" />
 import { Action, AnyAction } from './actions'
 import { Reducer } from './reducers'
 

--- a/src/utils/symbol-observable.ts
+++ b/src/utils/symbol-observable.ts
@@ -1,1 +1,2 @@
-export default (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();
+export default (() =>
+  (typeof Symbol === 'function' && Symbol.observable) || '@@observable')()

--- a/src/utils/symbol-observable.ts
+++ b/src/utils/symbol-observable.ts
@@ -1,0 +1,1 @@
+export default (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -18,12 +18,15 @@ import {
 import * as reducers from './helpers/reducers'
 import { from, ObservableInput } from 'rxjs'
 import { map } from 'rxjs/operators'
-import $$observable from 'symbol-observable'
+import $$observable from '../src/utils/symbol-observable';
 
 describe('createStore', () => {
   it('exposes the public API', () => {
     const store = createStore(combineReducers(reducers))
-    const methods = Object.keys(store)
+
+    // Since switching to internal Symbol.observable impl, it will show up as a key in node env
+    // So we filter it out
+    const methods = Object.keys(store).filter(key => key !== $$observable);
 
     expect(methods.length).toBe(4)
     expect(methods).toContain('subscribe')

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -741,10 +741,7 @@ describe('createStore', () => {
       sub.unsubscribe()
       store.dispatch({ type: 'bar' })
 
-      expect(results).toEqual([
-        { foo: 0, bar: 0 },
-        { foo: 1, bar: 0 }
-      ])
+      expect(results).toEqual([{ foo: 0, bar: 0 }, { foo: 1, bar: 0 }])
     })
 
     it('should pass an integration test with a common library (RxJS)', () => {

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -18,7 +18,7 @@ import {
 import * as reducers from './helpers/reducers'
 import { from, ObservableInput } from 'rxjs'
 import { map } from 'rxjs/operators'
-import $$observable from '../src/utils/symbol-observable';
+import $$observable from '../src/utils/symbol-observable'
 
 describe('createStore', () => {
   it('exposes the public API', () => {
@@ -26,7 +26,7 @@ describe('createStore', () => {
 
     // Since switching to internal Symbol.observable impl, it will show up as a key in node env
     // So we filter it out
-    const methods = Object.keys(store).filter(key => key !== $$observable);
+    const methods = Object.keys(store).filter(key => key !== $$observable)
 
     expect(methods.length).toBe(4)
     expect(methods).toContain('subscribe')
@@ -741,7 +741,10 @@ describe('createStore', () => {
       sub.unsubscribe()
       store.dispatch({ type: 'bar' })
 
-      expect(results).toEqual([{ foo: 0, bar: 0 }, { foo: 1, bar: 0 }])
+      expect(results).toEqual([
+        { foo: 0, bar: 0 },
+        { foo: 1, bar: 0 }
+      ])
     })
 
     it('should pass an integration test with a common library (RxJS)', () => {


### PR DESCRIPTION
Partialy fixes #3567 
Removed `symbol-observable` from `package.json` and added a polifyll to `/src/utils/symbol-observable`, similar to RxJs implementation.


_Sorry for the mess, I do not know what is wrong with my pc and why it keeps messing up the formatting._