### PR TITLE
[Docs] Spelling Mistake in configureStore Method

### DIFF
--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -148,7 +148,7 @@ const counterSlice = createSlice({
 export const { incremented, decremented } = counterSlice.actions
 
 const store = configureStore({
-  reducer: counterSlice.reducer
+  reducer: counterSlice.reducers
 })
 
 // Can still subscribe to the store


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [X] Is there an existing issue for this PR?
  -[#4048](https://github.com/reduxjs/redux/issues/4048)
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Toolkit Example
- **Page**: Getting Started

## What is the problem?
counterSlice doesn't have a property called "reducer". It should be "reducers"

## What changes does this PR make to fix the problem?
Changed the spelling from "reducer" to "reducers"