### PR TITLE
Fix website readme

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -5,13 +5,13 @@ This website is built using Docusaurus 2, a modern static website generator.
 ### Installation
 
 ```
-$ yarn
+$ npm install
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+$ npm start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and open up a browser window. Mos
 ### Build
 
 ```
-$ yarn build
+$ npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -27,7 +27,7 @@ This command generates static content into the `build` directory and can be serv
 ### Deployment
 
 ```
-$ GIT_USER=<Your GitHub username> USE_SSH=1 yarn deploy
+$ GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
## Checklist

- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

## What is the problem?

- Redux website have `package-lock.json` and do not have `yarn.lock`. Shell commands in the readme should use `npm`.

- Docusaurus requires an `USE_SSH=true` env. variable to use SSH, not an `USE_SSH=1`. Please see https://v2.docusaurus.io/docs/deployment#environment-settings

