### PR TITLE
Fix documentation navigation items from wrapping

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -31,6 +31,10 @@ a code {
   color: inherit;
 }
 
+.navbar .navbar__items {
+  flex: 1 1 auto;
+}
+
 .footer__logo {
   width: 50px;
   height: 50px;


### PR DESCRIPTION
---
name: "\U0001F41B Bug fix or new feature"
about: Fixing a problem with Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

This PR adjusts the `navbar__items` flex declaration to prevent the items from wrapping.

`flex: 1 0 0` will create equal width items, causing the `navbar__items--right` to not have enough space. Adjusting to `flex: 1 1 auto` will allow the items to fill their available space.

**BEFORE**
![Screen Shot 2020-01-06 at 9 02 55 AM](https://user-images.githubusercontent.com/825855/71822949-2e4ecb00-3064-11ea-8334-2fb234040691.png)

**AFTER**
![Screen Shot 2020-01-06 at 9 04 38 AM](https://user-images.githubusercontent.com/825855/71822953-327ae880-3064-11ea-9955-8be028de6001.png)

### Why should this PR be included?

## Checklist

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

## New Features

### What new capabilities does this PR add?

### What docs changes are needed to explain this?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

### What is the expected behavior?

### How does this PR fix the problem?
