### PR TITLE
Fix naming when thunk-ifying AddPostForm.js.

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -704,7 +704,7 @@ const postsSlice = createSlice({
 
 ### Checking Thunk Results in Components
 
-Finally, we'll update `<AddPostForm>` to dispatch the `addNewPost` thunk instead the old `postUpdated` action. Since this is another API call to the server, it will take some time and _could_ fail. The `addNewPost()` thunk will automatically dispatch its `pending/fulfilled/rejected` actions to the Redux store, which we're already handling. We _could_ track the request status in `postsSlice` using a second loading enum if we wanted to, but for this example let's keep the loading state tracking limited to the component.
+Finally, we'll update `<AddPostForm>` to dispatch the `addNewPost` thunk instead the old `postAdded` action. Since this is another API call to the server, it will take some time and _could_ fail. The `addNewPost()` thunk will automatically dispatch its `pending/fulfilled/rejected` actions to the Redux store, which we're already handling. We _could_ track the request status in `postsSlice` using a second loading enum if we wanted to, but for this example let's keep the loading state tracking limited to the component.
 
 It would be good if we can at least disable the "Save Post" button while we're waiting for the request, so the user can't accidentally try to save a post twice. If the request fails, we might also want to show an error message here in the form, or perhaps just log it to the console.
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Async Logic and Data Fetching
- **Page**: Checking Thunk Results in Components

## What is the problem?
Naming of function being replaced is inaccurate.

## What changes does this PR make to fix the problem?
Correctly names function to be replaced with thunk.
