### PR TITLE
[Docs] Add a missing import

### DIFF
--- a/docs/tutorials/fundamentals/part-7-standard-patterns.md
+++ b/docs/tutorials/fundamentals/part-7-standard-patterns.md
@@ -309,7 +309,7 @@ import React from 'react'
 import { useSelector, shallowEqual } from 'react-redux'
 
 // highlight-next-line
-import { selectTodoIds }
+import { selectTodoIds } from './todosSlice'
 import TodoListItem from './TodoListItem'
 
 const TodoList = () => {

--- a/docs/tutorials/fundamentals/part-7-standard-patterns.md
+++ b/docs/tutorials/fundamentals/part-7-standard-patterns.md
@@ -316,7 +316,7 @@ const TodoList = () => {
   // highlight-next-line
   const todoIds = useSelector(selectTodoIds)
 
-  const renderedListItems = todoIds.map((todoId) => {
+  const renderedListItems = todoIds.map(todoId => {
     return <TodoListItem key={todoId} id={todoId} />
   })
 


### PR DESCRIPTION
## Checklist

- [ ] Is there an existing issue for this PR?
  - i don't know
- [ ] Have the files been linted and formatted?
  - no

## What docs page needs to be fixed?

- **Section**: Memoizing Selectors with `createSelector`
- **Page**: [Standard Redux Patterns](https://redux.js.org/tutorials/fundamentals/part-7-standard-patterns#memoizing-selectors-with-createselector)

## What is the problem?

Missing import

## What changes does this PR make to fix the problem?

adds the import