### PR TITLE
Add PURE annotations

### DIFF
--- a/src/utils/actionTypes.ts
+++ b/src/utils/actionTypes.ts
@@ -13,8 +13,8 @@ const randomString = () =>
     .join('.')
 
 const ActionTypes = {
-  INIT: `@@redux/INIT${randomString()}`,
-  REPLACE: `@@redux/REPLACE${randomString()}`,
+  INIT: `@@redux/INIT${/* #__PURE__ */ randomString()}`,
+  REPLACE: `@@redux/REPLACE${/* #__PURE__ */ randomString()}`,
   PROBE_UNKNOWN_ACTION: () => `@@redux/PROBE_UNKNOWN_ACTION${randomString()}`
 }
 

--- a/src/utils/symbol-observable.ts
+++ b/src/utils/symbol-observable.ts
@@ -1,2 +1,5 @@
-export default (() =>
-  (typeof Symbol === 'function' && Symbol.observable) || '@@observable')()
+const $$observable = /* #__PURE__ */ (() =>
+  (typeof Symbol === 'function' && (Symbol as any).observable) ||
+  '@@observable')()
+
+export default $$observable


### PR DESCRIPTION
Similar to what got added to react-redux - it lets minifiers to remove those 3 small calls when `redux` stays unused in the bundle.
