### PR TITLE
Rewrite "Usage with TS" guide page

### DIFF
--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -6,238 +6,212 @@ hide_title: true
 
 # Usage with TypeScript
 
+:::tip What You'll Learn
+
+- Standard patterns for setting up a Redux app with TypeScript
+- Techniques for correctly typing portions of Redux logic
+
+:::
+
+:::important Prerequisites
+
+- Understanding of [TypeScript syntax and terms](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
+- Familiarity with TypeScript concepts like [generics](https://www.typescriptlang.org/docs/handbook/2/generics.html) and [utility types](https://www.typescriptlang.org/docs/handbook/utility-types.html)
+- Knowledge of [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+
+:::
+
 ## Overview
 
-**TypeScript** is a typed superset of JavaScript. It has become popular recently in applications due to the benefits it can bring. If you are new to TypeScript it is highly recommended to become familiar with it first before proceeding. You can check out its documentation [here.](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
-
-TypeScript has the potential to bring the following benefits to a Redux application:
+**TypeScript** is a typed superset of JavaScript that provides compile-time checking of source code. When used with Redux, TypeScript can help provide:
 
 1. Type safety for reducers, state and action creators, and UI components
 2. Easy refactoring of typed code
 3. A superior developer experience in a team environment
 
-## Notes & Considerations
+[**We strongly recommend using TypeScript in Redux applications**](../style-guide/style-guide.md#use-static-typing). However, like all tools, TypeScript has tradeoffs. It adds complexity in terms of writing additional code, understanding TS syntax, and building the application. At the same time, it provides value by catching errors early, enabling correct refactoring, and acting as documentation for existing source code. We believe that **[pragmatic use of Typescript](https://blog.isquaredsoftware.com/2019/11/blogged-answers-learning-and-using-typescript/#pragmatism-is-vital) provides more than enough value and benefit to justify the added overhead**, especially in larger codebases, but you should take time to **evaluate the tradeoffs and decide whether it's worth using TS in your own application**.
 
-- While we do [officially recommend use of static typing with Redux](../style-guide/style-guide.md#use-static-typing), use of TypeScript does have tradeoffs in terms of setup, amount of code written, and readability. TypeScript will likely provide a net benefit in larger apps or codebases need to be maintained over time by many people, but may feel like too much overhead in smaller projects. Take time to evaluate the tradeoffs and decide whether it's worth using TS in your own application.
-- This page primarily covers adding type checking for the Redux core, and only gives shorter examples of using TS with other Redux libraries. See their respective documentation for further details.
-- There are multiple possible approaches to type checking Redux code. This page demonstrates some of the common and recommended approaches to keep things simple, and is not an exhaustive guide
+There are multiple possible approaches to type checking Redux code. This page demonstrates some of the common and recommended approaches to keep things simple, and is not an exhaustive guide.
 
-## A Practical Example
+## Standard Redux Toolkit Project Setup with TypeScript
 
-We will be going through a simplistic chat application to demonstrate a possible approach to include static typing. This chat application will have two reducers. The _chat reducer_ will focus on storing the chat history and the _system reducer_ will focus on storing session information.
+We assume that a typical Redux project is using Redux Toolkit and React Redux together.
 
-The full source code is available on [codesandbox here](https://codesandbox.io/s/w02m7jm3q7). Note that by going through this example yourself you will experience some of the benefits of using TypeScript.
+[Redux Toolkit](https://redux-toolkit.js.org) (RTK) is the standard approach for writing modern Redux logic. RTK is already written in TypeScript, and its API is designed to provide a good experience for TypeScript usage.
 
-### Type Checking State
+[React-Redux](https://react-redux.js.org) doesn't ship with its own type definitions. If you are using Typescript you should install the [`@types/react-redux` type definitions](https://npm.im/@types/react-redux) from npm. In addition to typing the library functions, the types also export some helpers to make it easier to write typesafe interfaces between your Redux store and your React components.
 
-Adding types to each slice of state is a good place to start since it does not rely on other types. In this example we start by describing the chat reducer's slice of state:
+The [Redux+TS template for Create-React-App](https://github.com/reduxjs/cra-template-redux-typescript) comes with a working example of these patterns already configured.
 
-```ts
-// src/store/chat/types.ts
+### Define Root State and Dispatch Types
 
-export interface Message {
-  user: string
-  message: string
-  timestamp: number
-}
+Using [configureStore](https://redux-toolkit.js.org/api/configureStore) should not need any additional typings. You will, however, want to extract the `RootState` type and the `Dispatch` type so that they can be referenced as needed. Inferring these types from the store itself means that they correctly update as you add more state slices or modify middleware settings.
 
-export interface ChatState {
-  messages: Message[]
-}
-```
+Since those are types, it's safe to export them directly from your store setup file such as `app/store.ts` and import them directly into other files.
 
-And then do the same for the system reducer's slice of state:
+```ts title="app/store.ts"
+import { configureStore } from '@reduxjs/toolkit'
+// ...
 
-```ts
-// src/store/system/types.ts
-
-export interface SystemState {
-  loggedIn: boolean
-  session: string
-  userName: string
-}
-```
-
-Note that we are exporting these interfaces to reuse them later in reducers and action creators.
-
-### Type Checking Actions & Action Creators
-
-We will be using string literals and using `typeof` to declare our action constants and infer types. Note that we are making a tradeoff here when we declare our types in a separate file. In exchange for separating our types into a separate file, we get to keep our other files more focused on their purpose. While this tradeoff can improve the maintainability of the codebase, it is perfectly fine to organize your project however you see fit.
-
-Chat Action Constants & Shape:
-
-```ts
-// src/store/chat/types.ts
-export const SEND_MESSAGE = 'SEND_MESSAGE'
-export const DELETE_MESSAGE = 'DELETE_MESSAGE'
-
-interface SendMessageAction {
-  type: typeof SEND_MESSAGE
-  payload: Message
-}
-
-interface DeleteMessageAction {
-  type: typeof DELETE_MESSAGE
-  meta: {
-    timestamp: number
+const store = configureStore({
+  reducer: {
+    one: oneSlice.reducer,
+    two: twoSlice.reducer
   }
-}
+})
 
-export type ChatActionTypes = SendMessageAction | DeleteMessageAction
+// highlight-start
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+// highlight-end
 ```
 
-Note that we are using TypeScript's Union Type here to express all possible actions.
+### Define Typed Hooks
 
-With these types declared we can now also type check chat's action creators. In this case we are taking advantage of TypeScript's inference:
+While it's possible to import the `RootState` and `AppDispatch` types into each component, it's better to create typed versions of the `useDispatch` and `useSelector` hooks for usage in your application. This is important for a couple reasons:
 
-```ts
-// src/store/chat/actions.ts
+- For `useSelector`, it saves you the need to type `(state: RootState)` every time
+- For `useDispatch`, the default `Dispatch` type does not know about thunks. In order to correctly dispatch thunks, you need to use the specific customized `AppDispatch` type from the store that includes the thunk middleware types, and use that with `useDispatch`. Adding a pre-typed `useDispatch` hook keeps you from forgetting to import `AppDispatch` where it's needed.
 
-import { Message, SEND_MESSAGE, DELETE_MESSAGE, ChatActionTypes } from './types'
+Since these are actual variables, not types, it's important to define them in a separate file such as `app/hooks.ts`, not the store setup file. This allows you to import them into any component file that needs to use the hooks, and avoids potential circular import dependency issues.
 
-// TypeScript infers that this function is returning SendMessageAction
-export function sendMessage(newMessage: Message): ChatActionTypes {
-  return {
-    type: SEND_MESSAGE,
-    payload: newMessage
-  }
+```ts title="app/hooks.ts"
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import { RootState, AppDispatch } from './store'
+
+// highlight-start
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+// highlight-end
+```
+
+## Application Usage
+
+### Define Slice State and Action Types
+
+Each slice file should define a type for its initial state value, so that `createSlice` can correctly infer the type of `state` in each case reducer.
+
+All generated actions should be defined using the `PayloadAction<T>` type from Redux Toolkit, which takes the type of the `action.payload` field as its generic argument.
+
+You can safely import the `RootState` type from the store file here. It's a circular import, but the TypeScript compiler can correctly handle that for types. This may be needed for use cases like writing selector functions.
+
+```ts title="features/counter/counterSlice.ts"
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from '../../app/store'
+
+// highlight-start
+// Define a type for the slice state
+interface CounterState {
+  value: number
 }
 
-// TypeScript infers that this function is returning DeleteMessageAction
-export function deleteMessage(timestamp: number): ChatActionTypes {
-  return {
-    type: DELETE_MESSAGE,
-    meta: {
-      timestamp
+// Define the initial state using that type
+const initialState: CounterState = {
+  value: 0
+}
+// highlight-end
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  // `createSlice` will infer the state type from the `initialState` argument
+  initialState,
+  reducers: {
+    increment: state => {
+      state.value += 1
+    },
+    decrement: state => {
+      state.value -= 1
+    },
+    // highlight-start
+    // Use the PayloadAction type to declare the contents of `action.payload`
+    incrementByAmount: (state, action: PayloadAction<number>) => {
+      // highlight-end
+      state.value += action.payload
     }
   }
+})
+
+export const { increment, decrement, incrementByAmount } = counterSlice.actions
+
+// Other code such as selectors can use the imported `RootState` type
+export const selectCount = (state: RootState) => state.counter.value
+
+export default counterSlice.reducer
+```
+
+The generated action creators will be correctly typed to accept a `payload` argument based on the `PayloadAction<T>` type you provided for the reducer. For example, `incrementByAmount` requires a `number` as its argument.
+
+### Use Typed Hooks in Components
+
+In component files, import the pre-typed hooks instead of the standard hooks from React-Redux.
+
+```tsx title="features/counter/Counter.tsx"
+import React, { useState } from 'react'
+
+// highlight-next-line
+import { useAppSelector, useAppDispatch } from 'app/hooks'
+
+import { decrement, increment } from './counterSlice'
+
+export function Counter() {
+  // highlight-start
+  // The `state` arg is correctly typed as `RootState` already
+  const count = useAppSelector(state => state.counter.value)
+  const dispatch = useAppDispatch()
+  // highlight-end
+
+  // omit rendering logic
 }
 ```
 
-System Action Constants & Shape:
-
-```ts
-// src/store/system/types.ts
-export const UPDATE_SESSION = 'UPDATE_SESSION'
-
-interface UpdateSessionAction {
-  type: typeof UPDATE_SESSION
-  payload: SystemState
-}
-
-export type SystemActionTypes = UpdateSessionAction
-```
-
-With these types we can now also type check system's action creators:
-
-```ts
-// src/store/system/actions.ts
-
-import { SystemState, UPDATE_SESSION, SystemActionTypes } from './types'
-
-export function updateSession(newSession: SystemState): SystemActionTypes {
-  return {
-    type: UPDATE_SESSION,
-    payload: newSession
-  }
-}
-```
+## Typing Additional Redux Logic
 
 ### Type Checking Reducers
 
-Reducers are just pure functions that take the previous state, an action and then return the next state. In this example, we explicitly declare the type of actions this reducer will receive along with what it should return (the appropriate slice of state). With these additions TypeScript will give rich intellisense on the properties of our actions and state. In addition, we will also get errors when a certain case does not return the `ChatState`.
+[Reducers](../tutorials/fundamentals/part-3-state-actions-reducers.md) are pure functions that receive the current `state` and incoming `action` as arguments, and return a new state.
 
-Type checked chat reducer:
+If you are using Redux Toolkit's `createSlice`, you should rarely need to specifically type a reducer separately. If you do actually write a standalone reducer, it's typically sufficient to declare the type of the `initialState` value, and type the `action` as `AnyAction<string>`:
 
 ```ts
-// src/store/chat/reducers.ts
+import { AnyAction } from 'redux'
 
-import {
-  ChatState,
-  ChatActionTypes,
-  SEND_MESSAGE,
-  DELETE_MESSAGE
-} from './types'
-
-const initialState: ChatState = {
-  messages: []
+interface CounterState {
+  value: number
 }
 
-export function chatReducer(
+const initialState: CounterState = {
+  value: 0
+}
+
+export default function counterReducer(
   state = initialState,
-  action: ChatActionTypes
-): ChatState {
-  switch (action.type) {
-    case SEND_MESSAGE:
-      return {
-        messages: [...state.messages, action.payload]
-      }
-    case DELETE_MESSAGE:
-      return {
-        messages: state.messages.filter(
-          message => message.timestamp !== action.meta.timestamp
-        )
-      }
-    default:
-      return state
-  }
+  action: AnyAction<string>
+) {
+  // logic here
 }
 ```
 
-Type checked system reducer:
+However, the Redux core does export a `Reducer<State, Action>` type you can use as well.
+
+### Type Checking Middleware
+
+[Middleware](../tutorials/fundamentals/part-4-store.md#middleware) are an extension mechanism for the Redux store. Middleware are composed into a pipeline that wrap the store's `dispatch` method, and have access to the store's `dispatch` and `getState` methods.
+
+The Redux core exports a `Middleware` type that can be used to correctly type a middleware function:
 
 ```ts
-// src/store/system/reducers.ts
-
-import { SystemState, SystemActionTypes, UPDATE_SESSION } from './types'
-
-const initialState: SystemState = {
-  loggedIn: false,
-  session: '',
-  userName: ''
-}
-
-export function systemReducer(
-  state = initialState,
-  action: SystemActionTypes
-): SystemState {
-  switch (action.type) {
-    case UPDATE_SESSION: {
-      return {
-        ...state,
-        ...action.payload
-      }
-    }
-    default:
-      return state
-  }
-}
+export interface Middleware<
+  DispatchExt = {}, // legacy type parameter that is no longer relevant
+  S = any, // type of the Redux store state
+  D extends Dispatch = Dispatch // type of the dispatch method
+>
 ```
 
-We now need to generate the root reducer function, which is normally done using `combineReducers`. Note that we do not have to explicitly declare a new interface for RootState. We can use `ReturnType` to infer state shape from the `rootReducer`.
+A custom middleware should use the `Middleware` type, and pass the generic args for `S` (state) and `D` (dispatch) if needed:
 
 ```ts
-// src/store/index.ts
-
-import { systemReducer } from './system/reducers'
-import { chatReducer } from './chat/reducers'
-
-const rootReducer = combineReducers({
-  system: systemReducer,
-  chat: chatReducer
-})
-
-export type RootState = ReturnType<typeof rootReducer>
-```
-
-### Type Checking Middlewares
-
-A middleware is a higher-order function that composes a dispatch function to return a new dispatch function.
-To create a type checked middleware function, we can leverage the `Middleware` interface provided by Redux together with our store type (as defined in the previous example):
-
-```ts
-// src/middleware/example.ts
-
 import { Middleware } from 'redux'
 
 import { RootState } from '../store'
@@ -245,20 +219,80 @@ import { RootState } from '../store'
 export const exampleMiddleware: Middleware<
   {}, // legacy type parameter added to satisfy interface signature
   RootState
-> = store => next => action => {
-  // code here
+> = storeApi => next => action => {
+  const state = storeApi.getState() // correctly typed as RootState
 }
 ```
 
+The dispatch generic should likely only be needed if you are dispatching additional thunks within the middleware.
+
+### Type Checking Redux Thunks
+
+[Redux Thunk](https://github.com/reduxjs/redux-thunk) is the standard middleware for writing sync and async logic that interacts with the Redux store. A thunk function receives `dispatch` and `getState` as its parameters. Redux Thunk has a built in `ThunkAction` type which we can use to define types for those arguments:
+
+```ts
+export type ThunkAction<
+  R, // Return type of the thunk function
+  S, // state type used by getState
+  E, // any "extra argument" injected into the thunk
+  A extends Action // known types of actions that can be dispatched
+> = (dispatch: ThunkDispatch<S, E, A>, getState: () => S, extraArgument: E) => R
+```
+
+You will typically want to provide the `R` (return type) and `S` (state) generic arguments. Unfortunately, TS does not allow only providng _some_ generic arguments, so the usual values for the other arguments are `unknown` for `E` and `Action<string>` for `A`:
+
+```ts
+import { Action } from 'redux'
+import { sendMessage } from './store/chat/actions'
+import { RootState } from './store'
+import { ThunkAction } from 'redux-thunk'
+
+export const thunkSendMessage = (
+  message: string
+): ThunkAction<void, RootState, unknown, Action<string>> => async dispatch => {
+  const asyncResp = await exampleAPI()
+  dispatch(
+    sendMessage({
+      message,
+      user: asyncResp,
+      timestamp: new Date().getTime()
+    })
+  )
+}
+
+function exampleAPI() {
+  return Promise.resolve('Async Chat Bot')
+}
+```
+
+To reduce repetition, you might want to define a reusable `AppThunk` type once, in your store file, and then use that type whenever you write a thunk:
+
+```ts
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>
+```
+
+Note that this assumes that there is no meaningful return value from the thunk. If your thunk returns a promise and you want to [use the returned promise after dispatching the thunk](../tutorials/essentials/part-5-async-logic.md#checking-thunk-results-in-components), you'd want to use this as `AppThunk<Promise<SomeReturnType>>`.
+
+:::caution
+
+Don't forget that **the default `useDispatch` hook does not know about thunks**, and so dispatching a thunk will cause a type error. Be sure to [use an updated form of `Dispatch` that recognizes thunks](#define-root-state-and-dispatch-types) in your components.
+
+:::
+
 ## Usage with React Redux
 
-While React Redux is a separate library from Redux itself, it is commonly used with React.
+While [React Redux](https://react-redux.js.org) is a separate library from Redux itself, it is commonly used with React.
 
 For a complete guide on how to correctly use React-Redux with TypeScript, see **[the "Static Typing" page in the React-Redux docs](https://react-redux.js.org/using-react-redux/static-typing)**. This section will highlight the standard patterns.
 
-React-Redux doesn't ship with its own type definitions. If you are using Typescript you should install the [`@types/react-redux` type definitions](https://npm.im/@types/react-redux) from npm. In addition to typing the library functions, the types also export some helpers to make it easier to write typesafe interfaces between your Redux store and your React components.
+As mentioned above, React Redux doesn't ship with its own type definitions. If you are using Typescript you should install the [`@types/react-redux` type definitions](https://npm.im/@types/react-redux) from npm.
 
-### Typing the useSelector hook
+### Typing the `useSelector` hook
 
 Declare the type of the `state` parameter in the selector function, and the return type of `useSelector` will be inferred to match the return type of the selector:
 
@@ -274,6 +308,8 @@ const selectIsOn = (state: RootState) => state.isOn
 const isOn = useSelector(selectIsOn)
 ```
 
+However, prefer creating a pre-typed `useSelector` hook with the correct type of `state` built-in instead.
+
 ### Typing the `useDispatch` hook
 
 By default, the return value of `useDispatch` is the standard `Dispatch` type defined by the Redux core types, so no declarations are needed:
@@ -282,9 +318,11 @@ By default, the return value of `useDispatch` is the standard `Dispatch` type de
 const dispatch = useDispatch()
 ```
 
+However, prefer creating a pre-typed `useAppDispatch` hook with the correct type of `Dispatch` built-in instead.
+
 ### Typing the `connect` higher order component
 
-Use the `ConnectedProps<T>` type exported by `@types/react-redux^7.1.2` to infer the types of the props from `connect` automatically. This requires splitting the `connect(mapState, mapDispatch)(MyComponent)` call into two parts:
+If you are still using `connect`, you should use the `ConnectedProps<T>` type exported by `@types/react-redux^7.1.2` to infer the types of the props from `connect` automatically. This requires splitting the `connect(mapState, mapDispatch)(MyComponent)` call into two parts:
 
 ```tsx
 import { connect, ConnectedProps } from 'react-redux'
@@ -322,99 +360,222 @@ const MyComponent = (props: Props) => (
 export default connector(MyComponent)
 ```
 
-## Usage with Redux Thunk
-
-Redux Thunk is a commonly used middleware for writing sync and async logic that interacts with the Redux store. Feel free to check out its documentation [here](https://github.com/reduxjs/redux-thunk). A thunk is a function that wraps an expression for delaying the evaluation of that expression. In Redux, a thunk takes parameters `dispatch` and `getState`. Redux Thunk has a built in type `ThunkAction` which we can use to define types for those arguments:
-
-```ts
-// src/thunks.ts
-
-import { Action } from 'redux'
-import { sendMessage } from './store/chat/actions'
-import { RootState } from './store'
-import { ThunkAction } from 'redux-thunk'
-
-export const thunkSendMessage = (
-  message: string
-): ThunkAction<void, RootState, unknown, Action<string>> => async dispatch => {
-  const asyncResp = await exampleAPI()
-  dispatch(
-    sendMessage({
-      message,
-      user: asyncResp,
-      timestamp: new Date().getTime()
-    })
-  )
-}
-
-function exampleAPI() {
-  return Promise.resolve('Async Chat Bot')
-}
-```
-
-To reduce repetition, you might want to define a reusable `AppThunk` type once, in your store file, and then use that type whenever you write a thunk:
-
-```ts
-export type AppThunk<ReturnType = void> = ThunkAction<
-  ReturnType,
-  RootState,
-  unknown,
-  Action<string>
->
-```
-
-It is highly recommended to use action creators in your dispatch since we can reuse the work that has already been done to type check these functions.
-
 ## Usage with Redux Toolkit
 
-The official [Redux Toolkit](https://redux-toolkit.js.org) package is written in TypeScript, and provides APIs that are designed to work well in TypeScript applications.
+The [Standard Redux Toolkit Project Setup with TypeScript](#standard-redux-toolkit-project-setup-with-typescript) section already covered the normal usage patterns for `configureStore` and `createSlice`, and the [Redux Toolkit "Usage with TypeScript" page](https://redux-toolkit.js.org/usage/usage-with-typescript) covers all of the RTK APIs in detail.
+
+Here are some additional typing patterns you will commonly see when using RTK.
 
 ### Typing `configureStore`
 
-`configureStore` infers the type of the state value from the provided root reducer function, so no specific type declarations should be needed. However, you may want to export the type of `store.dispatch`, which should already have the Thunk middleware types included:
+`configureStore` infers the type of the state value from the provided root reducer function, so no specific type declarations should be needed.
+
+If you want to add additional middleware to the store, be sure to use the specialized `.concat()` and `.prepend()` methods included in the array returned by `getDefaultMiddleware()`, as those will correctly preserve the types of the middleware you're adding. (Using plain JS array spreads often loses those types.)
 
 ```ts
 const store = configureStore({
-  reducer: rootReducer
-})
-
-export type AppDispatch = typeof store.dispatch
-```
-
-### Typing `createAction`
-
-`createAction` requires that the type of the payload be explicitly defined, unless there is no payload required:
-
-```ts
-const add = createAction<number>(1)
-```
-
-### Typing `createReducer`
-
-`createReducer` will infer the type of its state value from the `initialState` argument. Action types should be declared explicitly:
-
-```ts
-const initialState: number = 0
-const counterReducer = createReducer(initialState, {
-  increment: (state, action: PayloadAction<number>) => state + action.payload
+  reducer: rootReducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware()
+      .prepend(
+        // correctly typed middlewares can just be used
+        additionalMiddleware,
+        // you can also type middlewares manually
+        untypedMiddleware as Middleware<
+          (action: Action<'specialAction'>) => number,
+          RootState
+        >
+      )
+      // prepend and concat calls can be chained
+      .concat(logger)
 })
 ```
+
+### Matching Actions
+
+RTK-generated action creators have a `match` method that acts as a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates). Calling `someActionCreator.match(action)` will do a string comparison against the `action.type` string, and if used as a condition, narrow the type of `action` down to be the correct TS type:
+
+```ts
+const increment = createAction<number>('increment')
+function test(action: Action) {
+  if (increment.match(action)) {
+    // action.payload inferred correctly here
+    const num = 5 + action.payload
+  }
+}
+```
+
+This is particularly useful when checking for action types in Redux middleware, such as custom middleware, `redux-observable`, and RxJS's `filter` method.
 
 ### Typing `createSlice`
 
-Similar to `createReducer`, `createSlice` will infer the type of its state value from the `initialState` argument. Action types should be declared explicitly, and will be reused for the generated action creators:
+#### Defining Separate Case Reducers
+
+If you have too many case reducers and defining them inline would be messy, or you want to reuse case reducers across slices, you can also define them outside the `createSlice` call and type them as `CaseReducer`:
 
 ```ts
-const counterSlice = createSlice({
-  name: 'counter',
-  initialState: 0 as number,
+type State = number
+const increment: CaseReducer<State, PayloadAction<number>> = (state, action) =>
+  state + action.payload
+
+createSlice({
+  name: 'test',
+  initialState: 0,
   reducers: {
-    increment(state, action: PayloadAction<number>) {
-      return state + action.payload
+    increment
+  }
+})
+```
+
+#### Typing `extraReducers`
+
+If you are adding an `extraReducers` field in `createSlice`, be sure to use the "builder callback" form, as the "plain object" form cannot infer action types correctly. Passing an RTK-generated action creator to `builder.addCase()` will correctly infer the type of the `action`:
+
+```ts
+const usersSlice = createSlice({
+  name: 'users',
+  initialState,
+  reducers: {
+    // fill in primary logic here
+  },
+  // highlight-start
+  extraReducers: builder => {
+    builder.addCase(fetchUserById.pending, (state, action) => {
+      // both `state` and `action` are now correctly typed
+      // based on the slice state and the `pending` action creator
+    })
+  }
+  // highlight-end
+})
+```
+
+#### Typing `prepare` Callbacks
+
+If you want to add a `meta` or `error` property to your action, or customize the `payload` of your action, you have to use the `prepare` notation for defining the case reducer. Using this notation with TypeScript looks like:
+
+```ts
+const blogSlice = createSlice({
+  name: 'blogData',
+  initialState,
+  reducers: {
+    // highlight-start
+    receivedAll: {
+      reducer(
+        state,
+        action: PayloadAction<Page[], string, { currentPage: number }>
+      ) {
+        state.all = action.payload
+        state.meta = action.meta
+      },
+      prepare(payload: Page[], currentPage: number) {
+        return { payload, meta: { currentPage } }
+      }
+    }
+    // highlight-end
+  }
+})
+```
+
+#### Fixing Circular Types in Exported Slices
+
+Finally, on rare occasions you might need to export the slice reducer with a specific type in order to break a circular type dependency problem. This might look like:
+
+```ts
+export counterSlice.reducer as Reducer<Counter>
+```
+
+### Typing `createAsyncThunk`
+
+For basic usage, the only type you need to provide for `createAsyncThunk` is the type of the single argument for your payload creation callback. You should also ensure that the return value of the callback is typed correctly:
+
+```ts
+const fetchUserById = createAsyncThunk(
+  'users/fetchById',
+  // Declare the type your function argument here:
+  async (userId: number) => {
+    const response = await fetch(`https://reqres.in/api/users/${userId}`)
+    // Inferred return type: Promise<MyData>
+    return (await response.json()) as MyData
+  }
+)
+
+// the parameter of `fetchUserById` is automatically inferred to `number` here
+// and dispatching the resulting thunkAction will return a Promise of a correctly
+// typed "fulfilled" or "rejected" action.
+const lastReturnedAction = await store.dispatch(fetchUserById(3))
+```
+
+If you need to modify the types of the `thunkApi` parameter, such as supplying the type of the `state` returned by `getState()`, you must supply the first two generic arguments for return type and payload argument, plus whicher "thunkApi argument fields" are relevant in an object:
+
+```ts
+const fetchUserById = createAsyncThunk<
+  // Return type of the payload creator
+  MyData,
+  // First argument to the payload creator
+  number,
+  {
+    // Optional fields for defining thunkApi field types
+    dispatch: AppDispatch
+    state: State
+    extra: {
+      jwt: string
+    }
+  }
+>('users/fetchById', async (userId, thunkApi) => {
+  const response = await fetch(`https://reqres.in/api/users/${userId}`, {
+    headers: {
+      Authorization: `Bearer ${thunkApi.extra.jwt}`
+    }
+  })
+  return (await response.json()) as MyData
+})
+```
+
+### Typing `createEntityAdapter`
+
+Typing `createEntityAdapter` only requires you to specify the entity type as the single generic argument. This typically looks like:
+
+```ts
+interface Book {
+  bookId: number
+  title: string
+  // ...
+}
+
+// highlight-next-line
+const booksAdapter = createEntityAdapter<Book>({
+  selectId: book => book.bookId,
+  sortComparer: (a, b) => a.title.localeCompare(b.title)
+})
+
+const booksSlice = createSlice({
+  name: 'books',
+  // highlight-start
+  // The type of the state is inferred here
+  initialState: booksAdapter.getInitialState(),
+  // highlight-end
+  reducers: {
+    bookAdded: booksAdapter.addOne,
+    booksReceived(state, action: PayloadAction<{ books: Book[] }>) {
+      booksAdapter.setAll(state, action.payload.books)
     }
   }
 })
 ```
+
+## Additional Recommendations
+
+### Use the React-Redux Hooks API
+
+**We recommend using the React-Redux hooks API as the default approach**. The hooks API is much simpler to use with TypeScript, as `useSelector` is a simple hook that takes a selector function, and the return type is easily inferred from the type of the `state` argument.
+
+While `connect` still works fine, and _can_ be typed, it's much more difficult to type correctly.
+
+### Avoid Action Type Unions
+
+**We specifically recommend _against_ trying to create unions of action types**, as it provides no real benefit and actually misleads the compiler in some ways. See RTK maintainer Lenz Weber's post [Do Not Create Union Types with Redux Action Types](https://phryneas.de/redux-typescript-no-discriminating-union) for an explanation of why this is a problem.
+
+In addition, if you're using `createSlice`, you already know that all actions defined by that slice are being handled correctly.
 
 ## Resources
 
@@ -422,9 +583,11 @@ For further information, see these additional resources:
 
 - Redux library documentation:
   - [React-Redux docs: Static Typing](https://react-redux.js.org/using-react-redux/static-typing): Examples of how to use the React-Redux APIs with TypeScript
-  - [Redux Toolkit docs: Advanced Tutorial](https://redux-toolkit.js.org/tutorials/advanced-tutorial): shows how to use RTK and the React-Redux hooks API with TypeScript
+  - [Redux Toolkit docs: Usage with TypeScript](https://redux-toolkit.js.org/usage/usage-with-typescript): Examples of how to use the Redux Toolkit APIs with TypeScript
 - React + Redux + TypeScript guides:
   - [React+TypeScript Cheatsheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet): a comprehensive guide to using React with TypeScript
   - [React + Redux in TypeScript Guide](https://github.com/piotrwitek/react-redux-typescript-guide): extensive information on patterns for using React and Redux with TypeScript
+    - _Note: while this guide has some useful info, many of the patterns it shows go against our recommended practices shown in this page, such as using action type unions. We link this out of completeness_
 - Other articles:
+  - [Do Not Create Union Types with Redux Action Types](https://phryneas.de/redux-typescript-no-discriminating-union)
   - [Redux with Code-Splitting and Type Checking](https://www.matthewgerstman.com/tech/redux-code-split-typecheck/)

--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -29,7 +29,7 @@ hide_title: true
 2. Easy refactoring of typed code
 3. A superior developer experience in a team environment
 
-[**We strongly recommend using TypeScript in Redux applications**](../style-guide/style-guide.md#use-static-typing). However, like all tools, TypeScript has tradeoffs. It adds complexity in terms of writing additional code, understanding TS syntax, and building the application. At the same time, it provides value by catching errors early, enabling correct refactoring, and acting as documentation for existing source code.
+[**We strongly recommend using TypeScript in Redux applications**](../style-guide/style-guide.md#use-static-typing). However, like all tools, TypeScript has tradeoffs. It adds complexity in terms of writing additional code, understanding TS syntax, and building the application. At the same time, it provides value by catching errors earlier in development, enabling safer and more efficient refactoring, and acting as documentation for existing source code.
 
 We believe that **[pragmatic use of Typescript](https://blog.isquaredsoftware.com/2019/11/blogged-answers-learning-and-using-typescript/#pragmatism-is-vital) provides more than enough value and benefit to justify the added overhead**, especially in larger codebases, but you should take time to **evaluate the tradeoffs and decide whether it's worth using TS in your own application**.
 
@@ -41,7 +41,7 @@ We assume that a typical Redux project is using Redux Toolkit and React Redux to
 
 [Redux Toolkit](https://redux-toolkit.js.org) (RTK) is the standard approach for writing modern Redux logic. RTK is already written in TypeScript, and its API is designed to provide a good experience for TypeScript usage.
 
-[React-Redux](https://react-redux.js.org) doesn't ship with its own type definitions. If you are using Typescript you should install the [`@types/react-redux` type definitions](https://npm.im/@types/react-redux) from npm. In addition to typing the library functions, the types also export some helpers to make it easier to write typesafe interfaces between your Redux store and your React components.
+[React Redux](https://react-redux.js.org) doesn't ship with its own type definitions. If you are using Typescript you should install the [`@types/react-redux` type definitions](https://npm.im/@types/react-redux) from npm. In addition to typing the library functions, the types also export some helpers to make it easier to write typesafe interfaces between your Redux store and your React components.
 
 The [Redux+TS template for Create-React-App](https://github.com/reduxjs/cra-template-redux-typescript) comes with a working example of these patterns already configured.
 
@@ -147,7 +147,7 @@ The generated action creators will be correctly typed to accept a `payload` argu
 
 ### Use Typed Hooks in Components
 
-In component files, import the pre-typed hooks instead of the standard hooks from React-Redux.
+In component files, import the pre-typed hooks instead of the standard hooks from React Redux.
 
 ```tsx title="features/counter/Counter.tsx"
 import React, { useState } from 'react'
@@ -290,7 +290,7 @@ Don't forget that **the default `useDispatch` hook does not know about thunks**,
 
 While [React Redux](https://react-redux.js.org) is a separate library from Redux itself, it is commonly used with React.
 
-For a complete guide on how to correctly use React-Redux with TypeScript, see **[the "Static Typing" page in the React-Redux docs](https://react-redux.js.org/using-react-redux/static-typing)**. This section will highlight the standard patterns.
+For a complete guide on how to correctly use React Redux with TypeScript, see **[the "Static Typing" page in the React Redux docs](https://react-redux.js.org/using-react-redux/static-typing)**. This section will highlight the standard patterns.
 
 As mentioned above, React Redux doesn't ship with its own type definitions. If you are using Typescript you should install the [`@types/react-redux` type definitions](https://npm.im/@types/react-redux) from npm.
 
@@ -567,9 +567,9 @@ const booksSlice = createSlice({
 
 ## Additional Recommendations
 
-### Use the React-Redux Hooks API
+### Use the React Redux Hooks API
 
-**We recommend using the React-Redux hooks API as the default approach**. The hooks API is much simpler to use with TypeScript, as `useSelector` is a simple hook that takes a selector function, and the return type is easily inferred from the type of the `state` argument.
+**We recommend using the React Redux hooks API as the default approach**. The hooks API is much simpler to use with TypeScript, as `useSelector` is a simple hook that takes a selector function, and the return type is easily inferred from the type of the `state` argument.
 
 While `connect` still works fine, and _can_ be typed, it's much more difficult to type correctly.
 
@@ -584,7 +584,7 @@ In addition, if you're using `createSlice`, you already know that all actions de
 For further information, see these additional resources:
 
 - Redux library documentation:
-  - [React-Redux docs: Static Typing](https://react-redux.js.org/using-react-redux/static-typing): Examples of how to use the React-Redux APIs with TypeScript
+  - [React Redux docs: Static Typing](https://react-redux.js.org/using-react-redux/static-typing): Examples of how to use the React Redux APIs with TypeScript
   - [Redux Toolkit docs: Usage with TypeScript](https://redux-toolkit.js.org/usage/usage-with-typescript): Examples of how to use the Redux Toolkit APIs with TypeScript
 - React + Redux + TypeScript guides:
   - [React+TypeScript Cheatsheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet): a comprehensive guide to using React with TypeScript

--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -29,9 +29,11 @@ hide_title: true
 2. Easy refactoring of typed code
 3. A superior developer experience in a team environment
 
-[**We strongly recommend using TypeScript in Redux applications**](../style-guide/style-guide.md#use-static-typing). However, like all tools, TypeScript has tradeoffs. It adds complexity in terms of writing additional code, understanding TS syntax, and building the application. At the same time, it provides value by catching errors early, enabling correct refactoring, and acting as documentation for existing source code. We believe that **[pragmatic use of Typescript](https://blog.isquaredsoftware.com/2019/11/blogged-answers-learning-and-using-typescript/#pragmatism-is-vital) provides more than enough value and benefit to justify the added overhead**, especially in larger codebases, but you should take time to **evaluate the tradeoffs and decide whether it's worth using TS in your own application**.
+[**We strongly recommend using TypeScript in Redux applications**](../style-guide/style-guide.md#use-static-typing). However, like all tools, TypeScript has tradeoffs. It adds complexity in terms of writing additional code, understanding TS syntax, and building the application. At the same time, it provides value by catching errors early, enabling correct refactoring, and acting as documentation for existing source code.
 
-There are multiple possible approaches to type checking Redux code. This page demonstrates some of the common and recommended approaches to keep things simple, and is not an exhaustive guide.
+We believe that **[pragmatic use of Typescript](https://blog.isquaredsoftware.com/2019/11/blogged-answers-learning-and-using-typescript/#pragmatism-is-vital) provides more than enough value and benefit to justify the added overhead**, especially in larger codebases, but you should take time to **evaluate the tradeoffs and decide whether it's worth using TS in your own application**.
+
+There are multiple possible approaches to type checking Redux code. **This page shows our standard recommended patterns for using Redux and TypeScript together**, and is not an exhaustive guide. Following these patterns should result in a good TS usage experience, with **the best tradeoffs between type safety and amount of type declarations you have to add to your codebase**.
 
 ## Standard Redux Toolkit Project Setup with TypeScript
 
@@ -280,7 +282,7 @@ Note that this assumes that there is no meaningful return value from the thunk. 
 
 :::caution
 
-Don't forget that **the default `useDispatch` hook does not know about thunks**, and so dispatching a thunk will cause a type error. Be sure to [use an updated form of `Dispatch` that recognizes thunks](#define-root-state-and-dispatch-types) in your components.
+Don't forget that **the default `useDispatch` hook does not know about thunks**, and so dispatching a thunk will cause a type error. Be sure to [use an updated form of `Dispatch` in your components that recognizes thunks as an acceptable type to dispatch](#define-root-state-and-dispatch-types).
 
 :::
 

--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -275,6 +275,12 @@ It's a bit more typing, but it results in the most understandable code and state
 
 </DetailedExplanation>
 
+### Organize State Structure Based on Data Types, Not Components
+
+Root state slices should be defined and named based on the major data types or areas of functionality in your application, not based on which specific components you have in your UI. This is because there is not a strict 1:1 correlation between data in the Redux store and components in the UI, and many components may need to access the same data. Think of the state tree as a sort of global database that any part of the app can access to read just the pieces of state needed in that component.
+
+For example, a blogging app might need to track who is logged in, information on authors and posts, and perhaps some info on what screen is active. A good state structure might look like `{auth, posts, users, ui}`. A bad structure would be something like `{loginScreen, usersList, postsList}`.
+
 ### Treat Reducers as State Machines
 
 Many Redux reducers are written "unconditionally". They only look at the dispatched action and calculate a new state value, without basing any of the logic on what the current state might be. This can cause bugs, as some actions may not be "valid" conceptually at certain times depending on the rest of the app logic. For example, a "request succeeded" action should only have a new value calculated if the state says that it's already "loading", or an "update this item" action should only be dispatched if there is an item marked as "being edited".
@@ -593,7 +599,7 @@ However, don't feel that you _must_ write selector functions for every field in 
 
 ### Name Selector Functions as `selectThing`
 
-**We recommend prefixing selector function names with the word `select`**, combined with a description of the value being selected. Examples of this would be `selectTodos`, `selectVisibleTodos`, and `selectTodoById`,
+**We recommend prefixing selector function names with the word `select`**, combined with a description of the value being selected. Examples of this would be `selectTodos`, `selectVisibleTodos`, and `selectTodoById`.
 
 ### Avoid Putting Form State In Redux
 


### PR DESCRIPTION
---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**

Updates the "Usage with TypeScript" page

## Checklist

- [x] Is there an existing issue for this PR?
  - #4025
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Recipes
- **Page**: Usage with TypeScript

## For Updating Existing Content

- Dropped legacy section that showed use of action type unions andhand-written action creators
- Copied TS quick start section from RTK docs
- Added "what you'll learn / prerequisites" boxes
- Added additional details for typing reducers / thunks / middleware
- Removed now-duplicate RTK usage info
- Added additional RTK common usage patterns info
- Added "recommendations" section

Also added a new Style Guide entry that says to "organize state by data type, not components"
