### PR TITLE
added key prop to <article> inside of  map()

### DIFF
--- a/docs/tutorials/essentials/part-3-data-flow.md
+++ b/docs/tutorials/essentials/part-3-data-flow.md
@@ -170,7 +170,7 @@ export const PostsList = () => {
   const posts = useSelector(state => state.posts)
 
   const renderedPosts = posts.map(post => (
-    <article className="post-excerpt">
+    <article className="post-excerpt" key={post.id}>
       <h3>{post.title}</h3>
       <p>{post.content.substring(0, 100)}</p>
     </article>


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - no
- [ ] Have the files been linted and formatted?
  - yes: npm run format:check

## What docs page needs to be fixed?

- **Section**: Showing the Posts List
- **Page**: part-3-data-flow

- **code listing**:  features/posts/PostsList.js

## What is the problem?

Missing `key` for `<article>` inside of `map()`

## What changes does this PR make to fix the problem?

Add the key