### PR TITLE
Declared variable rootReducer

### DIFF
--- a/examples/todos/src/reducers/index.js
+++ b/examples/todos/src/reducers/index.js
@@ -2,7 +2,9 @@ import { combineReducers } from 'redux'
 import todos from './todos'
 import visibilityFilter from './visibilityFilter'
 
-export default combineReducers({
+let rootReducer;
+export default rootReducer = combineReducers({
   todos,
   visibilityFilter
 })
+

--- a/examples/todos/src/reducers/index.js
+++ b/examples/todos/src/reducers/index.js
@@ -2,9 +2,8 @@ import { combineReducers } from 'redux'
 import todos from './todos'
 import visibilityFilter from './visibilityFilter'
 
-let rootReducer;
-export default rootReducer = combineReducers({
+let rootReducer = combineReducers({
   todos,
   visibilityFilter
-})
-
+});
+export default rootReducer


### PR DESCRIPTION
declared var `rootReducer` then assigned to function combineReducers.

---
name: "\U0001F41B Bug fix or new feature"
about: Fixing a problem with Redux tutorial example: Todos
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

### Why should this PR be included?

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
  - Separate pr for doc update [here](https://github.com/reduxjs/redux/pull/3738)
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

## New Features

### What new capabilities does this PR add?

### What docs changes are needed to explain this?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
While following the tutorial [here](https://redux.js.org/basics/example) on creating a basic todos app, at the [entry point](https://redux.js.org/basics/example#indexjs), a module `rootReducer` is imported but never declared

```js
// index.js

import React from 'react'
import { render } from 'react-dom'
import { Provider } from 'react-redux'
import { createStore } from 'redux'
import rootReducer from './reducers'
import App from './components/App'

const store = createStore(rootReducer)

render(
  <Provider store={store}>
    <App />
  </Provider>,
  document.getElementById('root')
)
```
```js
// ./reducers/index.js

import { combineReducers } from 'redux'
import todos from './todos'
import visibilityFilter from './visibilityFilter'

export default combineReducers({
  todos,
  visibilityFilter
})
```
### What is the expected behavior?
The `rootReducer` function needs to be declared, then assigned and finally exported

```js
import { combineReducers } from 'redux'
import todos from './todos'
import visibilityFilter from './visibilityFilter'

let rootReducer = combineReducers({
  todos,
  visibilityFilter
});
export default rootReducer
```
### How does this PR fix the problem?
It declares the `rootReducer`, assigns it to the function `combineReducers` then exports it