### PR TITLE
Use a proper copyright symbol, en-dash, and current year in the footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -101,7 +101,7 @@ module.exports = {
         href: 'https://redux.js.org/'
       },
       copyright:
-        'Copyright (c) 2015-present Dan Abramov and the Redux documentation authors.'
+        `Copyright © 2015–${new Date().getFullYear()} Dan Abramov and the Redux documentation authors.`
     },
     algolia: {
       apiKey: '518c6e3c629811d8daa1d21dc8bcfa37',


### PR DESCRIPTION
Currently:

<img width="615" alt="Screen Shot 2020-02-18 at 10 19 53 PM" src="https://user-images.githubusercontent.com/353790/74798809-d16a4580-529c-11ea-888d-ec4e006c266d.png">

With this change:

<img width="592" alt="Screen Shot 2020-02-18 at 10 15 37 PM" src="https://user-images.githubusercontent.com/353790/74798785-bbf51b80-529c-11ea-9eaf-3ffb97fd8a9c.png">

(The "end-year" is dynamic, using the same code that Docusaurus uses on their own site.)
