### PR TITLE
Only apply mapped types to un-branded types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,9 @@ export type PreloadedState<S> = Required<S> extends {
       }
     : never
   : {
-      [K in keyof S]: S[K] extends object ? PreloadedState<S[K]> : S[K]
+      [K in keyof S]: S[K] extends (string | number | boolean | symbol)
+        ? S[K]
+        : PreloadedState<S[K]>
     }
 
 /* reducers */

--- a/package-lock.json
+++ b/package-lock.json
@@ -7305,9 +7305,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "typings-tester": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.1.1",
     "rxjs": "^6.5.2",
-    "typescript": "^3.5.3",
+    "typescript": "^3.9.6",
     "typings-tester": "^0.3.2"
   },
   "npmName": "redux",

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -11,12 +11,16 @@ import {
 } from 'redux'
 import 'symbol-observable'
 
+type BrandedString = string & { _brand: 'type' }
+const brandedString = 'a string' as BrandedString
+
 type State = {
   a: 'a'
   b: {
     c: 'c'
     d: 'd'
   }
+  c: BrandedString
 }
 
 interface DerivedAction extends Action {
@@ -30,7 +34,8 @@ const reducer: Reducer<State> = (
     b: {
       c: 'c',
       d: 'd'
-    }
+    },
+    c: brandedString
   },
   action: Action
 ): State => {
@@ -43,7 +48,8 @@ const reducerWithAction: Reducer<State, DerivedAction> = (
     b: {
       c: 'c',
       d: 'd'
-    }
+    },
+    c: brandedString
   },
   action: DerivedAction
 ): State => {
@@ -58,17 +64,20 @@ const store: Store<State> = createStore(reducer)
 
 const storeWithPreloadedState: Store<State> = createStore(reducer, {
   a: 'a',
-  b: { c: 'c', d: 'd' }
+  b: { c: 'c', d: 'd' },
+  c: brandedString
 })
 // typings:expect-error
 const storeWithBadPreloadedState: Store<State> = createStore(reducer, {
-  b: { c: 'c' }
+  b: { c: 'c' },
+  c: brandedString
 })
 
 const storeWithActionReducer = createStore(reducerWithAction)
 const storeWithActionReducerAndPreloadedState = createStore(reducerWithAction, {
   a: 'a',
-  b: { c: 'c', d: 'd' }
+  b: { c: 'c', d: 'd' },
+  c: brandedString
 })
 funcWithStore(storeWithActionReducer)
 funcWithStore(storeWithActionReducerAndPreloadedState)
@@ -77,7 +86,8 @@ funcWithStore(storeWithActionReducerAndPreloadedState)
 const storeWithActionReducerAndBadPreloadedState = createStore(
   reducerWithAction,
   {
-    b: { c: 'c' }
+    b: { c: 'c' },
+    c: brandedString
   }
 )
 
@@ -89,7 +99,8 @@ const storeWithPreloadedStateAndEnhancer: Store<State> = createStore(
   reducer,
   {
     a: 'a',
-    b: { c: 'c', d: 'd' }
+    b: { c: 'c', d: 'd' },
+    c: brandedString
   },
   enhancer
 )


### PR DESCRIPTION
## PR Type
Bugfix

### Why should this PR be included?
#3485 fixed #3672 for TS 3.5, though starting with TS 3.6 that fix no longer worked. Branded types (e.g. `string &  { _brand: "a" }`) now resolve to `never` in `PreloadedState`. This PR fixes #3672 for newer TS versions.

Note that this PR targets the 4.x branch, since we're using 4.0.5 today. If this PR is accepted I'll PR master with the same fix as well.

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Branded strings cannot be passed to `createStore` as part of the preloaded state:
```typescript
type BrandedString = string & { _brand: "a" };
interface IState {
    version: BrandedString;
}
const initialState: IState = {
    version: "1.0.0" as BrandedString,
};
createStore(…reducer…, initialState);
```
The error on `initialState` in the last line:
```
No overload matches this call.
  Overload 1 of 2, '(reducer: Reducer<IState, Action<any>>, enhancer?: StoreEnhancer<unknown, unknown> | undefined): Store<IState, Action<any>>', gave the following error.
    Argument of type 'IState' is not assignable to parameter of type 'StoreEnhancer<unknown, unknown>'.
      Type 'IState' provides no match for the signature '(next: StoreEnhancerStoreCreator<{}, {}>): StoreEnhancerStoreCreator<unknown, unknown>'.
  Overload 2 of 2, '(reducer: Reducer<IState, Action<any>>, preloadedState?: { version: never; } | undefined, enhancer?: StoreEnhancer<unknown, {}> | undefined): Store<...>', gave the following error.
    Argument of type 'IState' is not assignable to parameter of type '{ version: never; }'.
      Types of property 'version' are incompatible.
        Type 'BrandedString' is not assignable to type 'never'.ts(2769)
```

See [playground](https://www.typescriptlang.org/play/index.html#code/JYWwDg9gTgLgBAbzgYygUwIYzQZRtNOAXzgDMoIQ4AidAEwFcAPagbgCh2YBPMQgISgYAdnTR08UYMIDmcALxwAzjCmy4AMkRwA+gCMhogFw0M1Yh2nYopDMkIBJPFkIJ2cD3ABuaKEuAQwiaCImISqtIyHETsyIEqcNLAMMAYADbO2CZOMC4KiO6ePn4BQTQADAB0VeXmGEpwIaLikpEANOxEHKiY2HgEABQDKi7ZmYQAPnAMzaTS4gCUCgB8cAMIJPVwItwLbYnCyakZudgLHEA), note that everything is fine for TS 3.5 but starts breaking at 3.6+.

### What is the expected behavior?
The code compiles.

### How does this PR fix the problem?
Similar to the proposal in microsoft/TypeScript#35992 this PR changes the mapped object type to only apply for types that are not primitives, since branded primitives are _also_ objects, which is why the current code hits them. By reversing the condition we first exclude primitives and apply the mapped type to what's left: objects that aren't just a brand on a primitive.

Alternatively, the original suggestion in #3672 of allowing `PreloadedState<S> | S` should also work.

I could also change this PR to be slightly safer by making both the primitive escape hatch and the object matching explicit, e.g. `{ [K in keyof S]: S[K] extends string ? S[K] : S[K] extends object ? PreloadedState<S[K]> : S[K] }`
