### PR TITLE
Remove return type from TS docs

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -93,10 +93,10 @@ With these types declared we can now also type check chat's action creators. In 
 ```ts
 // src/store/chat/actions.ts
 
-import { Message, SEND_MESSAGE, DELETE_MESSAGE, ChatActionTypes } from './types'
+import { Message, SEND_MESSAGE, DELETE_MESSAGE } from './types'
 
 // TypeScript infers that this function is returning SendMessageAction
-export function sendMessage(newMessage: Message): ChatActionTypes {
+export function sendMessage(newMessage: Message) {
   return {
     type: SEND_MESSAGE,
     payload: newMessage
@@ -104,7 +104,7 @@ export function sendMessage(newMessage: Message): ChatActionTypes {
 }
 
 // TypeScript infers that this function is returning DeleteMessageAction
-export function deleteMessage(timestamp: number): ChatActionTypes {
+export function deleteMessage(timestamp: number) {
   return {
     type: DELETE_MESSAGE,
     meta: {

--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -133,9 +133,9 @@ With these types we can now also type check system's action creators:
 ```ts
 // src/store/system/actions.ts
 
-import { SystemState, UPDATE_SESSION, SystemActionTypes } from './types'
+import { SystemState, UPDATE_SESSION } from './types'
 
-export function updateSession(newSession: SystemState): SystemActionTypes {
+export function updateSession(newSession: SystemState) {
   return {
     type: UPDATE_SESSION,
     payload: newSession


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: usage-with-typescript
- **Page**: type-checking-actions--action-creators

## What is the problem?
The documentation mention taking advantage of TS type inference for the returns of the actions, but we are still typing the return on this code block

## What changes does this PR make to fix the problem?
Remove the types from the function return to simplify. I just did a fresh project doing the exact same and it works alright