### PR TITLE
[Docs] fix typo in code example of Usage With React section

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -151,7 +151,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const Link = ({ active, children, onClick }) => {
-  if (active) {
+  if (!active) {
     return <span>{children}</span>
   }
 


### PR DESCRIPTION
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Basic Tutorial
- **Page**: Usage With React 

## What is the problem?

`Link` component should return `span` with no `onClick` listeners in case if it's **inactive**. In case if it's **active** it should return an `a` with `onClick` listener

## What changes does this PR make to fix the problem?
It's fixing the code

Notes: in *Basic Tutorial* -> *Example: Todo List* `List` implementation is a little bit different and doesn't suffer from this bug
