### PR TITLE
docs(ecosystem): Add data-provider high-level abstraction

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -836,6 +836,9 @@ Takes a defined structure and uses 'behaviors' to create a set of actions, reduc
 **[Bloomca/redux-tiles](https://github.com/Bloomca/redux-tiles)** <br />
 Provides minimal abstraction on top of Redux, to allow easy composability, easy async requests, and sane testability.
 
+**[data-provider/core](https://github.com/data-provider/core)** <br />
+An async data provider over Redux. Agnostic about specific data origins, queryable, with powerful selectors inspired by Reselect, cache and memoization, it makes easy connecting views to any type of async data while retains data layer composability. Addons for different UI bindings are also distributed separately.
+
 ## Community Conventions
 
 **[Flux Standard Action](https://github.com/acdlite/flux-standard-action)** <br />


### PR DESCRIPTION
## PR Type

**This PR updates an existing page**

## Checklist

- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Introduction
- **Page**: Ecosystem

### What updates should be made to the page?

Add a new entry to the "Higher-level abstractions" chapter in order to introduce the ["data-provider" library](https://www.data-provider.org)
