### PR TITLE
[Docs] inline details-summary title with the disclosure triangle

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -175,9 +175,7 @@ details.detailed-explanation summary {
 
 .style-guide details summary h4,
 details.detailed-explanation summary h4 {
-  display: inline-block;
-  margin-top: 0;
-  margin-bottom: 0;
+  display: inline;
 }
 
 .style-guide details p,


### PR DESCRIPTION
---
name: "📝 Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Component**: DetailedExplanation

## What is the problem?

Before this change the title would drop one line under the triangle instead of
wrapping to the next line on small screens.

## What changes does this PR make to fix the problem?

Changes the display stile of the title.

## Screenshots

**Before:**
![localhost_3000_tutorials_essentials_part-5-async-logic(Galaxy S5)](https://user-images.githubusercontent.com/70445727/93624163-996ce180-f9e8-11ea-86ec-80c7d215505c.png)

**After:**
![localhost_3000_tutorials_essentials_part-5-async-logic(Galaxy S5) (1)](https://user-images.githubusercontent.com/70445727/93624189-a558a380-f9e8-11ea-8d4e-0b4e0eb637b7.png)

