### PR TITLE
docs: Fix broken url in docs

### DIFF
--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -17,7 +17,7 @@ We don't want to lock you in!
 
 Your process will look like this:
 
-- Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) ([source](https://github.com/reduxjs/redux/blob/master/src/createStore.ts)) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
+- Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) ([source](https://github.com/reduxjs/redux/blob/v4.0.5/src/createStore.js)) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
 
 - This allows you to gradually rewrite every Flux Store in your app as a reducer, but still export `createFluxStore(reducer)` so the rest of your app is not aware that this is happening and sees the Flux stores.
 

--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -17,7 +17,7 @@ We don't want to lock you in!
 
 Your process will look like this:
 
-- Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) ([source](https://github.com/reduxjs/redux/blob/master/src/createStore.js)) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
+- Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) ([source](https://github.com/reduxjs/redux/blob/master/src/createStore.ts)) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
 
 - This allows you to gradually rewrite every Flux Store in your app as a reducer, but still export `createFluxStore(reducer)` so the rest of your app is not aware that this is happening and sees the Flux stores.
 

--- a/docs/recipes/Troubleshooting.md
+++ b/docs/recipes/Troubleshooting.md
@@ -203,4 +203,4 @@ It's possible you're correctly dispatching an action and applying your reducer b
 ## Something else doesn't work
 
 Ask around on the **#redux** [Reactiflux](http://reactiflux.com/) Discord channel, or [create an issue](https://github.com/reduxjs/redux/issues).
-If you figure it out, [edit this document](https://github.com/reduxjs/redux/edit/master/docs/Troubleshooting.md) as a courtesy to the next person having the same problem.
+If you figure it out, [edit this document](https://github.com/reduxjs/redux/edit/master/docs/recipes/Troubleshooting.md) as a courtesy to the next person having the same problem.


### PR DESCRIPTION
## Summary

Easy Navigation and easy reading for others 

(Fix broken url in MigratingToRedux.md and Troubleshooting.md)
