### PR TITLE
Update egghead links in Learning Resources

### DIFF
--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -16,12 +16,12 @@ This page includes our recommendations for some of the best external resources a
 _Tutorials that teach the basic concepts of Redux and how to use it_
 
 - **Getting Started with Redux - Video Series** <br/>
-  https://egghead.io/series/getting-started-with-redux <br/>
+  https://app.egghead.io/courses/getting-started-with-redux <br/>
   https://github.com/tayiorbeii/egghead.io_redux_course_notes <br/>
   Dan Abramov, the creator of Redux, demonstrates various concepts in 30 short (2-5 minute) videos. The linked Github repo contains notes and transcriptions of the videos.
 
 - **Building React Applications with Idiomatic Redux - Video Series** <br/>
-  https://egghead.io/series/building-react-applications-with-idiomatic-redux <br/>
+  https://app.egghead.io/courses/building-react-applications-with-idiomatic-redux <br/>
   https://github.com/tayiorbeii/egghead.io_idiomatic_redux_course_notes <br/>
   Dan Abramov's second video tutorial series, continuing directly after the first. Includes lessons on store initial state, using Redux with React Router, using "selector" functions, normalizing state, use of Redux middleware, async action creators, and more. The linked Github repo contains notes and transcriptions of the videos.
 


### PR DESCRIPTION
## Checklist

- [X] Is there an existing issue for this PR?
      No 
- [X] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Introduction
- **Page**: LearningResources

## For Updating Existing Content

### What updates should be made to the page?
The link for a specific redux tutorial is not updated. It directs to a page that later asks the users to go to the new tutorial page. It would be better if the new link is added to save time and be on the safer side (just in case the older link is closed by the author).
### Do these updates change any of the assumptions or target audience? If so, how do they change?
No, they do not change any assumptions.