### PR TITLE
Fix navbar wrapping between 997 and 1157px

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -114,6 +114,10 @@ a:visited {
   color: var(--ifm-color-primary);
 }
 
+.navbar .navbar__inner {
+  flex-wrap: nowrap;
+}
+
 .navbar .navbar__items {
   flex: 1 1 auto;
 }


### PR DESCRIPTION
---
name: Bug fix\
about: Fixing a styling problem with Redux website
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Fix a bug. Resolves #3839

### Why should this PR be included?
Without this PR the navbar items will wrap between 997 and 1157px.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - Resolves #3839
- [x] Have the files been linted and formatted?
~~[ ] Have the docs been updated to match the changes in the PR?~~
~~[ ] Have the tests been updated to match the changes in the PR?~~
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behaviour, and the steps to reproduce the issue?
Website navbar overflows between 997 and 1157px. Can be viewed on any browser.

### What is the expected behaviour?
Navbar items shouldn't wrap if this behaviour breaks layout and impedes user interaction. 

### How does this PR fix the problem?
PR will modify the `flex-wrap` rule on the navbar to keep items on one line.