### PR TITLE
Link directly to #redux on Reactiflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is tiny (2kB, including dependencies), and has a rich ecosystem of addons.
 [![build status](https://img.shields.io/travis/reduxjs/redux/master.svg?style=flat-square)](https://travis-ci.org/reduxjs/redux)
 [![npm version](https://img.shields.io/npm/v/redux.svg?style=flat-square)](https://www.npmjs.com/package/redux)
 [![npm downloads](https://img.shields.io/npm/dm/redux.svg?style=flat-square)](https://www.npmjs.com/package/redux)
-[![redux channel on discord](https://img.shields.io/badge/discord-%23redux%20%40%20reactiflux-61dafb.svg?style=flat-square)](https://discord.gg/reactiflux)
+[![redux channel on discord](https://img.shields.io/badge/discord-%23redux%20%40%20reactiflux-61dafb.svg?style=flat-square)](https://discord.gg/0ZcbPKXt5bZ6au5t)
 [![Changelog #187](https://img.shields.io/badge/changelog-%23187-lightgrey.svg?style=flat-square)](https://changelog.com/187)
 
 ## Installation
@@ -69,7 +69,7 @@ The [**Redux Fundamentals tutorial**](https://redux.js.org/tutorials/fundamental
 
 ### Help and Discussion
 
-The **[#redux channel](https://discord.gg/reactiflux)** of the **[Reactiflux Discord community](http://www.reactiflux.com)** is our official resource for all questions related to learning and using Redux. Reactiflux is a great place to hang out, ask questions, and learn - please come and join us there!
+The **[#redux channel](https://discord.gg/0ZcbPKXt5bZ6au5t)** of the **[Reactiflux Discord community](http://www.reactiflux.com)** is our official resource for all questions related to learning and using Redux. Reactiflux is a great place to hang out, ask questions, and learn - please come and join us there!
 
 ## Before Proceeding Further
 

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -193,7 +193,7 @@ The [**Redux Fundamentals tutorial**](../tutorials/fundamentals/part-1-overview.
 
 ## Help and Discussion
 
-The **[#redux channel](https://discord.gg/reactiflux)** of the **[Reactiflux Discord community](http://www.reactiflux.com)** is our official resource for all questions related to learning and using Redux. Reactiflux is a great place to hang out, ask questions, and learn - come join us!
+The **[#redux channel](https://discord.gg/0ZcbPKXt5bZ6au5t)** of the **[Reactiflux Discord community](http://www.reactiflux.com)** is our official resource for all questions related to learning and using Redux. Reactiflux is a great place to hang out, ask questions, and learn - come join us!
 
 You can also ask questions on [Stack Overflow](https://stackoverflow.com) using the **[#redux tag](https://stackoverflow.com/questions/tagged/redux)**.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -80,7 +80,7 @@ module.exports = {
           items: [
             {
               label: 'Reactiflux Discord',
-              href: 'https://discord.gg/reactiflux'
+              href: 'https://discord.gg/0ZcbPKXt5bZ6au5t'
             },
             {
               label: 'Stack Overflow',


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Introduction
- **Page**: Getting Started with Redux

## What is the problem?
Links go to Reactiflux's #welcome channel which isn't specifically for Redux

## What changes does this PR make to fix the problem?
Link directly to #redux like other repositories in the organization