### PR TITLE
[Docs] Remove references to deprecated libraries in docs

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -670,22 +670,6 @@ const DynamicCounters = connectLean(
 )(CounterList);
 ```
 
-**[ioof-holdings/redux-subspace](https://github.com/ioof-holdings/redux-subspace)** <br />
-Creates isolated "sub-stores" for decoupled micro front-ends, with integration for React, sagas, and observables
-
-```js
-const reducer = combineReducers({
-  subApp1: namespaced('subApp1')(counter),
-  subApp2: namespaced('subApp2')(counter)
-})
-
-const subApp1Store = subspace(state => state.subApp1, 'subApp1')(store)
-const subApp2Store = subspace(state => state.subApp2, 'subApp2')(store)
-
-subApp1Store.dispatch({ type: 'INCREMENT' })
-console.log('store state:', store.getState()) // { "subApp1": { value: 2 }, "subApp2": { value: 1 } }
-```
-
 **[DataDog/redux-doghouse](https://github.com/DataDog/redux-doghouse)** <br />
 Aims to make reusable components easier to build with Redux by scoping actions and reducers to a particular instance of a component.
 

--- a/docs/recipes/CodeSplitting.md
+++ b/docs/recipes/CodeSplitting.md
@@ -159,8 +159,6 @@ To remove a reducer, one can now call `store.reducerManager.remove("asyncState")
 
 There are a few good libraries out there that can help you add the above functionality automatically:
 
-- [`redux-dynostore`](https://github.com/ioof-holdings/redux-dynostore):
-  Provides tools for building dynamic Redux stores, including dynamically adding reducers and sagas, and React bindings to help you add in association with components.
 - [`redux-dynamic-modules`](https://github.com/Microsoft/redux-dynamic-modules):
   This library introduces the concept of a 'Redux Module', which is a bundle of Redux artifacts (reducers, middleware) that should be dynamically loaded. It also exposes a React higher-order component to load 'modules' when areas of the application come online. Additionally, it has integrations with libraries like `redux-thunk` and `redux-saga` which also help dynamically load their artifacts (thunks, sagas).
 - [Redux Ecosystem Links: Reducers - Dynamic Reducer Injection](https://github.com/markerikson/redux-ecosystem-links/blob/master/reducers.md#dynamic-reducer-injection)


### PR DESCRIPTION
---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**

Update existing pages

## Checklist

- [ ] Is there an existing issue for this PR?
  - No existing issue.  Happy to create one if you want?
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Introduction**:
  - **Ecosystem**:
- **Recipes**:
  - **Code Splitting**:

### What updates should be made to the page?

There are references to some (of my) libraries that have recently been deprecated and archived:

ioof-holdings/redux-subspace#546
ioof-holdings/redux-dynostore#484

Removing them will help users not to choose an unmaintained option.

### Do these updates change any of the assumptions or target audience? If so, how do they change?

No.
