### PR TITLE
[Docs] fix PR-template emojis

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F41B Bug fix or new feature"
+name: :bug: Bug fix or new feature
 about: Fixing a problem with Redux
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/documentation-edit.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation-edit.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F4DD Documentation Fix"
+name: :memo: Documentation Fix
 about: Fixing a problem in an existing docs page
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/documentation-new.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation-new.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F4D6 New/Updated Documentation Content"
+name: :book: New/Updated Documentation Content
 about: Adding a new docs page, or updating content in an existing docs page
 ---
 


### PR DESCRIPTION
When creating a PR from a template, the emoji-unicode displayed as a plain text.
Changing to "markdown emoji markup" fixes this.
