### PR TITLE
Remove symbol-observable and loose-envify deps

### DIFF
--- a/.github/workflows/size.yaml
+++ b/.github/workflows/size.yaml
@@ -14,4 +14,4 @@ jobs:
       - uses: preactjs/compressed-size-action@v1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          pattern: './{dist,es,lib}/*.js'
+          pattern: './{dist,es,lib}/*.{js,mjs}'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="symbol-observable" />
-
 /**
  * An *action* is a plain object that represents an intention to change the
  * state. Actions are the only way to get data into the store. Any data,
@@ -222,6 +220,12 @@ export interface Dispatch<A extends Action = AnyAction> {
  */
 export interface Unsubscribe {
   (): void
+}
+
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -224,7 +224,7 @@ export interface Unsubscribe {
 
 declare global {
   interface SymbolConstructor {
-    readonly observable: symbol;
+    readonly observable: symbol
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7073,7 +7073,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -7296,6 +7297,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -9507,11 +9509,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
-      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "examples:test": "cross-env CI=true babel-node examples/testAll.js"
   },
   "dependencies": {
-    "loose-envify": "^1.4.0",
-    "symbol-observable": "^2.0.3",
     "@babel/runtime": "^7.9.2"
   },
   "devDependencies": {
@@ -102,11 +100,6 @@
       ]
     }
   ],
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
-  },
   "jest": {
     "testRegex": "(/test/.*\\.spec\\.[tj]s)$",
     "coverageProvider": "v8"

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,4 +1,4 @@
-import $$observable from 'symbol-observable'
+import $$observable from './utils/symbol-observable'
 
 import ActionTypes from './utils/actionTypes'
 import isPlainObject from './utils/isPlainObject'

--- a/src/utils/symbol-observable.js
+++ b/src/utils/symbol-observable.js
@@ -1,0 +1,3 @@
+// Inlined version of the `symbol-observable` polyfill
+export default (() =>
+  (typeof Symbol === 'function' && Symbol.observable) || '@@observable')()

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -19,8 +19,8 @@ describe('createStore', () => {
 
     // Since switching to internal Symbol.observable impl, it will show up as a key in node env
     // So we filter it out
-    const methods = Object.keys(store).filter(key => key !== $$observable)
-    
+    const methods = Object.keys(store).filter((key) => key !== $$observable)
+
     expect(methods.length).toBe(4)
     expect(methods).toContain('subscribe')
     expect(methods).toContain('dispatch')

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -11,13 +11,16 @@ import {
 import * as reducers from './helpers/reducers'
 import { from } from 'rxjs'
 import { map } from 'rxjs/operators'
-import $$observable from 'symbol-observable'
+import $$observable from '../src/utils/symbol-observable'
 
 describe('createStore', () => {
   it('exposes the public API', () => {
     const store = createStore(combineReducers(reducers))
-    const methods = Object.keys(store)
 
+    // Since switching to internal Symbol.observable impl, it will show up as a key in node env
+    // So we filter it out
+    const methods = Object.keys(store).filter(key => key !== $$observable)
+    
     expect(methods.length).toBe(4)
     expect(methods).toContain('subscribe')
     expect(methods).toContain('dispatch')

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -9,7 +9,8 @@ import {
   Unsubscribe,
   Observer,
 } from 'redux'
-import 'symbol-observable'
+// @ts-ignore
+import $$observable from '../src/utils/symbol-observable'
 
 type BrandedString = string & { _brand: 'type' }
 const brandedString = 'a string' as BrandedString


### PR DESCRIPTION
This PR:

- Drops the legacy `symbol-observable` and `loose-envify` dependencies
- Inlines the `symbol-observable` polyfill
