### PR TITLE
[Docs] Use direct course link instead of redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The [**Redux Fundamentals tutorial**](https://redux.js.org/tutorials/fundamental
 ### Additional Tutorials
 
 - The Redux repository contains several example projects demonstrating various aspects of how to use Redux. Almost all examples have a corresponding CodeSandbox sandbox. This is an interactive version of the code that you can play with online. See the complete list of examples in the **[Examples page](https://redux.js.org/introduction/examples)**.
-- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://app.egghead.io/series/getting-started-with-redux.)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
+- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://app.egghead.io/series/getting-started-with-redux)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
 - Redux maintainer Mark Erikson's **["Redux Fundamentals" conference talk](https://blog.isquaredsoftware.com/2018/03/presentation-reactathon-redux-fundamentals/)** and [**"Redux Fundamentals" workshop slides**](https://blog.isquaredsoftware.com/2018/06/redux-fundamentals-workshop-slides/)
 - Dave Ceddia's post [**A Complete React Redux Tutorial for Beginners**](https://daveceddia.com/redux-tutorial/)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The [**Redux Fundamentals tutorial**](https://redux.js.org/tutorials/fundamental
 ### Additional Tutorials
 
 - The Redux repository contains several example projects demonstrating various aspects of how to use Redux. Almost all examples have a corresponding CodeSandbox sandbox. This is an interactive version of the code that you can play with online. See the complete list of examples in the **[Examples page](https://redux.js.org/introduction/examples)**.
-- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://egghead.io/series/getting-started-with-redux)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
+- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://app.egghead.io/series/getting-started-with-redux.)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
 - Redux maintainer Mark Erikson's **["Redux Fundamentals" conference talk](https://blog.isquaredsoftware.com/2018/03/presentation-reactathon-redux-fundamentals/)** and [**"Redux Fundamentals" workshop slides**](https://blog.isquaredsoftware.com/2018/06/redux-fundamentals-workshop-slides/)
 - Dave Ceddia's post [**A Complete React Redux Tutorial for Beginners**](https://daveceddia.com/redux-tutorial/)
 

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -180,7 +180,7 @@ The [**Redux Fundamentals tutorial**](../tutorials/fundamentals/part-1-overview.
 ### Additional Tutorials
 
 - The Redux repository contains several example projects demonstrating various aspects of how to use Redux. Almost all examples have a corresponding CodeSandbox sandbox. This is an interactive version of the code that you can play with online. See the complete list of examples in the **[Examples page](./Examples.md)**.
-- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://app.egghead.io/series/getting-started-with-redux.)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
+- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://app.egghead.io/series/getting-started-with-redux)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
 - Redux maintainer Mark Erikson's **["Redux Fundamentals" conference talk](https://blog.isquaredsoftware.com/2018/03/presentation-reactathon-redux-fundamentals/)** and [**"Redux Fundamentals" workshop slides**](https://blog.isquaredsoftware.com/2018/06/redux-fundamentals-workshop-slides/)
 - Dave Ceddia's post [**A Complete React Redux Tutorial for Beginners**](https://daveceddia.com/redux-tutorial/)
 

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -180,7 +180,7 @@ The [**Redux Fundamentals tutorial**](../tutorials/fundamentals/part-1-overview.
 ### Additional Tutorials
 
 - The Redux repository contains several example projects demonstrating various aspects of how to use Redux. Almost all examples have a corresponding CodeSandbox sandbox. This is an interactive version of the code that you can play with online. See the complete list of examples in the **[Examples page](./Examples.md)**.
-- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://egghead.io/series/getting-started-with-redux)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
+- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://app.egghead.io/series/getting-started-with-redux.)** and **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** video courses on Egghead.io
 - Redux maintainer Mark Erikson's **["Redux Fundamentals" conference talk](https://blog.isquaredsoftware.com/2018/03/presentation-reactathon-redux-fundamentals/)** and [**"Redux Fundamentals" workshop slides**](https://blog.isquaredsoftware.com/2018/06/redux-fundamentals-workshop-slides/)
 - Dave Ceddia's post [**A Complete React Redux Tutorial for Beginners**](https://daveceddia.com/redux-tutorial/)
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix for course URL
about: Existing course points to a redirect instead of the direct link
---

## Checklist

- [x] Is there an existing issue for this PR?
  - Too minor to add one
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Introduction
- **Page**: Getting Started with Redux

## What is the problem?

With the current link when the user navigates, it shows this 404 message, I just use the link in the error to land the users in the correct page without having to redirect.

<img width="682" alt="Screenshot 2021-03-13 at 12 41 12" src="https://user-images.githubusercontent.com/1938043/111028804-67699480-83f9-11eb-8a88-ee19bd80a180.png">


## What changes does this PR make to fix the problem?

Adds `app.` to the current link
