### PR TITLE
docs: Add missing mention in "Extracting Posts Selectors" secti…

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -123,14 +123,14 @@ If we were to write out the code for a typical async thunk by hand, it might loo
 
 ```js
 const getRepoDetailsStarted = () => ({
-  type: "repoDetails/fetchStarted"
+  type: 'repoDetails/fetchStarted'
 })
-const getRepoDetailsSuccess = (repoDetails) => ({
-  type: "repoDetails/fetchSucceeded",
+const getRepoDetailsSuccess = repoDetails => ({
+  type: 'repoDetails/fetchSucceeded',
   payload: repoDetails
 })
-const getRepoDetailsFailed = (error) => ({
-  type: "repoDetails/fetchFailed",
+const getRepoDetailsFailed = error => ({
+  type: 'repoDetails/fetchFailed',
   error
 })
 const fetchIssuesCount = (org, repo) => async dispatch => {

--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -215,6 +215,20 @@ export const SinglePostPage = ({ match }) => {
 }
 ```
 
+```js title="features/posts/EditPostForm.js"
+// omit imports
+//highlight-next-line
+import { postUpdated, selectPostById } from './postsSlice'
+
+export const EditPostForm = ({ match }) => {
+  const { postId } = match.params
+
+  // highlight-next-line
+  const post = useSelector(state => selectPostById(state, postId))
+  // omit component logic
+}
+```
+
 It's often a good idea to encapsulate data lookups by writing reusable selectors. You can also create "memoized" selectors that can help improve performance, which we'll look at in a later part of this tutorial.
 
 But, like any abstraction, it's not something you should do _all_ the time, everywhere. Writing selectors means more code to understand and maintain. **Don't feel like you need to write selectors for every single field of your state**. Try starting without any selectors, and add some later when you find yourself looking up the same values in many parts of your application code.
@@ -533,6 +547,7 @@ export const PostsList = () => {
   const posts = useSelector(selectAllPosts)
 
   const postStatus = useSelector(state => state.posts.status)
+  // highlight-next-line
   const error = useSelector(state => state.posts.error)
 
   useEffect(() => {

--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -295,6 +295,30 @@ export const Navbar = () => {
 }
 ```
 
+Lastly, we need to update `App.js` with the "Notifications" route so we can navigate to it:
+
+```js title="App.js"
+// omit imports
+// highlight-next-line
+import { NotificationsList } from './features/notifications/NotificationsList'
+
+function App() {
+  return (
+    <Router>
+      <Navbar/>
+      <div className="App">
+        <Switch>
+          // omit existing routes
+          // highlight-next-line
+          <Route exact path="/notifications" component={ NotificationsList }/>
+          <Redirect to="/"/>
+        </Switch>
+      </div>
+    </Router>
+  )
+}
+```
+
 Here's what the "Notifications" tab looks like so far:
 
 ![Initial Notifications tab](/img/tutorials/essentials/notifications-initial.png)
@@ -417,6 +441,50 @@ This does actually show that **it's possible to dispatch an action and not have 
 Here's how the notifications tab looks now that we've got the "new/read" behavior working:
 
 ![New notifications](/img/tutorials/essentials/notifications-new.png)
+
+The last thing we need to do before we move on is to add the badge on our "Notifications" tab in the navbar. This will show us the count of "Unread" notifications when we are in other tabs:
+
+```js title="app/Navbar.js"
+// omit imports
+// highlight-next-line
+import { useDispatch, useSelector } from 'react-redux'
+
+// highlight-next-line
+import { fetchNotifications, selectAllNotifications } from '../features/notifications/notificationsSlice'
+
+export const Navbar = () => {
+  const dispatch = useDispatch()
+  // highlight-start
+  const notifications = useSelector(selectAllNotifications)
+  const numUnreadNotifications = notifications.filter((n) => !n.read).length
+  // highlight-end
+  // omit component contents
+  // highlight-start
+  let unreadNotificationsBadge
+
+  if (numUnreadNotifications > 0) {
+    unreadNotificationsBadge = (
+      <span className="badge">{numUnreadNotifications}</span>
+    )
+  }
+  // highlight-end
+  return (
+    <nav>
+      // omit component contents
+          <div className="navLinks">
+            <Link to="/">Posts</Link>
+            <Link to="/users">Users</Link>
+            // highlight-start
+            <Link to="/notifications">
+              Notifications {unreadNotificationsBadge}
+            </Link>
+            // highlight-end
+          </div>
+      // omit component contents
+    </nav>
+  )
+}
+```
 
 ## Improving Render Performance
 

--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -305,13 +305,12 @@ import { NotificationsList } from './features/notifications/NotificationsList'
 function App() {
   return (
     <Router>
-      <Navbar/>
+      <Navbar />
       <div className="App">
         <Switch>
-          // omit existing routes
-          // highlight-next-line
-          <Route exact path="/notifications" component={ NotificationsList }/>
-          <Redirect to="/"/>
+          // omit existing routes // highlight-next-line
+          <Route exact path="/notifications" component={NotificationsList} />
+          <Redirect to="/" />
         </Switch>
       </div>
     </Router>
@@ -450,13 +449,16 @@ The last thing we need to do before we move on is to add the badge on our "Notif
 import { useDispatch, useSelector } from 'react-redux'
 
 // highlight-next-line
-import { fetchNotifications, selectAllNotifications } from '../features/notifications/notificationsSlice'
+import {
+  fetchNotifications,
+  selectAllNotifications
+} from '../features/notifications/notificationsSlice'
 
 export const Navbar = () => {
   const dispatch = useDispatch()
   // highlight-start
   const notifications = useSelector(selectAllNotifications)
-  const numUnreadNotifications = notifications.filter((n) => !n.read).length
+  const numUnreadNotifications = notifications.filter(n => !n.read).length
   // highlight-end
   // omit component contents
   // highlight-start
@@ -471,15 +473,15 @@ export const Navbar = () => {
   return (
     <nav>
       // omit component contents
-          <div className="navLinks">
-            <Link to="/">Posts</Link>
-            <Link to="/users">Users</Link>
-            // highlight-start
-            <Link to="/notifications">
-              Notifications {unreadNotificationsBadge}
-            </Link>
-            // highlight-end
-          </div>
+      <div className="navLinks">
+        <Link to="/">Posts</Link>
+        <Link to="/users">Users</Link>
+        // highlight-start
+        <Link to="/notifications">
+          Notifications {unreadNotificationsBadge}
+        </Link>
+        // highlight-end
+      </div>
       // omit component contents
     </nav>
   )


### PR DESCRIPTION
---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - Resolves #3863
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: #extracting-posts-selectors
- **Page**: /tutorials/essentials/part-5-async-logic

## What is the problem?
Missing component mention in "Extracting Posts Selectors" section leading to future error

## What changes does this PR make to fix the problem?
Add missing mention and small highlight amend.