### PR TITLE
[Docs] add dark mode variables (issue #3762)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
   organizationName: 'reduxjs',
   projectName: 'redux',
   themeConfig: {
-    disableDarkMode: true,
+    disableDarkMode: false,
     prism: {
       theme: require('./src/js/monokaiTheme.js')
     },
@@ -100,7 +100,7 @@ module.exports = {
         src: 'img/redux.svg',
         href: 'https://redux.js.org/'
       },
-      copyright:
+      copyright: 
         `Copyright © 2015–${new Date().getFullYear()} Dan Abramov and the Redux documentation authors.`
     },
     algolia: {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -15,6 +15,24 @@
   --ifm-code-padding-horizontal: 0.2rem;
 }
 
+:root[data-theme='dark'] {
+  --ifm-color-primary: #ba8fff;
+  --ifm-color-primary-dark: #7431ca;
+  --ifm-color-primary-darker: #6d1cac;
+  --ifm-color-primary-darkest: #730c9a;
+  --ifm-color-primary-light: #b97cfd;
+  --ifm-color-primary-lighter: #cc8ffc;
+  --ifm-color-primary-lightest: #fcf2ff;
+
+  --ifm-blockquote-color: #1a1d1e;
+  --ifm-blockquote-color-dark: #6d1cac;
+}
+
+:root[data-theme='dark'] .hero.hero--primary {
+  --ifm-hero-background-color: #593d88;
+  --ifm-hero-text-color: #ffffff;
+}
+
 blockquote {
   color: var(--ifm-font-base-color);
   background-color: var(--ifm-blockquote-color);
@@ -25,6 +43,10 @@ blockquote {
 code {
   background-color: var(--ifm-color-emphasis-300);
   border-radius: 0.2rem;
+}
+
+:root[data-theme='dark'] code {
+  background-color: rgb(39, 40, 34);
 }
 
 a code {
@@ -102,15 +124,15 @@ a code {
 
 .style-guide .priority-essential h3:after {
   content: ' ESSENTIAL';
-  color: #6b2a2a;
+  color: var(--ifm-color-danger);
 }
 
 .style-guide .priority-stronglyrecommended h3:after {
   content: ' STRONGLY RECOMMENDED';
-  color: #8c480a;
+  color: var(--ifm-color-warning);
 }
 
 .style-guide .priority-recommended h3:after {
   content: ' RECOMMENDED';
-  color: #2b5a99;
+  color: var(--ifm-color-info);
 }

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -32,7 +32,7 @@
 .featureImage {
   height: 100px;
   width: 100px;
-  fill: var(--ifm-font-base-color);
+  fill: var(--ifm-font-color-base);
 }
 
 .featureAnchor svg {


### PR DESCRIPTION
---
name: "Add Dark Mode"
about: Adding variables and changing Docusaurus config to enable dark mode.
---

## Checklist

- [x] Is there an existing issue for this PR?
  - #3762
- [x] Have the files been linted and formatted?

## What is the problem?
Viewing redux docs at 1am in light mode hurts my eyes.

## What changes does this PR make to fix the problem?

- Modifies the docusaurus config to enable the classic theme's built-in dark mode.
- Adds new dark-mode-specific variable overrides to the custom Docusaurus css.
- Changes the 'recommendation' colors from hard-coded hex values to some color variables provided by Docusaurus.
- Fixes a css bug with the front page to correctly style the Feature svgs with the base font color (was previously typoed to an incorrect variable name and rendered as #000).
