### PR TITLE
Fix broken immer docs links

### DIFF
--- a/docs/recipes/structuring-reducers/ImmutableUpdatePatterns.md
+++ b/docs/recipes/structuring-reducers/ImmutableUpdatePatterns.md
@@ -199,7 +199,7 @@ const reducer = createReducer(initialState, {
 ```
 
 This is clearly _much_ shorter and easier to read. However, **this _only_ works correctly if you are using the "magic"
-`createReducer` function from Redux Toolkit** that wraps this reducer in Immer's [`produce` function](https://immerjs.github.io/immer/docs/produce).
+`createReducer` function from Redux Toolkit** that wraps this reducer in Immer's [`produce` function](https://immerjs.github.io/immer/produce).
 **If this reducer is used without Immer, it will actually mutate the state!**. It's also not obvious just by
 looking at the code that this function is actually safe and updates the state immutably. Please make sure you understand
 the concepts of immutable updates fully. If you do use this, it may help to add some comments to your code that explain

--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -48,7 +48,7 @@ Where multiple, equally good options exist, an arbitrary choice can be made to e
 
 Mutating state is the most common cause of bugs in Redux applications, including components failing to re-render properly, and will also break time-travel debugging in the Redux DevTools. **Actual mutation of state values should always be avoided**, both inside reducers and in all other application code.
 
-Use tools such as [`redux-immutable-state-invariant`](https://github.com/leoasis/redux-immutable-state-invariant) to catch mutations during development, and [Immer](https://immerjs.github.io/immer/docs/introduction) to avoid accidental mutations in state updates.
+Use tools such as [`redux-immutable-state-invariant`](https://github.com/leoasis/redux-immutable-state-invariant) to catch mutations during development, and [Immer](https://immerjs.github.io/immer/) to avoid accidental mutations in state updates.
 
 > **Note**: it is okay to modify _copies_ of existing values - that is a normal part of writing immutable update logic. Also, if you are using the Immer library for immutable updates, writing "mutating" logic is acceptable because the real data isn't being mutated - Immer safely tracks changes and generates immutably-updated values internally.
 
@@ -92,7 +92,7 @@ You are not required to use RTK with Redux, and you are free to use other approa
 
 ### Use Immer for Writing Immutable Updates
 
-Writing immutable update logic by hand is frequently difficult and prone to errors. [Immer](https://immerjs.github.io/immer/docs/introduction) allows you to write simpler immutable updates using "mutative" logic, and even freezes your state in development to catch mutations elsewhere in the app. **We recommend using Immer for writing immutable update logic, preferably as part of [Redux Toolkit](../redux-toolkit/overview.md)**.
+Writing immutable update logic by hand is frequently difficult and prone to errors. [Immer](https://immerjs.github.io/immer/) allows you to write simpler immutable updates using "mutative" logic, and even freezes your state in development to catch mutations elsewhere in the app. **We recommend using Immer for writing immutable update logic, preferably as part of [Redux Toolkit](../redux-toolkit/overview.md)**.
 
 <a id="structure-files-as-feature-folders-or-ducks"></a>
 

--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -339,7 +339,7 @@ Writing immutable update logic by hand _is_ hard, and accidentally mutating stat
 
 **That's why Redux Toolkit's `createSlice` function lets you write immutable updates an easier way!**
 
-`createSlice` uses a library called [Immer](https://immerjs.github.io/immer/docs/introduction) inside. Immer uses a special JS tool called a `Proxy` to wrap the data you provide, and lets you write code that "mutates" that wrapped data. But, **Immer tracks all the changes you've tried to make, and then uses that list of changes to return a safely immutably updated value**, as if you'd written all the immutable update logic by hand.
+`createSlice` uses a library called [Immer](https://immerjs.github.io/immer/) inside. Immer uses a special JS tool called a `Proxy` to wrap the data you provide, and lets you write code that "mutates" that wrapped data. But, **Immer tracks all the changes you've tried to make, and then uses that list of changes to return a safely immutably updated value**, as if you'd written all the immutable update logic by hand.
 
 So, instead of this:
 

--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -754,7 +754,7 @@ Notice that **our action object just contains the minimum amount of information 
 
 :::info
 
-When using Immer, you can either "mutate" an existing state object, or return a new state value yourself, but not both at the same time. See the Immer docs guides on [Pitfalls](https://immerjs.github.io/immer/docs/pitfalls) and [Returning New Data](https://immerjs.github.io/immer/docs/return) for more details.
+When using Immer, you can either "mutate" an existing state object, or return a new state value yourself, but not both at the same time. See the Immer docs guides on [Pitfalls](https://immerjs.github.io/immer/pitfalls) and [Returning New Data](https://immerjs.github.io/immer/return) for more details.
 
 :::
 

--- a/docs/tutorials/fundamentals/part-8-modern-redux.md
+++ b/docs/tutorials/fundamentals/part-8-modern-redux.md
@@ -301,7 +301,7 @@ As you've seen throughout this tutorial, we can write immutable updates by hand 
 
 **That's why Redux Toolkit's `createSlice` function lets you write immutable updates an easier way!**
 
-`createSlice` uses a library called [Immer](https://immerjs.github.io/immer/docs/introduction) inside. Immer uses a special JS tool called a `Proxy` to wrap the data you provide, and lets you write code that "mutates" that wrapped data. But, **Immer tracks all the changes you've tried to make, and then uses that list of changes to return a safely immutably updated value**, as if you'd written all the immutable update logic by hand.
+`createSlice` uses a library called [Immer](https://immerjs.github.io/immer/) inside. Immer uses a special JS tool called a `Proxy` to wrap the data you provide, and lets you write code that "mutates" that wrapped data. But, **Immer tracks all the changes you've tried to make, and then uses that list of changes to return a safely immutably updated value**, as if you'd written all the immutable update logic by hand.
 
 So, instead of this:
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  No existing issue
  Problem raised by `Noob!` on the `Reactiflux` discord: https://discord.com/channels/102860784329052160/103538784460615680/823140384917159946
- [x] Have the files been linted and formatted?
  Yes - only existing files altered with no formatting changes.

## What docs page needs to be fixed?
All pages linking to `immer` docs:
- **Section**: Recipes/Structuring Reducers
- **Page**: Immutable Update Patterns
- **Section**: Style Guide
- **Page**: Style guide: Best Practices
- **Section**: Tutorials/Redux Essentials
- **Page**: Redux App Structure
- **Section**: Tutorials/Redux Essentials
- **Page**: Using Redux Data
- **Section**: Tutorials/Redux Fundamentals
- **Page**: Modern Redux with Redux Toolkit

## What is the problem?
Immer's documentation now has a different format. e.g. what was previously https://immerjs.github.io/immer/docs/pitfalls is now https://immerjs.github.io/immer/pitfalls. My assumption is that this may have happened when `immer` updated to docusaurus 2: https://github.com/immerjs/immer/commit/42aac9569971f2f0a93d4af1a08fe9f365aed44d

## What changes does this PR make to fix the problem?
Updates the existing links as per the current `immer` website.