### PR TITLE
[Docs: Rephrase] Explain correctly what a thunk is

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -324,7 +324,7 @@ export default connector(MyComponent)
 
 ## Usage with Redux Thunk
 
-Redux Thunk is a commonly used middleware for writing sync and async logic that interacts with the Redux store. Feel free to check out its documentation [here](https://github.com/reduxjs/redux-thunk). A thunk is a function that returns another function that takes parameters `dispatch` and `getState`. Redux Thunk has a built in type `ThunkAction` which we can use to define types for those arguments:
+Redux Thunk is a commonly used middleware for writing sync and async logic that interacts with the Redux store. Feel free to check out its documentation [here](https://github.com/reduxjs/redux-thunk). A thunk is a function that wraps an expression for delaying the evaluation of that expression. In Redux, a thunk takes parameters `dispatch` and `getState`. Redux Thunk has a built in type `ThunkAction` which we can use to define types for those arguments:
 
 ```ts
 // src/thunks.ts


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - [issue 3972](https://github.com/reduxjs/redux/issues/3972)
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Recipes
- **Page**: Usage With TypeScript

## What is the problem?

In the paragraph [Usage with Redux Thunk](https://redux.js.org/recipes/usage-with-typescript#usage-with-redux-thunk), the concept of thunk is wrongly explained.

> A thunk is a function that returns another function that takes parameters dispatch and getState.

This definition corresponds to a **thunk action creator** but not to a thunk.
## What changes does this PR make to fix the problem?
Explain correctly what a thunk is.

