### PR TITLE
fix: Declare "EmptyObject" interface to wrap $CombinedState

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,16 +53,17 @@ declare const $CombinedState: unique symbol
  * typed as always undefined, so its never expected to have a meaningful
  * value anyway. It just makes this type distinquishable from plain `{}`.
  */
-export type CombinedState<S> = { readonly [$CombinedState]?: undefined } & S
+interface EmptyObject {
+  readonly [$CombinedState]?: undefined
+}
+export type CombinedState<S> = EmptyObject & S
 
 /**
  * Recursively makes combined state objects partial. Only combined state _root
  * objects_ (i.e. the generated higher level object with keys mapping to
  * individual reducers) are partial.
  */
-export type PreloadedState<S> = Required<S> extends {
-  [$CombinedState]: undefined
-}
+export type PreloadedState<S> = Required<S> extends EmptyObject
   ? S extends CombinedState<infer S1>
     ? {
         [K in keyof S1]?: S1[K] extends object ? PreloadedState<S1[K]> : S1[K]


### PR DESCRIPTION
---
name: Declare EmptyObject interface to wrap $CombinedState
about: Adding interface for $CombinedState appeases latest version of Typescript, allows exporting result of `combineReducers`
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Fix a bug with lastest version of Typescript

### Why should this PR be included?
No changes to exports are included, but the internal change from type->interface allows Typescript to correctly reference/export usage of `$CombinedState`

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - closes https://github.com/reduxjs/redux/issues/4030
  - Previous PR, different attempt at solution https://github.com/reduxjs/redux/pull/4026
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## New Features

### What new capabilities does this PR add?
None, just maintains support of typescript with latest 4.2.x releases

### What docs changes are needed to explain this?
None

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Upgrade to typescript v2.4.2

Create a file `example.ts` with the following content:

```
import { combineReducers, $CombinedState } from 'redux';

export default combineReducers({})
```
make sure `declarations: true` is in your `tsconfig.json`

Typescript will emit an error on:
`Default export of the module has or is using private name '$CombinedState'.`

Also see https://github.com/reduxjs/redux/pull/4029 for minimal reproducible issue

### What is the expected behavior?
No error should be emitted

### How does this PR fix the problem?

`combineReducers<S>()` returns a type of `Reducer<CombinedState<S>>`, and the `CombinedState<S>` is the type in question in this PR

https://www.typescriptlang.org/docs/handbook/advanced-types.html#interfaces-vs-type-aliases
Digging a bit into how Typescript works, but basically a `type` is an alias. So any usage of a `type` that internally uses `$CombinedState` means the resulting declaration must also use `$CombinedState`. Since that value is not exported, Typescript fails.

Using an interface however does not need direct access to `$CombinedState`, so the exporting of `combineReducers` will magically succeed.
