### PR TITLE
StrictReducer type is provided for reducers without initial state

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -9,7 +9,7 @@ import {
   ExtendState
 } from './types/store'
 import { Action } from './types/actions'
-import { Reducer } from './types/reducers'
+import { Reducer, StrictReducer } from './types/reducers'
 import ActionTypes from './utils/actionTypes'
 import isPlainObject from './utils/isPlainObject'
 
@@ -55,6 +55,16 @@ export default function createStore<
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
+  enhancer?: StoreEnhancer<Ext, StateExt>
+): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+export default function createStore<
+  S,
+  A extends Action,
+  Ext = {},
+  StateExt = never
+>(
+  reducer: StrictReducer<S, A>,
+  preloadedState: S,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 export default function createStore<

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
 // reducers
 export {
   Reducer,
+  StrictReducer,
   ReducerFromReducersMapObject,
   ReducersMapObject,
   StateFromReducersMapObject,

--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -32,6 +32,21 @@ export type Reducer<S = any, A extends Action = AnyAction> = (
 ) => S
 
 /**
+ * A reducer that expect fully initialized input state. When you use
+ * this reducer, you should provide defined initial state.
+ *
+ * It can be useful for a normalized state and a reducer delegation,
+ * when you can't provide initial state statically.
+ *
+ * @template S The type of state consumed and produced by this reducer.
+ * @template A The type of actions the reducer can potentially respond to.
+ */
+export type StrictReducer<S = any, A extends Action = AnyAction> = (
+  state: S,
+  action: A
+) => S
+
+/**
  * Object whose values correspond to different reducer functions.
  *
  * @template A The type of actions the reducers can potentially respond to.

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -2,6 +2,7 @@ import {
   Store,
   createStore,
   Reducer,
+  StrictReducer,
   Action,
   StoreEnhancer,
   Unsubscribe,
@@ -138,6 +139,26 @@ const storeWithBadPreloadedStateAndEnhancer: Store<State> = createStore(
     b: { c: 'c' }
   },
   enhancer
+)
+
+const strictReducer: StrictReducer<State> = (
+  state: State,
+  action: Action
+): State => {
+  return state
+}
+
+const storeWithStrictReducer: Store<State> = createStore(strictReducer, {
+  a: 'a',
+  b: {
+    c: 'c',
+    d: 'd'
+  }
+})
+
+// typings:expect-error
+const storeWithStrictReducerAndWithoutPreloadedState: Store<State> = createStore(
+  strictReducer
 )
 
 /* dispatch */


### PR DESCRIPTION
---
name: "\U0001F41B Bug fix or new feature"
about: Fixing a problem with Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
_feature_

### Why should this PR be included?
Sometimes it isn't possible to provide initial state for reducer, and this state should be provided externally. This changes should help in this cases.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## New Features
StrictReducer type is provided for reducers without initial state. Also `createStore` overload is supported for reducer without initial state.

### What new capabilities does this PR add?
If you want to create reducer without inittial state, you can use type shortcut for it.
Also, if you use reducer in `createStore`, that don't accept undefined as input state, you shoul provide initial state for it.

### What docs changes are needed to explain this?
I think docs changes aren't needed for this PR, because it is type checking improvement, Typescript should help you if something goes wrong.
