### PR TITLE
Fix combineReducers typings.

### DIFF
--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -130,7 +130,7 @@ export default function combineReducers<S>(
 export default function combineReducers<S, A extends Action = AnyAction>(
   reducers: ReducersMapObject<S, A>
 ): Reducer<CombinedState<S>, A>
-export default function combineReducers<M extends ReducersMapObject<any, any>>(
+export default function combineReducers<M extends ReducersMapObject>(
   reducers: M
 ): Reducer<
   CombinedState<StateFromReducersMapObject<M>>,

--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -36,7 +36,7 @@ export type Reducer<S = any, A extends Action = AnyAction> = (
  *
  * @template A The type of actions the reducers can potentially respond to.
  */
-export type ReducersMapObject<S = any, A extends Action = Action> = {
+export type ReducersMapObject<S = any, A extends Action = AnyAction> = {
   [K in keyof S]: Reducer<S[K], A>
 }
 

--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -45,10 +45,7 @@ export type ReducersMapObject<S = any, A extends Action = AnyAction> = {
  *
  * @template M Object map of reducers as provided to `combineReducers(map: M)`.
  */
-export type StateFromReducersMapObject<M> = M extends ReducersMapObject<
-  any,
-  any
->
+export type StateFromReducersMapObject<M> = M extends ReducersMapObject
   ? { [P in keyof M]: M[P] extends Reducer<infer S, any> ? S : never }
   : never
 


### PR DESCRIPTION
<!--
name: "Bug fix or new feature"
about: Fixing a problem with Redux
-->

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

Fixes a bug.

### Why should this PR be included?

It fixes a typing issue I and some other folks have with the `combineReducers` function: https://github.com/reduxjs/redux/issues/2709

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/2709 (it is closed, but many people are still affected)
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

Unfortunately, I failed to create a simple reproduction example. Still, it happens that TypeScript would fail to infer the proper generic type to `combineReducers` function. In my case, I'm doing something like this:

```ts
interface FooState {…}
interface AppAction extends Redux.Action<string> {}
interface FooAction0 extends AppAction {…}
interface FooAction1 extends AppAction {…}
type FooActions = FooAction0 | FooAction1;

function fooReducer(state: FooState, action: FooActions): FooState {
  return state;
}

// Type error:
// Argument of type 'Reducer<CombinedState<{ fooReducer: FooState; }>, FooActions>' is not assignable to parameter of type 'Reducer<CombinedState<{ fooReducer: FooState; }>, AnyAction>'.
combineReducers({ fooReducer: fooReducer });

// works
combineReducers<{fooReducer: FooState}>({ fooReducer: fooReducer });
```

### What is the expected behavior?

I would expect TypeScript to infer a generic type automatically.

### How does this PR fix the problem?

It removes explicit `any`s which appears to help TypeScript to infer a type. I'm not sure why though :man_shrugging: . Could this be a bug in TypeScript?

More specifically, the first generic type of `ReducersMapObject` is a state which is already `any` by default, and the second generic type is `A extends Action` which is `Action` by default and not `any`. So the fact that the second generic type is `any` confuses TS for some reason.