### PR TITLE
fix: Export type of $CombinedState

### DIFF
--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -20,6 +20,7 @@ export type ExtendState<State, Extension> = [Extension] extends [never]
  * Internal "virtual" symbol used to make the `CombinedState` type unique.
  */
 declare const $CombinedState: unique symbol
+export type { $CombinedState }
 
 /**
  * State base type for reducers created with `combineReducers()`.


### PR DESCRIPTION
---
name: Export type of $CombinedState
about: Support latest version of Typescript
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Fix a bug with lastest version of Typescript

### Why should this PR be included?
Exporting the result of `combineReducers` currently fails with latest version of Typescript, requires access to `$CombinedState`.

See `Bug Fixed -> What is the current behavior, and the steps to reproduce the issue?` for in-depth explanation

Only the type is exported, so it is not possible a consumer thinks the value is actually usable (no risk)

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - None, but can create if needs to be discussed further
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## New Features
Typeof `$CombinedState` is exported an available to consumers

### What new capabilities does this PR add?
Adds support for Typescript exporting the result of `combineReducers` with latest version of typescript

### What docs changes are needed to explain this?
None

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Upgrade to [typescript v2.4.2](https://github.com/microsoft/TypeScript/releases/tag/v4.2.2)

Create a file `example.ts` with the following content:
```
import { combineReducers, $CombinedState } from 'redux';

export default combineReducers({})
```

Typescript will emit an error on:
`Default export of the module has or is using private name '$CombinedState'.`

### What is the expected behavior?
No error should be emitted

### How does this PR fix the problem?
By explicitly exporting the typeof `$CombinedState`, Typescript will be able to properly handle an exported `combineReducers`

Admittedly this mostly feels like an issue with Typescript (the type is already available to import) but it is an otherwise safe, non-breaking change so it is worth fixing at the Redux level
