### PR TITLE
Fixing link to WP redux site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <a href='https://redux.js.org'><img src='https://camo.githubusercontent.com/f28b5bc7822f1b7bb28a96d8d09e7d79169248fc/687474703a2f2f692e696d6775722e636f6d2f4a65567164514d2e706e67' height='60' alt='Redux Logo' aria-label='redux.js.org' /></a>
 
 Redux is a predictable state container for JavaScript apps.
-(Not to be confused with a WordPress framework – [Redux Framework](https://reduxframework.com/))
+(Not to be confused with a WordPress framework – [Redux Framework](https://redux.io))
 
 It helps you write applications that behave consistently, run in different environments (client, server, and native), and are easy to test. On top of that, it provides a great developer experience, such as [live code editing combined with a time traveling debugger](https://github.com/reduxjs/redux-devtools).
 


### PR DESCRIPTION
Fixing link to the WordPress Redux site in readme.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Intro
- **Page**: Top of first page

## What is the problem?

Outdated/broken link.

## What changes does this PR make to fix the problem?

Updates readme with correct link.