### PR TITLE
Tighten applyMiddleware types

### DIFF
--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -1,7 +1,7 @@
 import compose from './compose'
 import { Middleware, MiddlewareAPI } from './types/middleware'
 import { AnyAction } from './types/actions'
-import { StoreEnhancer, StoreCreator, Dispatch } from './types/store'
+import { StoreEnhancer, Dispatch, PreloadedState, StoreEnhancerStoreCreator } from './types/store'
 import { Reducer } from './types/reducers'
 
 /**
@@ -55,11 +55,11 @@ export default function applyMiddleware<Ext, S = any>(
 export default function applyMiddleware(
   ...middlewares: Middleware[]
 ): StoreEnhancer<any> {
-  return (createStore: StoreCreator) => <S, A extends AnyAction>(
+  return (createStore: StoreEnhancerStoreCreator) => <S, A extends AnyAction>(
     reducer: Reducer<S, A>,
-    ...args: any[]
+    preloadedState?: PreloadedState<S>
   ) => {
-    const store = createStore(reducer, ...args)
+    const store = createStore(reducer, preloadedState)
     let dispatch: Dispatch = () => {
       throw new Error(
         'Dispatching while constructing your middleware is not allowed. ' +

--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -1,7 +1,12 @@
 import compose from './compose'
 import { Middleware, MiddlewareAPI } from './types/middleware'
 import { AnyAction } from './types/actions'
-import { StoreEnhancer, Dispatch, PreloadedState, StoreEnhancerStoreCreator } from './types/store'
+import {
+  StoreEnhancer,
+  Dispatch,
+  PreloadedState,
+  StoreEnhancerStoreCreator
+} from './types/store'
 import { Reducer } from './types/reducers'
 
 /**


### PR DESCRIPTION
---
name: "Tighten applyMiddleware types"
about: More correctly types applyMiddleware
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Fixes types

### Why should this PR be included?
The `applyMiddleware` enhancer should not be allowed to accept any arguments, since it is only guaranteed to accept `preloadedState?` as its second argument.

Also the `createStore` parameter should not be `StoreCreator` since it doesn't allow for enhancers. It should match [the parameter type for `StoreEnhancor`](https://github.com/reduxjs/redux/blob/master/src/types/store.ts#L259-L261).

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - Simple enough that it probably doesn't need an issue.
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
It's implied that more than 2 arguments are accepted by this enhancer, when it should it only be called with 2 arguments.

### What is the expected behavior?
TypeScript should produce an error if trying to pass more than the two defined arguments.

### How does this PR fix the problem?
It tightens the arguments' types.
