### PR TITLE
Fix: Confusing part in the tutorial

### DIFF
--- a/docs/tutorials/essentials/part-3-data-flow.md
+++ b/docs/tutorials/essentials/part-3-data-flow.md
@@ -82,9 +82,9 @@ ReactDOM.render(
 
 </DetailedExplanation>
 
-#### Exploring the Initial Project
+#### Exploring the Tutorial Project
 
-Let's take a quick look at what the initial project contains:
+Now back to our demo project, it contains some aditional files besides the ones created with the template, let's take a quick look at what the project contains:
 
 - `/src`
   - `index.js`: the entry point file for the application. It renders the React-Redux `<Provider>` component and the main `<App>` component.


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials/essentials
- **Page**: part-3-data-flow

## What is the problem?
The tutorial goes on a limb to explain how to create a new project than
sudenly go back to the tutorial demo app like if it was the same thing

## What changes does this PR make to fix the problem?
Add aditional information, making it clear for the reader that now we're talking about the demo app and not the generated one