### PR TITLE
refactor(types/actions): allow type-setting args on ActionCreator

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -66,7 +66,7 @@ The base dispatch function _always_ synchronously sends an action to the store's
 ## Action Creator
 
 ```js
-type ActionCreator<A, P = any> = (...args: P[]) => Action | AsyncAction
+type ActionCreator<A, P extends any[] = any[]> = (...args: P) => Action | AsyncAction
 ```
 
 An _action creator_ is, quite simply, a function that creates an action. Do not confuse the two terms—again, an action is a payload of information, and an action creator is a factory that creates an action.

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -66,7 +66,7 @@ The base dispatch function _always_ synchronously sends an action to the store's
 ## Action Creator
 
 ```js
-type ActionCreator = (...args: any) => Action | AsyncAction
+type ActionCreator<A, P = any> = (...args: P[]) => Action | AsyncAction
 ```
 
 An _action creator_ is, quite simply, a function that creates an action. Do not confuse the two terms—again, an action is a payload of information, and an action creator is a factory that creates an action.

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -49,13 +49,13 @@ export interface AnyAction extends Action {
  *
  * @template A Returned action type.
  */
-export interface ActionCreator<A, P = any> {
-  (...args: P[]): A
+export interface ActionCreator<A, P extends any[] = any[]> {
+  (...args: P): A
 }
 
 /**
  * Object whose values are action creator functions.
  */
-export interface ActionCreatorsMapObject<A = any, P = any> {
+export interface ActionCreatorsMapObject<A = any, P extends any[] = any[]> {
   [key: string]: ActionCreator<A, P>
 }

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -49,13 +49,13 @@ export interface AnyAction extends Action {
  *
  * @template A Returned action type.
  */
-export interface ActionCreator<A> {
-  (...args: any[]): A
+export interface ActionCreator<A, P = any> {
+  (...args: P[]): A
 }
 
 /**
  * Object whose values are action creator functions.
  */
-export interface ActionCreatorsMapObject<A = any> {
-  [key: string]: ActionCreator<A>
+export interface ActionCreatorsMapObject<A = any, P = any> {
+  [key: string]: ActionCreator<A, P>
 }

--- a/test/typescript/actionCreators.ts
+++ b/test/typescript/actionCreators.ts
@@ -10,7 +10,7 @@ interface AddTodoAction extends Action {
   text: string
 }
 
-const addTodo: ActionCreator<AddTodoAction> = (text: string) => ({
+const addTodo: ActionCreator<AddTodoAction, string> = text => ({
   type: 'ADD_TODO',
   text
 })
@@ -19,7 +19,7 @@ const addTodoAction: AddTodoAction = addTodo('test')
 
 type AddTodoThunk = (dispatch: Dispatch) => AddTodoAction
 
-const addTodoViaThunk: ActionCreator<AddTodoThunk> = (text: string) => (
+const addTodoViaThunk: ActionCreator<AddTodoThunk, string> = text => (
   dispatch: Dispatch
 ) => ({
   type: 'ADD_TODO',
@@ -33,8 +33,8 @@ const boundAddTodo = bindActionCreators(addTodo, dispatch)
 const dispatchedAddTodoAction: AddTodoAction = boundAddTodo('test')
 
 const boundAddTodoViaThunk = bindActionCreators<
-  ActionCreator<AddTodoThunk>,
-  ActionCreator<AddTodoAction>
+  ActionCreator<AddTodoThunk, string>,
+  ActionCreator<AddTodoAction, string>
 >(addTodoViaThunk, dispatch)
 
 const dispatchedAddTodoViaThunkAction: AddTodoAction = boundAddTodoViaThunk(
@@ -48,11 +48,11 @@ const otherDispatchedAddTodoAction: AddTodoAction = boundActionCreators.addTodo(
 )
 
 interface M extends ActionCreatorsMapObject {
-  addTodoViaThunk: ActionCreator<AddTodoThunk>
+  addTodoViaThunk: ActionCreator<AddTodoThunk, string>
 }
 
 interface N extends ActionCreatorsMapObject {
-  addTodoViaThunk: ActionCreator<AddTodoAction>
+  addTodoViaThunk: ActionCreator<AddTodoAction, string>
 }
 
 const boundActionCreators2 = bindActionCreators<M, N>(

--- a/test/typescript/actionCreators.ts
+++ b/test/typescript/actionCreators.ts
@@ -10,7 +10,7 @@ interface AddTodoAction extends Action {
   text: string
 }
 
-const addTodo: ActionCreator<AddTodoAction, string> = text => ({
+const addTodo: ActionCreator<AddTodoAction, [string]> = text => ({
   type: 'ADD_TODO',
   text
 })
@@ -19,7 +19,7 @@ const addTodoAction: AddTodoAction = addTodo('test')
 
 type AddTodoThunk = (dispatch: Dispatch) => AddTodoAction
 
-const addTodoViaThunk: ActionCreator<AddTodoThunk, string> = text => (
+const addTodoViaThunk: ActionCreator<AddTodoThunk> = text => (
   dispatch: Dispatch
 ) => ({
   type: 'ADD_TODO',
@@ -33,8 +33,8 @@ const boundAddTodo = bindActionCreators(addTodo, dispatch)
 const dispatchedAddTodoAction: AddTodoAction = boundAddTodo('test')
 
 const boundAddTodoViaThunk = bindActionCreators<
-  ActionCreator<AddTodoThunk, string>,
-  ActionCreator<AddTodoAction, string>
+  ActionCreator<AddTodoThunk, [string]>,
+  ActionCreator<AddTodoAction, [string]>
 >(addTodoViaThunk, dispatch)
 
 const dispatchedAddTodoViaThunkAction: AddTodoAction = boundAddTodoViaThunk(
@@ -48,11 +48,11 @@ const otherDispatchedAddTodoAction: AddTodoAction = boundActionCreators.addTodo(
 )
 
 interface M extends ActionCreatorsMapObject {
-  addTodoViaThunk: ActionCreator<AddTodoThunk, string>
+  addTodoViaThunk: ActionCreator<AddTodoThunk, [string]>
 }
 
 interface N extends ActionCreatorsMapObject {
-  addTodoViaThunk: ActionCreator<AddTodoAction, string>
+  addTodoViaThunk: ActionCreator<AddTodoAction, [string]>
 }
 
 const boundActionCreators2 = bindActionCreators<M, N>(


### PR DESCRIPTION
Following up https://github.com/reduxjs/redux/pull/3541#discussion_r437355966

We are allowing Action creators to be typed by declaring their return type as well as the argument type so function calls keep the expected parameter types.

---
name: "allow type-setting args on ActionCreator"
about: improving type declarations on Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
It sort of adds a new feature, but it's opt-in for the type usage defaulting to the same as the previous behaviour. 

### Why should this PR be included?
Allow developers to use Redux provided typings in order to implement ActionCreators

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## New Features

### What new capabilities does this PR add?

### What docs changes are needed to explain this?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

### What is the expected behavior?

### How does this PR fix the problem?
