### PR TITLE
Fix "Introduction" link of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Redux co-maintainer [Mark Erikson](https://twitter.com/acemarke) has put togethe
 
 ## Documentation
 
-- [Introduction](http://redux.js.org/introduction)
+- [Introduction](http://redux.js.org/introduction/getting-started)
 - [Basics](http://redux.js.org/basics/basic-tutorial)
 - [Advanced](http://redux.js.org/advanced/advanced-tutorial)
 - [Recipes](http://redux.js.org/recipes/recipe-index)


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- README.md

## What is the problem?

"Introduction" link was page not found.

## What changes does this PR make to fix the problem?

Update link to Introduction/getting-started
