### PR TITLE
Docs update: recommend `unknown` instead of `null` as ThunkAction extraArgument type

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -319,7 +319,7 @@ import { ThunkAction } from 'redux-thunk'
 
 export const thunkSendMessage = (
   message: string
-): ThunkAction<void, RootState, null, Action<string>> => async dispatch => {
+): ThunkAction<void, RootState, unknown, Action<string>> => async dispatch => {
   const asyncResp = await exampleAPI()
   dispatch(
     sendMessage({
@@ -341,7 +341,7 @@ To reduce repetition, you might want to define a reusable `AppThunk` type once, 
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
   RootState,
-  null,
+  unknown,
   Action<string>
 >
 ```


### PR DESCRIPTION
Currently, the docs suggest `null` as type for the `extraArgument` generic argument of `ThunkAction`.
This only works if the `ThunkMiddleware` is invoked with `null` as `extraArgument` as well. The default value for `ThunkMiddleware` is `unknown` though, making these thunks incompatible with the default-typed `ThunkMiddleware`.

This change suggests to use `unknown` instead, which would work with Middlewares typed for any type of `extraArgument`.