### PR TITLE
Fix "ReducerFromReducersMapObject" typing

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -6,7 +6,8 @@ import {
   StoreEnhancer,
   Dispatch,
   Observer,
-  ExtendState
+  ExtendState,
+  UnpackedState
 } from './types/store'
 import { Action } from './types/actions'
 import { Reducer } from './types/reducers'
@@ -41,32 +42,32 @@ import isPlainObject from './utils/isPlainObject'
 export default function createStore<
   S,
   A extends Action,
-  Ext = {},
+  StoreExt = {},
   StateExt = never
 >(
   reducer: Reducer<S, A>,
-  enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+): Store<ExtendState<UnpackedState<S>, StateExt>, A, StateExt, StoreExt> & StoreExt
 export default function createStore<
   S,
   A extends Action,
-  Ext = {},
+  StoreExt = {},
   StateExt = never
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
-  enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+): Store<ExtendState<UnpackedState<S>, StateExt>, A, StateExt, StoreExt> & StoreExt
 export default function createStore<
   S,
   A extends Action,
-  Ext = {},
+  StoreExt = {},
   StateExt = never
 >(
   reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
-  enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext {
+  preloadedState?: PreloadedState<S> | StoreEnhancer<StoreExt, StateExt>,
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+): Store<ExtendState<UnpackedState<S>, StateExt>, A, StateExt, StoreExt> & StoreExt {
   if (
     (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
     (typeof enhancer === 'function' && typeof arguments[3] === 'function')
@@ -79,7 +80,7 @@ export default function createStore<
   }
 
   if (typeof preloadedState === 'function' && typeof enhancer === 'undefined') {
-    enhancer = preloadedState as StoreEnhancer<Ext, StateExt>
+    enhancer = preloadedState as StoreEnhancer<StoreExt, StateExt>
     preloadedState = undefined
   }
 
@@ -90,7 +91,7 @@ export default function createStore<
 
     return enhancer(createStore)(reducer, preloadedState as PreloadedState<
       S
-    >) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+    >) as Store<ExtendState<UnpackedState<S>, StateExt>, A, StateExt, StoreExt> & StoreExt
   }
 
   if (typeof reducer !== 'function') {
@@ -268,7 +269,7 @@ export default function createStore<
    */
   function replaceReducer<NewState, NewActions extends A>(
     nextReducer: Reducer<NewState, NewActions>
-  ): Store<ExtendState<NewState, StateExt>, NewActions, StateExt, Ext> & Ext {
+  ): Store<ExtendState<NewState, StateExt>, NewActions, StateExt, StoreExt> & StoreExt {
     if (typeof nextReducer !== 'function') {
       throw new Error('Expected the nextReducer to be a function.')
     }
@@ -289,9 +290,9 @@ export default function createStore<
       ExtendState<NewState, StateExt>,
       NewActions,
       StateExt,
-      Ext
+      StoreExt
     > &
-      Ext
+      StoreExt
   }
 
   /**
@@ -345,6 +346,12 @@ export default function createStore<
     getState,
     replaceReducer,
     [$$observable]: observable
-  } as unknown) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+  } as unknown) as Store<
+    ExtendState<UnpackedState<S>, StateExt>,
+    A,
+    StateExt,
+    StoreExt
+  > &
+    StoreExt
   return store
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import __DO_NOT_USE__ActionTypes from './utils/actionTypes'
 // store
 export {
   CombinedState,
+  UnpackedState,
   PreloadedState,
   Dispatch,
   Unsubscribe,

--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -36,7 +36,7 @@ export type Reducer<S = any, A extends Action = AnyAction> = (
  *
  * @template A The type of actions the reducers can potentially respond to.
  */
-export type ReducersMapObject<S = any, A extends Action = Action> = {
+export type ReducersMapObject<S = any, A extends Action = AnyAction> = {
   [K in keyof S]: Reducer<S[K], A>
 }
 
@@ -53,19 +53,6 @@ export type StateFromReducersMapObject<M> = M extends ReducersMapObject<
   : never
 
 /**
- * Infer reducer union type from a `ReducersMapObject`.
- *
- * @template M Object map of reducers as provided to `combineReducers(map: M)`.
- */
-export type ReducerFromReducersMapObject<M> = M extends {
-  [P in keyof M]: infer R
-}
-  ? R extends Reducer<any, any>
-    ? R
-    : never
-  : never
-
-/**
  * Infer action type from a reducer function.
  *
  * @template R Type of reducer.
@@ -77,9 +64,18 @@ export type ActionFromReducer<R> = R extends Reducer<any, infer A> ? A : never
  *
  * @template M Object map of reducers as provided to `combineReducers(map: M)`.
  */
-export type ActionFromReducersMapObject<M> = M extends ReducersMapObject<
+export type ActionFromReducersMapObject<M> = {
+  [P in keyof M]: ActionFromReducer<M[P]>
+}[keyof M]
+
+/**
+ * Infer reducer union type from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+export type ReducerFromReducersMapObject<M> = M extends ReducersMapObject<
   any,
   any
 >
-  ? ActionFromReducer<ReducerFromReducersMapObject<M>>
+  ? Reducer<StateFromReducersMapObject<M>, ActionFromReducersMapObject<M>>
   : never

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -39,18 +39,25 @@ declare const $CombinedState: unique symbol
 export type CombinedState<S> = { readonly [$CombinedState]?: undefined } & S
 
 /**
+ * Unpack the `CombinedState<S>` to `S` for conciseness and readability.
+ */
+export type UnpackedState<S> = S extends CombinedState<infer S1>
+  ? S1 extends object
+    ? {
+        [K in keyof S1]: UnpackedState<S1[K]>
+      }
+    : S1
+  : S
+
+/**
  * Recursively makes combined state objects partial. Only combined state _root
  * objects_ (i.e. the generated higher level object with keys mapping to
  * individual reducers) are partial.
  */
-export type PreloadedState<S> = Required<S> extends {
-  [$CombinedState]: undefined
-}
-  ? S extends CombinedState<infer S1>
-    ? {
-        [K in keyof S1]?: S1[K] extends object ? PreloadedState<S1[K]> : S1[K]
-      }
-    : never
+export type PreloadedState<S> = S extends CombinedState<infer S1>
+  ? {
+      [K in keyof S1]?: S1[K] extends object ? PreloadedState<S1[K]> : S1[K]
+    }
   : {
       [K in keyof S]: S[K] extends object ? PreloadedState<S[K]> : S[K]
     }

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -516,6 +516,7 @@ describe('createStore', () => {
 
   it('throws if action type is missing', () => {
     const store = createStore(reducers.todos)
+    // @ts-ignore
     expect(() => store.dispatch({})).toThrow(
       /Actions may not have an undefined "type" property/
     )

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -1,4 +1,12 @@
-import { Reducer, Action, combineReducers, ReducersMapObject } from '../..'
+import {
+  Reducer,
+  Action,
+  combineReducers,
+  ReducersMapObject,
+  StateFromReducersMapObject,
+  ActionFromReducersMapObject,
+  ReducerFromReducersMapObject
+} from '../..'
 
 /**
  * Simple reducer definition with no action shape checks.
@@ -233,4 +241,30 @@ function reducersMapObject() {
     // typings:expect-error
     obj[key](undefined, 'not-an-action')
   }
+}
+
+function fromReducersMapObject() {
+  type TodoReducer = Reducer<
+    string[],
+    { type: 0; id: number } | { type: 1; text: string }
+  >
+  type FilterReducer = Reducer<number, { type: 2; filter: number }>
+  type MapObject = { todo: TodoReducer; filter: FilterReducer }
+
+  function stateTest(_state: { todo: string[]; filter: number }) {}
+  let state!: StateFromReducersMapObject<MapObject>
+  stateTest(state)
+
+  function actionTest(
+    _action:
+      | { type: 0; id: number }
+      | { type: 1; text: string }
+      | { type: 2; filter: number }
+  ) {}
+  let action!: ActionFromReducersMapObject<MapObject>
+  actionTest(action)
+
+  function reducersTest(_reducer: Reducer<typeof state, typeof action>) {}
+  let reducer!: ReducerFromReducersMapObject<MapObject>
+  reducersTest(reducer)
 }


### PR DESCRIPTION
```ts
import { Reducer, ReducerFromReducersMapObject } from './reducers'

type TodoReducer = Reducer<
  string[],
  { type: 0; id: number } | { type: 1; text: string }
>
type FilterReducer = Reducer<number, { type: 2; filter: number }>
type MapObject = { todo: TodoReducer; filter: FilterReducer }
type State = {
  todo: string[]
  filter: number
}
type Action =
  | { type: 0; id: number }
  | { type: 1; text: string }
  | { type: 2; filter: number }

function reducersTest(_reducer: Reducer<State, Action>) {}
let reducer!: ReducerFromReducersMapObject<MapObject>
// Error: Argument of type 'Reducer<string[], { type: 0; id: number; } | { type: 1; text: string; }> | Reducer<number, { type: 2; filter: number; }>'
// is not assignable to parameter of type 'Reducer<State, Action>'
reducersTest(reducer)
```

Please code review and merge PR.