### PR TITLE
Fixed broken links in the docs and in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,11 +70,11 @@ npm run test:watch
 
 ### Docs
 
-Improvements to the documentation are always welcome. You can find them in the [`docs`](/docs) path. We use [Docusaurus](https://docusaurus.io/) to build our documentation website. The website is published automatically whenever the `master` branch is updated.
+Improvements to the documentation are always welcome. You can find them in the [`docs`](/website/docs) path. We use [Docusaurus](https://docusaurus.io/) to build our documentation website. The website is published automatically whenever the `master` branch is updated.
 
 ### Examples
 
-Redux comes with [official examples](http://redux.js.org/docs/introduction/Examples.html) to demonstrate various concepts and best practices.
+Redux comes with [official examples](https://redux.js.org/introduction/examples) to demonstrate various concepts and best practices.
 
 When adding a new example, please adhere to the style and format of the existing examples, and try to reuse as much code as possible. For example, `index.html`, `server.js`, and `webpack.config.js` can typically be reused.
 
@@ -88,7 +88,7 @@ npm run examples:test
 
 Not all examples have tests. If you see an example project without tests, you are very welcome to add them in a way consistent with the examples that have tests.
 
-Please visit the [Examples page](http://redux.js.org/docs/introduction/Examples.html) for information on running individual examples.
+Please visit the [Examples page](https://redux.js.org/introduction/examples) for information on running individual examples.
 
 ### Sending a Pull Request
 

--- a/website/docs/recipes/structuring-reducers/RefactoringReducersExample.md
+++ b/website/docs/recipes/structuring-reducers/RefactoringReducersExample.md
@@ -263,7 +263,7 @@ Notice that because the two "slice of state" reducers are now getting only their
 
 #### Reducing Boilerplate
 
-We're almost done. Since many people don't like switch statements, it's very common to use a function that creates a lookup table of action types to case functions. We'll use the `createReducer` function described in [Reducing Boilerplate](../recipes/reducing-boilerplate):
+We're almost done. Since many people don't like switch statements, it's very common to use a function that creates a lookup table of action types to case functions. We'll use the `createReducer` function described in [Reducing Boilerplate](../reducing-boilerplate):
 
 ```js
 // Omitted


### PR DESCRIPTION
Fixed Reducing Boilerplate link in Recipes > Structuring Reducers > Refactoring Reducers Example
Fixed links to the examples page and a link to the docs in contributing.md