### PR TITLE
Update ExampleRedditAPI.md

### DIFF
--- a/docs/advanced/ExampleRedditAPI.md
+++ b/docs/advanced/ExampleRedditAPI.md
@@ -245,7 +245,6 @@ class AsyncApp extends Component {
 
   handleChange(nextSubreddit) {
     this.props.dispatch(selectSubreddit(nextSubreddit))
-    this.props.dispatch(fetchPostsIfNeeded(nextSubreddit))
   }
 
   handleRefreshClick(e) {


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: containers/AsyncApp.js
- **Page**: Advanced Tutorial -> Example: Reddit API

## What is the problem?
Is there any need to  call  `this.props.dispatch(fetchPostsIfNeeded(nextSubreddit))` in `handleChange(nextSubreddit)` , since, `componentDidUpdate()` is already going to dispatch this action after **selectedSubreddit** state in store is changed ?

**Note:** I previously created similar [PR](https://github.com/reduxjs/redux/pull/3752). But, was choosing incorrect function for modification
## What changes does this PR make to fix the problem?
Removes `this.props.dispatch(fetchPostsIfNeeded(nextSubreddit))` from `handleChange(nextSubreddit)` 