### PR TITLE
Clearify merge approach example for updating normalized data

### DIFF
--- a/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
+++ b/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
@@ -7,13 +7,13 @@ hide_title: true
 
 # Managing Normalized Data
 
-As mentioned in [Normalizing State Shape](./NormalizingStateShape.md), the Normalizr library is frequently used to transform nested response data into a normalized shape suitable for integration into the store. However, that doesn't address the issue of executing further updates to that normalized data as it's being used elsewhere in the application. There are a variety of different approaches that you can use, based on your own preference. We'll use the example of adding a new Comment to a Post.
+As mentioned in [Normalizing State Shape](./NormalizingStateShape.md), the Normalizr library is frequently used to transform nested response data into a normalized shape suitable for integration into the store. However, that doesn't address the issue of executing further updates to that normalized data as it's being used elsewhere in the application. There are a variety of different approaches that you can use, based on your own preference. We'll use the example of handling mutations for Comments on a Post.
 
 ## Standard Approaches
 
 ### Simple Merging
 
-One approach is to merge the contents of the action into the existing state. In this case, we need to do a deep recursive merge, not just a shallow copy. The Lodash `merge` function can handle this for us:
+One approach is to merge the contents of the action into the existing state. In this case, we can use deep recursive merge, not just a shallow copy, to allow for actions with partial items to update stored items. The Lodash `merge` function can handle this for us:
 
 ```js
 import merge from 'lodash/merge'


### PR DESCRIPTION
Instead of only: _"Adding comments to a post"_ we actually describe how to Add/Update (-can be done with both: Simple Merging & Slice Reducer Composition solutions) or Delete (-which can be done with Slice Reducer Composition solution only-). So we should rather say: _"We'll use the example of handling mutations for Comments on a Post"_

Instead of: _"we need to do a deep recursive merge, not just a shallow copy"_, which is not correct because we don't have to, if we don't plan to have update actions with only partial items, we should rather say:  _"we can use deep recursive merge, not just a shallow copy, to allow for actions with partial items to update stored items."_

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
