### PR TITLE
docs: overview-concepts obj reference

### DIFF
--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -177,7 +177,7 @@ This is called _mutating_ the object or array. It's the same object or array ref
 We can do this by hand using JavaScript's array / object spread operators, as well as array methods that return new copies of the array instead of mutating the original array:
 
 ```js
-const obj1 = {
+const obj = {
   a: {
     // To safely update obj.a.c, we have to copy each piece
     c: 3


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/3828
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials
- **Page**: overview-concepts

## What is the problem?
`const obj1 =` in the "In order to update values immutably, your code must make copies of existing objects/arrays, and then modify the copies" section should be `const obj =` as it is referenced below it as just `obj`
## What changes does this PR make to fix the problem?
change `const obj1` = to `const obj =`