### PR TITLE
Fix API reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Redux co-maintainer [Mark Erikson](https://twitter.com/acemarke) has put togethe
 - [FAQ](http://redux.js.org/faq)
 - [Troubleshooting](http://redux.js.org/troubleshooting)
 - [Glossary](http://redux.js.org/glossary)
-- [API Reference](http://redux.js.org/api)
+- [API Reference](https://redux.js.org/api/api-reference)
 
 For PDF, ePub, and MOBI exports for offline reading, and instructions on how to create them, please see: [paulkogel/redux-offline-docs](https://github.com/paulkogel/redux-offline-docs).
 


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

^^ This content was auto populated.

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

README

## What is the problem?

The current API reference link doesn't work.

## What changes does this PR make to fix the problem?

Updates the link to one that works, but I don't know if the old is supposed to and something else is wrong (not doing a redirect or loading an index it should be).