### PR TITLE
update symbol-observable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7072,9 +7072,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "loose-envify": "^1.4.0",
-    "symbol-observable": "^1.2.0"
+    "symbol-observable": "^2.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",


### PR DESCRIPTION
Latest version respects environments where `Symbol` may be frozen.
