### PR TITLE
Change package module field to point to the .mjs file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "main": "lib/redux.js",
   "unpkg": "dist/redux.js",
-  "module": "es/redux.js",
+  "module": "es/redux.mjs",
   "types": "types/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
### Does this PR add a new _feature_, or fix a _bug_?
I would classify it as a bug, but there could be other opinions about it. It's probably a breaking change though.

### Why should this PR be included?
I've tried to find a similar issue/PR, but couldn't find it and I was wondering if it was ever even discussed. This may be closed if so, but if not:

This PR is basically just an idea (and I am new to Redux so please bear with me), let me know what you think.

When this PR is accepted there is no more need for `import ... from 'redux/es/redux.mjs';` imports when using ES modules in a browser environment, these can be shortened to: `import ... from 'redux';`.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Is there an existing issue for this PR?~~ No
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR? Not yet
- [ ] Have the tests been updated to match the changes in the PR? No
- [ ] Have you run the tests locally to confirm they pass? No

For what it's worth, I did do a functional check in my personal project using ES modules with Redux and this change fixed my `process is not defined` issues.

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
`import ... from 'redux';` loads `redux/es/redux.js` which then shows a (probably) well-known error: `process is not defined`.

### What is the expected behavior?
That it works without the error.

### How does this PR fix the problem?
The generated `.mjs` file has filtered out usages of `process`.