### PR TITLE
Fix type error in Redux Essentials.

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -55,7 +55,7 @@ export const SinglePostPage = ({ match }) => {
   const { postId } = match.params
 
   const post = useSelector(state =>
-    state.posts.find(post => post.id === postId)
+    state.posts.find(post => post.id.toString() === postId)
   )
 
   if (!post) {


### PR DESCRIPTION
---
name: "Fix error in Redux Essentials tutorial"
about: Fixes a type error in the Redux Essentials tutorial
---

## PR Type: Documentation Fix

### Does this PR add a new _feature_, or fix a _bug_?

This PR fixes a bug in the Redux Essentials Tutorial, fixing issue #3812.

### Why should this PR be included?

New users who go through the Redux Essentials tutorial will have code that might not work as expected if this fix is not added.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
    - See #3812.
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

### What docs changes are needed to explain this?

See above.

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

When the user visits the route `/posts/1` or `/posts/2`, the not found screen appears.

### What is the expected behavior?

The post for id `1` or id `2` should display.

### How does this PR fix the problem?

This PR adds a `.toString()` call in a comparison function to fix a type error where the selector was comparing an integer and a string (which will always return false).
