### PR TITLE
Update ExampleTodoList.md

### DIFF
--- a/docs/basics/ExampleTodoList.md
+++ b/docs/basics/ExampleTodoList.md
@@ -111,7 +111,8 @@ import { combineReducers } from 'redux'
 import todos from './todos'
 import visibilityFilter from './visibilityFilter'
 
-export default combineReducers({
+let rootReducer;
+export default rootReducer = combineReducers({
   todos,
   visibilityFilter
 })

--- a/docs/basics/ExampleTodoList.md
+++ b/docs/basics/ExampleTodoList.md
@@ -111,11 +111,11 @@ import { combineReducers } from 'redux'
 import todos from './todos'
 import visibilityFilter from './visibilityFilter'
 
-let rootReducer;
-export default rootReducer = combineReducers({
+let rootReducer = combineReducers({
   todos,
   visibilityFilter
-})
+});
+export default rootReducer
 ```
 
 ## Presentational Components


### PR DESCRIPTION
Declared var `rootReducer` then assigned it to function `combineReducers`

---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing [Example: Todo List](https://redux.js.org/basics/example)
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: [Entry Point](https://redux.js.org/basics/example#indexjs)
- **Page**: [Example: Todo List](https://redux.js.org/basics/example)

## What is the problem?
There is a `rootReducer` that is imported but never declared
```js
// index.js
import React from 'react'
import { render } from 'react-dom'
import { Provider } from 'react-redux'
import { createStore } from 'redux'
import rootReducer from './reducers'
import App from './components/App'

const store = createStore(rootReducer)

render(
  <Provider store={store}>
    <App />
  </Provider>,
  document.getElementById('root')
)
```
```js
// reducers/index.js

import { combineReducers } from 'redux'
import todos from './todos'
import visibilityFilter from './visibilityFilter'

export default combineReducers({
  todos,
  visibilityFilter
})
```
## What changes does this PR make to fix the problem?
It declares the `rootReducer`, then assigns it and finally exports it
```js
// reducers/index.js

import { combineReducers } from 'redux'
import todos from './todos'
import visibilityFilter from './visibilityFilter'

let rootReducer = combineReducers({
  todos,
  visibilityFilter
});
export default rootReducer
```