### PR TITLE
Always rebuild docs on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,4 @@
   base    = "website"
   publish = "website/build"
   command = "npm run build && cp _redirects ./build"
+  ignore  = "false"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
   base    = "website"
   publish = "website/build"
   command = "npm run build && cp _redirects ./build"
-  ignore = "git diff --quiet HEAD^ HEAD -- ../docs/ ."
+  ignore  = "git diff --quiet HEAD^ HEAD -- ../docs/ ."

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
   base    = "website"
   publish = "website/build"
   command = "npm run build && cp _redirects ./build"
-  ignore  = "false"
+  ignore = "git diff --quiet HEAD^ HEAD -- ../docs/ ."


### PR DESCRIPTION
Hi, while I was preparing a Japanese translation of the Redux docs using the fork-based approach, I noticed that Netlify refuses to rebuild and deploy the forked site even after I pushed some translated docs under `/docs`. The deploy log says:

```
12:27:22 PM: No changes detected in base directory. Returning early from build.
12:27:22 PM: Failed during stage 'checking build content for changes': Canceled build due to no content change
```

And this is due to [the change Netlify made in October 2019](https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds):

> For sites connected to a Git repo after October 3rd, 2019, Netlify tries to determine if there are any changes in the site's base directory by comparing the last known version of the files within that directory. If no change was detected, the build system skips the build, returning early from the build process.

This PR fixes this problem. It adds the `ignore` attribute in `netlify.toml` so that the site will be rebuilt on _every_ push even when the contents of the `/website` directory have not changed. (This uses `/bin/false`, a UNIX command that just exits with the status code `1`.)

According to the Netlify docs, this doesn't affect how Netlify builds the original docs site (redux.js.org), but it helps new forks in the future.