### PR TITLE
docs: fix syntax error for createAction with TypeScript

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -366,7 +366,7 @@ export type AppDispatch = typeof store.dispatch
 `createAction` requires that the type of the payload be explicitly defined, unless there is no payload required:
 
 ```ts
-const add = createAction<number>('add')
+const add = createAction<number>(1)
 ```
 
 ### Typing `createReducer`


### PR DESCRIPTION
## What docs page needs to be fixed?

- **Section**: recipes
- **Page**: UsageWithTypescript

## What is the problem?

The example was incorrect as the type of `createAction` is `number` but the payload is of type `string`.

## What changes does this PR make to fix the problem?

Payload is changed to be a number :-)