### PR TITLE
Docs: remove bad import

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -190,11 +190,7 @@ Type checked system reducer:
 ```ts
 // src/store/system/reducers.ts
 
-import {
-  SystemState,
-  SystemActionTypes,
-  UPDATE_SESSION
-} from './types'
+import { SystemState, SystemActionTypes, UPDATE_SESSION } from './types'
 
 const initialState: SystemState = {
   loggedIn: false,

--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -191,7 +191,6 @@ Type checked system reducer:
 // src/store/system/reducers.ts
 
 import {
-  SystemActions,
   SystemState,
   SystemActionTypes,
   UPDATE_SESSION

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -184,7 +184,7 @@ function mhelmersonExample() {
         ...store,
         replaceReducer<NS, NA extends Action = AnyAction>(
           nextReducer: (
-            state: NS & ExtraState | undefined,
+            state: (NS & ExtraState) | undefined,
             action: NA
           ) => NS & ExtraState
         ) {
@@ -234,7 +234,7 @@ function finalHelmersonExample() {
     config: any,
     reducer: Reducer<S, A>
   ) {
-    return (state: S & ExtraState | undefined, action: AnyAction) => {
+    return (state: (S & ExtraState) | undefined, action: AnyAction) => {
       const newState = reducer(state, (action as unknown) as A)
       return {
         ...newState,


### PR DESCRIPTION
## Checklist
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?
https://redux.js.org/recipes/usage-with-typescript#type-checking-reducer

## What is the problem?
`SystemActions` import is not required, nor is it in `types.ts`.
## What changes does this PR make to fix the problem?
Remove `SystemActions` from `import`