### PR TITLE
Broken image src link to ReduxDataFlowDiagram.gif

### DIFF
--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -435,7 +435,7 @@ For Redux specifically, we can break these steps into more detail:
 
 Here's what that data flow looks like visually:
 
-![Redux data flow diagram](/img/tutorials/ReduxDataFlowDiagram.gif)
+![Redux data flow diagram](/img/tutorials/essentials/ReduxDataFlowDiagram.gif)
 
 ## What You've Learned
 


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

Resolves #3809 

## Checklist

- [x] Is there an existing issue for this PR?
  - #3809 
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials > Redux Essentials
- **Page**: Redux Overview and Concepts
- **URL**: https://redux.js.org/tutorials/essentials/part-1-overview-concepts#redux-application-data-flow

## What is the problem?

The img src link to `ReduxDataFlowDiagram.gif` is broken.

## What should be changed to fix the problem?

Point to `https://redux.js.org/img/tutorials/essentials/ReduxDataFlowDiagram.gif`
