### PR TITLE
enhanced state derives from original

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -88,10 +88,7 @@ export default function createStore<
       throw new Error('Expected the enhancer to be a function.')
     }
 
-    return enhancer(createStore)(
-      reducer,
-      preloadedState as PreloadedState<S>
-    )
+    return enhancer(createStore)(reducer, preloadedState as PreloadedState<S>)
   }
 
   if (typeof reducer !== 'function') {

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -45,7 +45,7 @@ export default function createStore<
   StateExt = never
 >(
   reducer: Reducer<S, A>,
-  enhancer?: StoreEnhancer<Ext, StateExt>
+  enhancer?: StoreEnhancer<Ext, StateExt, S>
 ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 export default function createStore<
   S,
@@ -55,7 +55,7 @@ export default function createStore<
 >(
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState<S>,
-  enhancer?: StoreEnhancer<Ext, StateExt>
+  enhancer?: StoreEnhancer<Ext, StateExt, S>
 ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 export default function createStore<
   S,
@@ -64,8 +64,8 @@ export default function createStore<
   StateExt = never
 >(
   reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
-  enhancer?: StoreEnhancer<Ext, StateExt>
+  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt, S>,
+  enhancer?: StoreEnhancer<Ext, StateExt, S>
 ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext {
   if (
     (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
@@ -79,7 +79,7 @@ export default function createStore<
   }
 
   if (typeof preloadedState === 'function' && typeof enhancer === 'undefined') {
-    enhancer = preloadedState as StoreEnhancer<Ext, StateExt>
+    enhancer = preloadedState as StoreEnhancer<Ext, StateExt, S>
     preloadedState = undefined
   }
 
@@ -91,7 +91,7 @@ export default function createStore<
     return enhancer(createStore)(
       reducer,
       preloadedState as PreloadedState<S>
-    ) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
+    )
   }
 
   if (typeof reducer !== 'function') {

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -262,7 +262,11 @@ export interface StoreCreator {
 export type StoreEnhancer<Ext = {}, StateExt = never, TState = never> = (
   next: StoreEnhancerStoreCreator<Ext, StateExt, TState>
 ) => StoreEnhancerStoreCreator<Ext, StateExt, TState>
-export type StoreEnhancerStoreCreator<Ext = {}, StateExt = never, TState = any> = <
+export type StoreEnhancerStoreCreator<
+  Ext = {},
+  StateExt = never,
+  TState = any
+> = <
   S extends ([TState] extends [never] ? any : TState) | TState,
   A extends Action = AnyAction
 >(

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -263,7 +263,7 @@ export type StoreEnhancer<Ext = {}, StateExt = never, TState = never> = (
   next: StoreEnhancerStoreCreator<Ext, StateExt, TState>
 ) => StoreEnhancerStoreCreator<Ext, StateExt, TState>
 export type StoreEnhancerStoreCreator<Ext = {}, StateExt = never, TState = any> = <
-  S extends ([TState] extends [never] ? any : TState),
+  S extends ([TState] extends [never] ? any : TState) | TState,
   A extends Action = AnyAction
 >(
   reducer: Reducer<S, A>,

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -229,12 +229,12 @@ export interface Store<
 export interface StoreCreator {
   <S, A extends Action, Ext = {}, StateExt = never>(
     reducer: Reducer<S, A>,
-    enhancer?: StoreEnhancer<Ext, StateExt>
+    enhancer?: StoreEnhancer<Ext, StateExt, S>
   ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
   <S, A extends Action, Ext = {}, StateExt = never>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
-    enhancer?: StoreEnhancer<Ext>
+    enhancer?: StoreEnhancer<Ext, StateExt, S>
   ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
 }
 
@@ -259,11 +259,11 @@ export interface StoreCreator {
  * @template Ext Store extension that is mixed into the Store type.
  * @template StateExt State extension that is mixed into the state type.
  */
-export type StoreEnhancer<Ext = {}, StateExt = never> = (
-  next: StoreEnhancerStoreCreator<Ext, StateExt>
-) => StoreEnhancerStoreCreator<Ext, StateExt>
-export type StoreEnhancerStoreCreator<Ext = {}, StateExt = never> = <
-  S = any,
+export type StoreEnhancer<Ext = {}, StateExt = never, TState = never> = (
+  next: StoreEnhancerStoreCreator<Ext, StateExt, TState>
+) => StoreEnhancerStoreCreator<Ext, StateExt, TState>
+export type StoreEnhancerStoreCreator<Ext = {}, StateExt = never, TState = any> = <
+  S extends ([TState] extends [never] ? any : TState),
   A extends Action = AnyAction
 >(
   reducer: Reducer<S, A>,

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -300,7 +300,7 @@ function originalStateShapeEnhancer() {
   const originalShapeEnhancer = <TState>(
     initialStateEnhancement: (state: PreloadedState<TState> | undefined) => PreloadedState<TState>,
     reducerDecorator: <S extends TState, A extends AnyAction>(reducer: Reducer<S, A>) => Reducer<S, A>
-  ): StoreEnhancer<{}, never, TState> => next => <S extends ([TState] extends [never] ? any : TState), A extends Action>(
+  ): StoreEnhancer<{}, never, TState> => next => <S extends TState, A extends Action>(
     reducer: Reducer<S, A>,
     state?: PreloadedState<S>
   ) => {

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -1,5 +1,13 @@
 import { create } from 'domain'
-import { StoreEnhancer, Action, AnyAction, Reducer, createStore, PreloadedState, StoreEnhancerStoreCreator } from '../..'
+import {
+  StoreEnhancer,
+  Action,
+  AnyAction,
+  Reducer,
+  createStore,
+  PreloadedState,
+  StoreEnhancerStoreCreator
+} from '../..'
 
 interface State {
   someField: 'string' | 'enhanced!'
@@ -298,18 +306,29 @@ function finalHelmersonExample() {
 
 function originalStateShapeEnhancer() {
   const originalShapeEnhancer = <TState>(
-    initialStateEnhancement: (state: PreloadedState<TState> | undefined) => PreloadedState<TState>,
-    reducerDecorator: <S extends TState, A extends AnyAction>(reducer: Reducer<S, A>) => Reducer<S, A>
-  ): StoreEnhancer<{}, never, TState> => next => <S extends TState, A extends Action>(
+    initialStateEnhancement: (
+      state?: PreloadedState<TState>
+    ) => PreloadedState<TState>,
+    reducerDecorator: <S extends TState, A extends AnyAction>(
+      reducer: Reducer<S, A>
+    ) => Reducer<S, A>
+  ): StoreEnhancer<{}, never, TState> => next => <
+    S extends TState,
+    A extends Action
+  >(
     reducer: Reducer<S, A>,
     state?: PreloadedState<S>
   ) => {
     const extendedInitialState = initialStateEnhancement(state)
-    const enhancedInitialState = (extendedInitialState ? { ...state, ...extendedInitialState } : state) as PreloadedState<S> | undefined
+    const enhancedInitialState = (extendedInitialState
+      ? { ...state, ...extendedInitialState }
+      : state) as PreloadedState<S> | undefined
 
     return next(reducerDecorator(reducer), enhancedInitialState)
-  };
-  const reducerDecorator = <S extends State, A extends AnyAction>(reducer: Reducer<S, A>): Reducer<S, A> => (state, action) => {
+  }
+  const reducerDecorator = <S extends State, A extends AnyAction>(
+    reducer: Reducer<S, A>
+  ): Reducer<S, A> => (state, action) => {
     state?.someField
     // typings:expect-error
     state?.wrongField
@@ -321,9 +340,12 @@ function originalStateShapeEnhancer() {
     state?.wrongField
 
     return newState
-  };
+  }
 
-  const store = createStore(reducer, originalShapeEnhancer(_ => ({someField: 'enhanced!'}), reducerDecorator))
+  const store = createStore(
+    reducer,
+    originalShapeEnhancer(_ => ({ someField: 'enhanced!' }), reducerDecorator)
+  )
 
   store.getState().someField
   // typings:expect-error


### PR DESCRIPTION
:bug: Bug fix: by design the resulting state type of any enhancer is based on the original type.  Providing this relationship in the generic constraints allows enhancers to gain type safety based on the original type.

use case: a slice of the state may need to be altered or acted upon as a decorator around the original reducer (allowing an enhancer to act as a decorator, not changing the original store or reducer)
- https://github.com/hypnopotamus/ReduxPersistentStoreEnhancer
  - the types in this potential package will need to be adjusted to what the type changes ended up actually being (TState is the last parameter, not the first)
  - specifically, the case that lead to this persistence reducer: state contained a session object that needed to persist through page refreshes => session storage.  The entire state did not need to be persisted, only the session slice.
