### PR TITLE
remove deprecated and archived repositories from ecosystem.md

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -60,9 +60,6 @@ The official React bindings for Redux, maintained by the Redux team
 **[angular-redux/ng-redux](https://github.com/angular-redux/ng-redux)** <br />
 Angular 1 bindings for Redux
 
-**[angular-redux/store](https://github.com/angular-redux/store)** <br />
-Angular 2+ bindings for Redux
-
 **[ember-redux/ember-redux](https://github.com/ember-redux/ember-redux)** <br />
 Ember bindings for Redux
 
@@ -621,9 +618,6 @@ Queue actions when offline and dispatch them when getting back online.
 **[rangle/redux-beacon](https://github.com/rangle/redux-beacon)** <br />
 Integrates with any analytics services, can track while offline, and decouples analytics logic from app logic
 
-**[hyperlab/redux-insights](https://github.com/hyperlab/redux-insights)** <br />
-Analytics and tracking with an easy API for writing your own adapters
-
 **[markdalgleish/redux-analytics](https://github.com/markdalgleish/redux-analytics)** <br />
 Watches for Flux Standard Actions with meta analytics values and processes them
 
@@ -654,18 +648,6 @@ JSON-API abstraction with async CRUD, normalization, optimistic updates, caching
 A tiny but powerful system for managing 'resources': data that is persisted to remote servers.
 
 ## Component State and Encapsulation
-
-**[tonyhb/redux-ui](https://github.com/tonyhb/redux-ui)** <br />
-"Block-level scoping" for UI state. Decorated components declare data fields, which become props and can be updated by nested children.
-
-```js
-@ui({
-  key: 'some-name',
-  state: { uiVar1: '', uiVar2: (props, state) => state.someValue },
-  reducer: (state, action) => {}
-})
-class YourComponent extends React.Component {}
-```
 
 **[threepointone/redux-react-local](https://github.com/threepointone/redux-react-local)** <br />
 Local component state in Redux, with handling for component actions
@@ -746,17 +728,11 @@ A resizable and movable dock for Redux DevTools monitors
 **[Slider Monitor](https://github.com/calesce/redux-slider-monitor)** <br />
 A custom monitor for Redux DevTools to replay recorded Redux actions
 
-**[Inspector](https://github.com/alexkuz/redux-devtools-inspector)** <br />
-A custom monitor for Redux DevTools that lets you filter actions, inspect diffs, and pin deep paths in the state to observe their changes
-
 **[Diff Monitor](https://github.com/whetstone/redux-devtools-diff-monitor)** <br />
 A monitor for Redux DevTools that diffs the Redux store mutations between actions
 
 **[Filterable Log Monitor](https://github.com/bvaughn/redux-devtools-filterable-log-monitor/)** <br />
 Filterable tree view monitor for Redux DevTools
-
-**[Chart Monitor](https://github.com/romseguy/redux-devtools-chart-monitor)** <br />
-A chart monitor for Redux DevTools
 
 **[Filter Actions](https://github.com/zalmoxisus/redux-devtools-filter-actions)** <br />
 Redux DevTools composable monitor with the ability to filter actions
@@ -808,9 +784,6 @@ Makes integration and unit testing of sagas a breeze
 **[supasate/connected-react-router](https://github.com/supasate/connected-react-router)**
 Synchronize React Router 4 state with your Redux store.
 
-**[FormidableLabs/redux-little-router](https://github.com/FormidableLabs/redux-little-router)** <br />
-A tiny router for Redux applications that lets the URL do the talking
-
 **[faceyspacey/redux-first-router](https://github.com/faceyspacey/redux-first-router)** <br />
 Seamless Redux-first routing. Think of your app in states, not routes, not components, while keeping the address bar in sync. Everything is state. Connect your components and just dispatch flux standard actions.
 
@@ -826,9 +799,6 @@ React Redux Form is a collection of reducer creators and action creators that ma
 
 **[keajs/kea](https://github.com/keajs/kea)** <br />
 An abstraction over Redux, Redux-Saga and Reselect. Provides a framework for your app’s actions, reducers, selectors and sagas. It empowers Redux, making it as simple to use as setState. It reduces boilerplate and redundancy, while retaining composability.
-
-**[jumpsuit/jumpstate](https://github.com/jumpsuit/jumpstate)** <br />
-A simplified layer over Redux. No action creators or explicit dispatching, with a built-in simple side effects system.
 
 **[TheComfyChair/redux-scc](https://github.com/TheComfyChair/redux-scc)** <br />
 Takes a defined structure and uses 'behaviors' to create a set of actions, reducer responses and selectors.


### PR DESCRIPTION
---
name: :book: Updated Documentation Content
about: Update Ecosystem.md content
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**
The PR update the ecosystem.md section corresponding to the introduction page.
## Checklist

- [X] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/3941
- [X] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Ecosystem
- **Page**: Introduction


## For Updating Existing Content

### What updates should be made to the page?
Remove links to github repositories that are deprecated/archived.

