### PR TITLE
Re-enable TypeScript tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4782,7 +4782,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -6370,7 +6371,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -11516,7 +11518,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -12463,6 +12466,15 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
+    },
+    "typings-tester": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/typings-tester/-/typings-tester-0.3.2.tgz",
+      "integrity": "sha512-HjGoAM2UoGhmSKKy23TYEKkxlphdJFdix5VvqWFLzH1BJVnnwG38tpC6SXPgqhfFGfHY77RlN1K8ts0dbWBQ7A==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.12.2"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-typescript2": "^0.27.0",
     "rxjs": "^6.5.5",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "typings-tester": "^0.3.2"
   },
   "npmName": "redux",
   "npmFileMap": [

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,5 +1,6 @@
 import { Action, AnyAction } from './actions'
 import { Reducer } from './reducers'
+import '../utils/symbol-observable'
 
 /**
  * Extend the state

--- a/test/typescript.spec.ts
+++ b/test/typescript.spec.ts
@@ -1,0 +1,7 @@
+import { checkDirectory } from 'typings-tester'
+
+describe('TypeScript definitions', function() {
+  it('should compile against index.d.ts', () => {
+    checkDirectory(__dirname + '/typescript')
+  })
+})

--- a/test/typescript.spec.ts
+++ b/test/typescript.spec.ts
@@ -1,6 +1,6 @@
 import { checkDirectory } from 'typings-tester'
 
-describe('TypeScript definitions', function() {
+describe('TypeScript definitions', function () {
   it('should compile against index.d.ts', () => {
     checkDirectory(__dirname + '/typescript')
   })


### PR DESCRIPTION
---
name: "Re-enable TypeScript tests"
about: Testing is important
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Internal change.

### Why should this PR be included?
See https://github.com/reduxjs/redux/issues/3500#issuecomment-542363238 and following. I tried out `tsd`, but I did not like it as much. The `expect()` method syntax made it more cumbersome to assert in some scenarios. It also wasn't very well documented. I had to read the source code to figure out how to use it. So, I think sticking with `typings-tester` is preferable for now.

Note, I also needed to add an import in `types\store.ts` in order to get the global `Symbol.observable` definition working in the type outputs.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - No, this is an internal change.
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Types can break.

### What is the expected behavior?
The ability to test types.

### How does this PR fix the problem?
Re-enables types testing.
