### PR TITLE
Update test example on todosSlice reducer

### DIFF
--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -164,7 +164,7 @@ take the result, and check to see if it matches what you expect:
 ```js title="todosSlice.spec.js"
 import todosReducer from './todosSlice'
 
-test(('Toggles a todo based on id') => {
+test(('Toggles a todo based on id'), () => {
   const initialState = [{ id: 0, text: 'Test text', completed: false }]
 
   const action = { type: 'todos/todoToggled', payload: 0 }

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -164,7 +164,7 @@ take the result, and check to see if it matches what you expect:
 ```js title="todosSlice.spec.js"
 import todosReducer from './todosSlice'
 
-test(('Toggles a todo based on id'), () => {
+test('Toggles a todo based on id', () => {
   const initialState = [{ id: 0, text: 'Test text', completed: false }]
 
   const action = { type: 'todos/todoToggled', payload: 0 }


### PR DESCRIPTION
Corrected a syntax error on the todosSlice reducer.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials
- **Page**: part-4-store

## What is the problem?

The example for the unit-testing of the reducer did not have the proper syntax and was giving the following error

`Parsing error: Binding invalid left-hand side in function parameter list` 

## What changes does this PR make to fix the problem?

I corrected the syntax to the proper one. Really minor fix.
