### PR TITLE
Update key event property - Closes Issue #4040

### DIFF
--- a/docs/tutorials/fundamentals/part-5-ui-and-react.md
+++ b/docs/tutorials/fundamentals/part-5-ui-and-react.md
@@ -246,7 +246,7 @@ const Header = () => {
   const handleKeyDown = e => {
     const trimmedText = e.target.value.trim()
     // If the user pressed the Enter key:
-    if (e.which === 13 && trimmedText) {
+    if (e.key === 'Enter' && trimmedText) {
       // highlight-start
       // Dispatch the "todo added" action with this text
       dispatch({ type: 'todos/todoAdded', payload: trimmedText })


### PR DESCRIPTION
Related to Redux Fundamentals Tutorial - Part 5, UI & React. Previously
the `handleKeyDown` event handler was evaluating key press values using
`e.which`, which is deprecated. Updated to `e.key`. [This property has
wide browser
support](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#browser_compatibility)

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [√ ] Is there an existing issue for this PR?
  - [Issue](https://github.com/reduxjs/redux/issues/4040)
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:  [Redux Fundamentals, Part 5 : UI & React](https://redux.js.org/tutorials/fundamentals/part-5-ui-react#redux-fundamentals-part-5-ui-and-react)
- **Page**:  [Dispatching Actions with useDispatch()](https://redux.js.org/tutorials/fundamentals/part-5-ui-react#dispatching-actions-with-usedispatch)

## What is the problem?

- The keydown event listener is comparing the key value using a deprecated property, `e.which`.

## What changes does this PR make to fix the problem?

- Updated to `e.key`, which has wide browser support. 
