### PR TITLE
[Docs - Advanced - Async Actions] remove note about fetch

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -395,24 +395,6 @@ export function fetchPosts(subreddit) {
 }
 ```
 
-> ##### Note on `fetch`
->
-> We use [`fetch` API](https://developer.mozilla.org/en/docs/Web/API/Fetch_API) in the examples. It is a new API for making network requests that replaces `XMLHttpRequest` for most common needs. Because most browsers don't yet support it natively, we suggest that you use [`cross-fetch`](https://github.com/lquixada/cross-fetch) library:
->
-> ```js
-> // Do this in every file where you use `fetch`
-> import fetch from 'cross-fetch'
-> ```
->
-> Internally, it uses [`whatwg-fetch` polyfill](https://github.com/github/fetch) on the client, and [`node-fetch`](https://github.com/bitinn/node-fetch) on the server, so you won't need to change API calls if you change your app to be [universal](https://medium.com/@mjackson/universal-javascript-4761051b7ae9).
->
-> Be aware that any `fetch` polyfill assumes a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) polyfill is already present. The easiest way to ensure you have a Promise polyfill is to enable Babel's ES6 polyfill in your entry point before any other code runs:
->
-> ```js
-> // Do this once before any other code in your app
-> import 'babel-polyfill'
-> ```
-
 How do we include the Redux Thunk middleware in the dispatch mechanism? We use the [`applyMiddleware()`](../api/applyMiddleware.md) store enhancer from Redux, as shown below:
 
 #### `index.js`


### PR DESCRIPTION
Remove this note: https://redux.js.org/advanced/async-actions#note-on-fetch

Obsolete and irrelevant for redux tutorial.