### PR TITLE
Change example code for merge approach

### DIFF
--- a/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
+++ b/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
@@ -22,7 +22,9 @@ function commentsById(state = {}, action) {
   switch (action.type) {
     default: {
       if (action.entities && action.entities.comments) {
-        return merge({}, state, action.entities.comments.byId)
+        return { ...state, ...action.entities.comments.byId}
+        // or if storing shallow copy of action items is not recommended:
+        // return merge({ ...state}, action.entities.comments.byId)
       }
       return state
     }


### PR DESCRIPTION
For just adding new items to state (Comments in our example) deep merge for unchanged state properties is unnecessary, just return a new state object with references to old items, and for new items either shallow copy action`s items or ( - if action items should not be used - ) deep merge only for that added items.

However the use case for deepmerge  all properties, maybe if we wanna have a single logic to handle also scenarios where we have an UPDATE action which makes changes to existing items by supplying items ('post comments' in this example) which include only updated properties, so the reducer then needs to deep-merge those updated properties from each item ('comment') with their other unchanged properties.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
