### PR TITLE
docs: Add an example of type checking a middleware function

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -230,6 +230,26 @@ const rootReducer = combineReducers({
 export type RootState = ReturnType<typeof rootReducer>
 ```
 
+### Type Checking Middlewares
+
+A middleware is a higher-order function that composes a dispatch function to return a new dispatch function.
+To create a type checked middleware function, we can leverage the `Middleware` interface provided by Redux together with our store type (as defined in the previous example):
+
+```ts
+// src/middleware/example.ts
+
+import { Middleware } from 'redux'
+
+import { RootState } from '../store'
+
+export const exampleMiddleware: Middleware<
+  {},
+  RootState
+> = store => next => action => {
+  // code here
+}
+```
+
 ## Usage with React Redux
 
 While React Redux is a separate library from Redux itself, it is commonly used with React.

--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -243,7 +243,7 @@ import { Middleware } from 'redux'
 import { RootState } from '../store'
 
 export const exampleMiddleware: Middleware<
-  {},
+  {}, // legacy type parameter added to satisfy interface signature
   RootState
 > = store => next => action => {
   // code here


### PR DESCRIPTION


---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**
It updates an existing page.
## Checklist

- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Recipes
- **Page**: Usage With TypeScript

## For Updating Existing Content

### What updates should be made to the page?
It was pointed out in a Reactiflux conversation last night that the TypeScript
examples provided by Redux currently do not demonstrate how to type a middleware
function. This patch adds a brief section to the docs that shows how to define a
typed middleware.

### Do these updates change any of the assumptions or target audience? If so, how do they change?
This recipe assumes an entry-level knowledge of Redux and TypeScript and the new example aims to remain in line with these expectations.