### PR TITLE
Remove redundant save options for npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Even if you haven't used Flux or Elm, Redux only takes a few minutes to get star
 To install the stable version:
 
 ```sh
-npm install --save redux
+npm install redux
 ```
 
 This assumes you are using [npm](https://www.npmjs.com/) as your package manager.
@@ -111,7 +111,7 @@ The Redux source code is written in ES2015 but we precompile both CommonJS and U
 Most likely, you'll also need [the React bindings](https://github.com/reduxjs/react-redux) and [the developer tools](https://github.com/reduxjs/redux-devtools).
 
 ```sh
-npm install --save react-redux
+npm install react-redux
 npm install --save-dev redux-devtools
 ```
 

--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -12,7 +12,7 @@ So you want to do routing with your Redux app. You can use it with [React Router
 
 `react-router-dom` is available on npm . This guides assumes you are using `react-router-dom@^4.1.1`.
 
-`npm install --save react-router-dom`
+`npm install react-router-dom`
 
 ## Configuring the Fallback URL
 

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -19,7 +19,7 @@ We will use React to build our simple todo app, and cover the basics of how to u
 [React bindings](https://github.com/reduxjs/react-redux) are not included in Redux by default. You need to install them explicitly:
 
 ```sh
-npm install --save react-redux
+npm install react-redux
 ```
 
 If you don't use npm, you may grab the latest UMD build from unpkg (either a [development](https://unpkg.com/react-redux@latest/dist/react-redux.js) or a [production](https://unpkg.com/react-redux@latest/dist/react-redux.min.js) build). The UMD build exports a global called `window.ReactRedux` if you add it to your page via a `<script>` tag.

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -18,7 +18,7 @@ Redux is available as a package on NPM for use with a module bundler or in a Nod
 
 ```bash
 # NPM
-npm install --save redux
+npm install redux
 
 # Yarn
 yarn add redux

--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -49,7 +49,7 @@ We will add two middlewares and one enhancer:
 #### Install `redux-thunk`
 
 ```sh
-npm install --save redux-thunk
+npm install redux-thunk
 ```
 
 #### middleware/logger.js

--- a/docs/recipes/ImplementingUndoHistory.md
+++ b/docs/recipes/ImplementingUndoHistory.md
@@ -382,7 +382,7 @@ In this part of the recipe, you will learn how to make the [Todo List example](.
 First of all, you need to run
 
 ```sh
-npm install --save redux-undo
+npm install redux-undo
 ```
 
 This installs the package that provides the `undoable` reducer enhancer.

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -33,7 +33,7 @@ In the following recipe, we are going to look at how to set up server-side rende
 For this example, we'll be using [Express](http://expressjs.com/) as a simple web server. We also need to install the React bindings for Redux, since they are not included in Redux by default.
 
 ```sh
-npm install --save express react-redux
+npm install express react-redux
 ```
 
 ## The Server Side

--- a/docs/redux-toolkit/overview.md
+++ b/docs/redux-toolkit/overview.md
@@ -16,7 +16,7 @@ Redux Toolkit is available as a package on NPM for use with a module bundler or 
 
 ```bash
 # NPM
-npm install --save @reduxjs/toolkit
+npm install @reduxjs/toolkit
 
 # Yarn
 yarn add @reduxjs/toolkit


### PR DESCRIPTION
---
name: "Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/pull/3357
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

Multiple sections and pages which have `npm install --save`

- **Section**:
- **Page**:

## What is the problem?

Follow up to https://github.com/reduxjs/redux/pull/3357 
--save is not required for `npm install`

## What changes does this PR make to fix the problem?

Brings more consistency.