### PR TITLE
grammer uses should be use.

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -242,7 +242,7 @@ export default postsSlice.reducer
 
 ### Creating an Edit Post Form
 
-Our new `<EditPostForm>` component will look similar to the `<AddPostForm>`, but the logic needs to be a bit different. We need to retrieve the right `post` object from the store, then use that to initialize the state fields in the component so the user can make changes. We'll save the changed title and content values back to the store after the user is done. We'll also uses React Router's history API to switch over to the single post page and show that post.
+Our new `<EditPostForm>` component will look similar to the `<AddPostForm>`, but the logic needs to be a bit different. We need to retrieve the right `post` object from the store, then use that to initialize the state fields in the component so the user can make changes. We'll save the changed title and content values back to the store after the user is done. We'll also use React Router's history API to switch over to the single post page and show that post.
 
 ```jsx title="features/posts/EditPostForm.js"
 import React, { useState } from 'react'


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - no
- [ ] Have the files been linted and formatted?
  - yes

## What docs page needs to be fixed?

- **Section**: Creating an Edit Post Form
- **Page**: part-4-using-data.md

## What is the problem?

Minor grammar / typo.

## What changes does this PR make to fix the problem?

Change the word 'uses' to 'use'.