### PR TITLE
Fix id in example

### DIFF
--- a/docs/recipes/structuring-reducers/NormalizingStateShape.md
+++ b/docs/recipes/structuring-reducers/NormalizingStateShape.md
@@ -120,7 +120,7 @@ An example of a normalized state structure for the blog example above might look
                 comment : ".....",
             },
         },
-        allIds : ["comment1", "comment2", "comment3", "commment4", "comment5"]
+        allIds : ["comment1", "comment2", "comment3", "comment4", "comment5"]
     },
     users : {
         byId : {


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixed typo in id
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Recipes/Structuring reducers
- **Page**: Normalizing State Shape

## What is the problem?
There was a typo (`commment4`) in one of the examples.

## What changes does this PR make to fix the problem?
Based on logic of example, a typo was corrected for the corresponding `id`