### PR TITLE
Fix type of next parameter in StoreEnhancer type

### DIFF
--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -1,12 +1,7 @@
 import compose from './compose'
 import { Middleware, MiddlewareAPI } from './types/middleware'
 import { AnyAction } from './types/actions'
-import {
-  StoreEnhancer,
-  Dispatch,
-  PreloadedState,
-  StoreEnhancerStoreCreator
-} from './types/store'
+import { StoreEnhancer, Dispatch, PreloadedState } from './types/store'
 import { Reducer } from './types/reducers'
 
 /**
@@ -60,7 +55,7 @@ export default function applyMiddleware<Ext, S = any>(
 export default function applyMiddleware(
   ...middlewares: Middleware[]
 ): StoreEnhancer<any> {
-  return (createStore: StoreEnhancerStoreCreator) =>
+  return createStore =>
     <S, A extends AnyAction>(
       reducer: Reducer<S, A>,
       preloadedState?: PreloadedState<S>

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -39,7 +39,12 @@ import { kindOf } from './utils/kindOf'
  * `import { legacy_createStore as createStore} from 'redux'`
  *
  */
-export function createStore<S, A extends Action, Ext = {}, StateExt = never>(
+export function createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {}
+>(
   reducer: Reducer<S, A>,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext
@@ -68,12 +73,22 @@ export function createStore<S, A extends Action, Ext = {}, StateExt = never>(
  * `import { legacy_createStore as createStore} from 'redux'`
  *
  */
-export function createStore<S, A extends Action, Ext = {}, StateExt = never>(
+export function createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {}
+>(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext
-export function createStore<S, A extends Action, Ext = {}, StateExt = never>(
+export function createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {}
+>(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
   enhancer?: StoreEnhancer<Ext, StateExt>
@@ -401,8 +416,8 @@ export function createStore<S, A extends Action, Ext = {}, StateExt = never>(
 export function legacy_createStore<
   S,
   A extends Action,
-  Ext = {},
-  StateExt = never
+  Ext extends {} = {},
+  StateExt extends {} = {}
 >(
   reducer: Reducer<S, A>,
   enhancer?: StoreEnhancer<Ext, StateExt>
@@ -440,8 +455,8 @@ export function legacy_createStore<
 export function legacy_createStore<
   S,
   A extends Action,
-  Ext = {},
-  StateExt = never
+  Ext extends {} = {},
+  StateExt extends {} = {}
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
@@ -450,8 +465,8 @@ export function legacy_createStore<
 export function legacy_createStore<
   S,
   A extends Action,
-  Ext = {},
-  StateExt = never
+  Ext extends {} = {},
+  StateExt extends {} = {}
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,7 @@ export {
   Store,
   StoreCreator,
   StoreEnhancer,
-  StoreEnhancerStoreCreator,
-  ExtendState
+  StoreEnhancerStoreCreator
 } from './types/store'
 // reducers
 export {

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -5,8 +5,7 @@ import {
   Action,
   StoreEnhancer,
   Unsubscribe,
-  Observer,
-  ExtendState
+  Observer
 } from '../../src'
 import 'symbol-observable'
 
@@ -20,46 +19,6 @@ type State = {
     d: 'd'
   }
   e: BrandedString
-}
-
-/* extended state */
-const noExtend: ExtendState<State, never> = {
-  a: 'a',
-  b: {
-    c: 'c',
-    d: 'd'
-  },
-  e: brandedString
-}
-
-const noExtendError: ExtendState<State, never> = {
-  a: 'a',
-  b: {
-    c: 'c',
-    d: 'd'
-  },
-  e: brandedString,
-  // @ts-expect-error
-  f: 'oops'
-}
-
-const yesExtend: ExtendState<State, { yes: 'we can' }> = {
-  a: 'a',
-  b: {
-    c: 'c',
-    d: 'd'
-  },
-  e: brandedString,
-  yes: 'we can'
-}
-// @ts-expect-error
-const yesExtendError: ExtendState<State, { yes: 'we can' }> = {
-  a: 'a',
-  b: {
-    c: 'c',
-    d: 'd'
-  },
-  e: brandedString
 }
 
 interface DerivedAction extends Action {


### PR DESCRIPTION
---
name: "Fix type of next parameter in StoreEnhancer type"
about: Fix type of next parameter in StoreEnhancer type
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Fix a bug. Resolves https://github.com/reduxjs/redux/issues/3768.

### Why should this PR be included?
Without this PR the type for `next` in `StoreEnhancer` is incorrect. It assumes that `next` will create a store with the current enhancers `Ext` and `StateExt` already applied to store. Instead, `next` returns a store with `NextExt` and `NextStateExt` generic parameters since the enhancer should work when composed with any other enhancer. It then expects the `StoreEnhancer` to return a new store creator that will create a store with `Ext` and `NextExt`, and `StateExt` and `NextStateExt`.

Note that I had to remove the `ExtendState` type in order to make this work. This type was introduced in https://github.com/reduxjs/redux/pull/3524, but I wasn't able to get the types working while using `ExtendState`. I think the types are more clear without it anyway.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/3768
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Steps to reproduce are in https://github.com/reduxjs/redux/issues/3768. There's also a new test for checking the types on stores created from composed enhancers. This test fails in `master`.

### What is the expected behavior?
The types should allow for a generic `NextExt` and `NextStateExt`.

### How does this PR fix the problem?
It adds those generics.
