### PR TITLE
Fix typo: There should be to ways...

### DIFF
--- a/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
+++ b/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
@@ -117,7 +117,7 @@ Let's start by figuring out the initial business requirements for this applicati
   category tag for a predefined list of colors, and delete todo items.
 - The counter should pluralize the number of active todos: "0 items", "1 item", "3 items", etc
 - There should be buttons to mark all todos as completed, and to clear all completed todos by removing them
-- There should be to ways to filter the displayed todos in the list:
+- There should be two ways to filter the displayed todos in the list:
   - Filtering based on showing "All", "Active", and "Completed" todos
   - Filtering based on selecting one or more colors, and showing any todos whose tag that match those colors
 


### PR DESCRIPTION
Hi Redux maintainers, I think the right text should be _"There should be **two** ways to..."_

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: defining-requirements
- **Page**: docs/tutorials/fundamentals/part-3-state-actions-reducers.md

## What is the problem?

Missing letter in a word, leading to confusion

## What changes does this PR make to fix the problem?

Just fix the typo
