### PR TITLE
Update createStore.ts

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -167,7 +167,7 @@ export default function createStore<
         'You may not call store.subscribe() while the reducer is executing. ' +
           'If you would like to be notified after the store has been updated, subscribe from a ' +
           'component and invoke store.getState() in the callback to access the latest state. ' +
-          'See https://redux.js.org/api-reference/store#subscribelistener for more details.'
+          'See https://redux.js.org/api/store#subscribelistener for more details.'
       )
     }
 


### PR DESCRIPTION
Replace broken link, "https://redux.js.org/api-reference/store#subscribelistener" link in the error message, by proper link "https://redux.js.org/api/store#subscribelistener"
Also I checked the current repo for any other such broken link but didn't find any

---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_ no such issue
- [ ] Have the files been linted and formatted?
 yes
## What docs page needs to be fixed?

- **Section**: N/A
- **Page**: N/A

## What is the problem?
    There is a broken link in the error message 
## What changes does this PR make to fix the problem?
 The PR changes the broken link in the error message to the correct one