### PR TITLE
Add Netlify Badge to Docs

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -69,6 +69,12 @@ class Footer extends React.Component {
             >
               Star
             </a>
+            <a href="https://www.netlify.com">
+              <img
+                src="https://www.netlify.com/img/global/badges/netlify-light.svg"
+                alt="Deploys by Netlify"
+              />
+            </a>
           </div>
         </section>
         <section className="copyright">


### PR DESCRIPTION
Netlify has updated their OSS plan to require attribution: https://www.netlify.com/legal/open-source-policy/