### PR TITLE
Adding the library jsonapi-redux-data to the Ecosystem.md

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -653,6 +653,9 @@ JSON-API abstraction with async CRUD, normalization, optimistic updates, caching
 **[jmeas/redux-resource](https://github.com/jmeas/redux-resource)** <br />
 A tiny but powerful system for managing 'resources': data that is persisted to remote servers.
 
+**[wednesday-solutions/jsonapi-redux-data](https://github.com/wednesday-solutions/jsonapi-redux-data)** <br />
+JsonApi Redux data is a one stop shop for all your redux-jsonapi needs: it provides methods to make your API call and automatically formats data based on relationships and updates it in the redux store!
+
 ## Component State and Encapsulation
 
 **[tonyhb/redux-ui](https://github.com/tonyhb/redux-ui)** <br />


### PR DESCRIPTION
---
name: "Adding the library [jsonapi-redux-data](https://github.com/wednesday-solutions/jsonapi-redux-data) to the Ecosystem.md"
about: Add a new library to the ecosystem page
---

## PR Type

**This PR updates an _existing_ page**


## What docs page is being added or updated?

- **Section**: Entities and Collections:
- **Page**: Ecosystem.md

This PR adds a reference to the library [jsonapi-redux-data](https://github.com/wednesday-solutions/jsonapi-redux-data) in the Ecosystem.md.

JsonApi Redux data is a one-stop-shop for all your jsonapi-redux needs: it provides methods to make your API call and automatically formats data based on relationships and updates it in the redux store