### PR TITLE
docs: fix link

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -358,7 +358,7 @@ describe('components', () => {
 
 ### Connected Components
 
-If you use a library like [React Redux](https://github.com/reduxjs/react-redux), you might be using [higher-order components](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) like [`connect()`](https://react-redux.js.org/api#connect). This lets you inject Redux state into a regular React component.
+If you use a library like [React Redux](https://github.com/reduxjs/react-redux), you might be using [higher-order components](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) like [`connect()`](https://react-redux.js.org/api/connect). This lets you inject Redux state into a regular React component.
 
 Consider the following `App` component:
 


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Recipes
- **Page**: Writing Tests

## What is the problem?

It seems to link to [old documentation](https://github.com/reduxjs/react-redux/blob/eae14cc92b79dfbc4f37131d31698b3446a9857d/website/versioned_docs/version-5.x/api/api.md).

## What changes does this PR make to fix the problem?

Link to the latest documentation.
