### PR TITLE
docs: Fix formatting for WritingTests

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -354,6 +354,7 @@ export default connect(mapStateToProps)(App)
 To test it, we can use the `wrapper` option in React Testing Library's `render` function and export our own `render` function as explained in React Testing Library's [setup docs](https://testing-library.com/docs/react-testing-library/setup).
 
 Our `render` function can look like this:
+
 ```js
 // test-utils.js
 import React from 'react'
@@ -367,12 +368,12 @@ function render(
     initialState,
     store = createStore(reducer, initialState),
     ...renderOptions
-  } = {},
+  } = {}
 ) {
-  function Wrapper({children}) {
+  function Wrapper({ children }) {
     return <Provider store={store}>{children}</Provider>
   }
-  return rtlRender(ui, {wrapper: Wrapper, ...renderOptions})
+  return rtlRender(ui, { wrapper: Wrapper, ...renderOptions })
 }
 
 // re-export everything
@@ -382,6 +383,7 @@ export { render }
 ```
 
 And our test can use our exported `render` function:
+
 ```js
 import React from 'react'
 // We're using our own custom render function and not RTL's render


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix - Formatting problem with WritingTests"
about: Format the WritingTests page again.
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **WritingTests**:

## What is the problem?
Linting problem.

## What changes does this PR make to fix the problem?
I ran `yarn:format` again.