### PR TITLE
corrected todosDeleted export to todosToggled in converting the todos…

### DIFF
--- a/docs/tutorials/fundamentals/part-8-modern-redux.md
+++ b/docs/tutorials/fundamentals/part-8-modern-redux.md
@@ -380,7 +380,7 @@ const todosSlice = createSlice({
   }
 })
 
-export const { todoAdded, todoDeleted } = todosSlice.actions
+export const { todoAdded, todoToggled } = todosSlice.actions
 
 export default todosSlice.reducer
 // highlight-end


### PR DESCRIPTION
… reducer section

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  https://github.com/reduxjs/redux/issues/3956
- [ ] Have the files been linted and formatted?
  No
## What docs page needs to be fixed?

- **Converting the Todos Reducer**:
- **Tutorials -> Redux Fundamentals -> Part 8: Modern Redux with Redux Toolkit**:

## What is the problem?
`export const { todoAdded, todoDeleted } = todosSlice.actions`
todoToggled should be exported instead of todoDeleted

## What changes does this PR make to fix the problem?
changed todoDeleted to todoToggled in export 
