### PR TITLE
Docs CSS fix: show pointer only on clickable part of details

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -78,6 +78,9 @@ a code {
   margin: 1rem 0;
   padding: 1rem;
   border-radius: var(--ifm-global-radius);
+}
+
+.style-guide details summary {
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Checklist

- [ ] Is there an existing issue for this PR?
  - no need; it’s a tiny change
- [ ] Have the files been linted and formatted?
  - N/A – I see no lint rules for docs CSS

## What docs page needs to be fixed?

- **Section**: Style Guide
- **Page**: Style Guide

## What is the problem?

The cursor turns to `pointer` when hovering over non-clickable parts of `details` elements.

## What changes does this PR make to fix the problem?

In the CSS, make the cursor turn to `pointer` only when hovering over the `summary` element, which is the clickable part.