### PR TITLE
Only apply mapped types to un-branded types

### DIFF
--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -53,7 +53,9 @@ export type PreloadedState<S> = Required<S> extends {
       }
     : never
   : {
-      [K in keyof S]: S[K] extends object ? PreloadedState<S[K]> : S[K]
+      [K in keyof S]: S[K] extends string | number | boolean | symbol
+        ? S[K]
+        : PreloadedState<S[K]>
     }
 
 /**

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -10,12 +10,16 @@ import {
 } from '../..'
 import 'symbol-observable'
 
+type BrandedString = string & { _brand: 'type' }
+const brandedString = 'a string' as BrandedString
+
 type State = {
   a: 'a'
   b: {
     c: 'c'
     d: 'd'
   }
+  e: BrandedString
 }
 
 /* extended state */
@@ -24,7 +28,8 @@ const noExtend: ExtendState<State, never> = {
   b: {
     c: 'c',
     d: 'd'
-  }
+  },
+  e: brandedString
 }
 // typings:expect-error
 const noExtendError: ExtendState<State, never> = {
@@ -33,7 +38,8 @@ const noExtendError: ExtendState<State, never> = {
     c: 'c',
     d: 'd'
   },
-  e: 'oops'
+  e: brandedString,
+  f: 'oops'
 }
 
 const yesExtend: ExtendState<State, { yes: 'we can' }> = {
@@ -42,6 +48,7 @@ const yesExtend: ExtendState<State, { yes: 'we can' }> = {
     c: 'c',
     d: 'd'
   },
+  e: brandedString,
   yes: 'we can'
 }
 // typings:expect-error
@@ -50,7 +57,8 @@ const yesExtendError: ExtendState<State, { yes: 'we can' }> = {
   b: {
     c: 'c',
     d: 'd'
-  }
+  },
+  e: brandedString
 }
 
 interface DerivedAction extends Action {
@@ -64,7 +72,8 @@ const reducer: Reducer<State> = (
     b: {
       c: 'c',
       d: 'd'
-    }
+    },
+    e: brandedString
   },
   action: Action
 ): State => {
@@ -77,7 +86,8 @@ const reducerWithAction: Reducer<State, DerivedAction> = (
     b: {
       c: 'c',
       d: 'd'
-    }
+    },
+    e: brandedString
   },
   action: DerivedAction
 ): State => {
@@ -95,17 +105,20 @@ const arrayReducer = (state: any[] = []) => state || []
 const storeWithArrayState: Store<any[]> = createStore(arrayReducer)
 const storeWithPreloadedState: Store<State> = createStore(reducer, {
   a: 'a',
-  b: { c: 'c', d: 'd' }
+  b: { c: 'c', d: 'd' },
+  e: brandedString
 })
 // typings:expect-error
 const storeWithBadPreloadedState: Store<State> = createStore(reducer, {
-  b: { c: 'c' }
+  b: { c: 'c' },
+  e: brandedString
 })
 
 const storeWithActionReducer = createStore(reducerWithAction)
 const storeWithActionReducerAndPreloadedState = createStore(reducerWithAction, {
   a: 'a',
-  b: { c: 'c', d: 'd' }
+  b: { c: 'c', d: 'd' },
+  e: brandedString
 })
 funcWithStore(storeWithActionReducer)
 funcWithStore(storeWithActionReducerAndPreloadedState)
@@ -114,7 +127,8 @@ funcWithStore(storeWithActionReducerAndPreloadedState)
 const storeWithActionReducerAndBadPreloadedState = createStore(
   reducerWithAction,
   {
-    b: { c: 'c' }
+    b: { c: 'c' },
+    e: brandedString
   }
 )
 
@@ -126,7 +140,8 @@ const storeWithPreloadedStateAndEnhancer: Store<State> = createStore(
   reducer,
   {
     a: 'a',
-    b: { c: 'c', d: 'd' }
+    b: { c: 'c', d: 'd' },
+    e: brandedString
   },
   enhancer
 )


### PR DESCRIPTION
This is the same as #3805, except it's targeting master instead of 4.x.