### PR TITLE
Add hightlight to Tutorials/Using Redux Data

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -479,6 +479,7 @@ import { postAdded } from './postsSlice'
 export const AddPostForm = () => {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
+  // highlight-next-line
   const [userId, setUserId] = useState('')
 
   const dispatch = useDispatch()


### PR DESCRIPTION
## What docs page needs to be fixed?

- **Section**: Tutorials
- **Page**: Redux Essentials, Part 4: Using Redux Data

## What is the problem?
The line 482 doesn't have the highlight. For people who are writing code manually maybe they don't notice that they need to add that line.
![code](https://user-images.githubusercontent.com/67462841/88487174-b225c180-cf7a-11ea-96b2-6ea12c56b149.PNG)
## What should be changed to fix the problem?
Add: **// highlight-next-line**
