### PR TITLE
[Docs] add editPost route to App in essentials tutorial

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -303,7 +303,43 @@ export const EditPostForm = ({ match }) => {
 }
 ```
 
-Like with `SinglePostPage`, we'll need to import it into `App.js` and add a route that will render this component. We should also add a new link to our `SinglePostPage` that will route to `EditPostPage`, like:
+Like with `SinglePostPage`, we'll need to import it into `App.js` and add a route that will render this component:
+
+```jsx title="App.js"
+import { PostsList } from './features/posts/PostsList'
+import { AddPostForm } from './features/posts/AddPostForm'
+import { SinglePostPage } from './features/posts/SinglePostPage'
+// highlight-next-line
+import { EditPostForm } from './features/posts/EditPostForm'
+
+function App() {
+  return (
+    <Router>
+      <Navbar />
+      <div className="App">
+        <Switch>
+          <Route
+            exact
+            path="/"
+            render={() => (
+              <React.Fragment>
+                <AddPostForm />
+                <PostsList />
+              </React.Fragment>
+            )}
+          />
+          <Route exact path="/posts/:postId" component={SinglePostPage} />
+          // highlight-next-line
+          <Route exact path="/editPost/:postId" component={EditPostForm} />
+          <Redirect to="/" />
+        </Switch>
+      </div>
+    </Router>
+  )
+}
+```
+
+We should also add a new link to our `SinglePostPage` that will route to `EditPostPage`, like:
 
 ```jsx title="features/post/SinglePostPage.js"
 // highlight-next-line


### PR DESCRIPTION
in essentials tutorial part 4

---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**
update

## Checklist

- [x] Is there an existing issue for this PR?
  - _link issue here_ no
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: essentials tutorial
- **Page**: part 4

## For Adding New Content

### What kind of content category is this page (tutorial, how-to, explanation, reference)?

### Who is the intended target audience?

#### What knowledge are we assuming they have?

### What are the intended results or takeaways from reading this page?

### What is the most critical info they should learn?

## For Updating Existing Content

### What updates should be made to the page?
add the necessary code for the updated routes when adding the editPost form to the tutorial at the place it is needed.

### Do these updates change any of the assumptions or target audience? If so, how do they change?
no. They might help a comparative newbie (like myself) not to break the app when trying to follow the tutorial, though.