### PR TITLE
Notify listeners after middleware

### DIFF
--- a/src/applyMiddleware.ts
+++ b/src/applyMiddleware.ts
@@ -80,9 +80,9 @@ export default function applyMiddleware(
     const chain = middlewares.map(middleware => middleware(middlewareAPI))
     const composedDispatch = compose<typeof dispatch>(...chain)(store.dispatch)
     dispatch = (action, ...args) => {
-      store[$$toggleListeners](false);
-      const result = composedDispatch(action, ...args);
-      store[$$toggleListeners](true);
+      store[$$toggleListeners](false)
+      const result = composedDispatch(action, ...args)
+      store[$$toggleListeners](true)
       // Notify listeners after synchronous middleware has finished so they can access the correct
       // state if the listener will end up dispatching.
       // See: https://github.com/reduxjs/redux/issues/4049

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -216,22 +216,16 @@ export interface Store<
   [Symbol.observable](): Observable<S>
 
   /**
-   * Base dispatch function, calls the reducer with the state tree and an action but does not notify
-   * listeners of the change.
-   *
-   * notifyListeners() must be called manually after this, it is only to be used when more control
-   * is needed over when listeners are notified.
-   *
+   * Enable or disable the notification of listeners, use it to control the timing of when listeners
+   * are called, mainly for use by applyMiddleware() so that it can allow synchronous middleware
+   * to finish before another dispatch has a chance to occur (causing nested middleware)
    * @private
-   * @returns For convenience, the same action object you dispatched.
-   *
    */
   [$$toggleListeners]: (value: boolean) => void
 
   /**
    * Triggers listeners. Should be called after a change to state.
    * Should only be called after dispatchSilent() for better control on when listeners are notified.
-   *
    * @private
    */
   [$$notifyListeners]: () => void

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,6 +1,7 @@
 import { Action, AnyAction } from './actions'
 import { Reducer } from './reducers'
 import '../utils/symbol-observable'
+import { $$dispatchSilent, $$notifyListeners, $$toggleListeners } from '../createStore'
 
 /**
  * Extend the state
@@ -213,6 +214,27 @@ export interface Store<
    * https://github.com/tc39/proposal-observable
    */
   [Symbol.observable](): Observable<S>
+
+  /**
+   * Base dispatch function, calls the reducer with the state tree and an action but does not notify
+   * listeners of the change.
+   *
+   * notifyListeners() must be called manually after this, it is only to be used when more control
+   * is needed over when listeners are notified.
+   *
+   * @private
+   * @returns For convenience, the same action object you dispatched.
+   *
+   */
+  [$$toggleListeners]: (value: boolean) => void
+
+  /**
+   * Triggers listeners. Should be called after a change to state.
+   * Should only be called after dispatchSilent() for better control on when listeners are notified.
+   * 
+   * @private
+   */
+  [$$notifyListeners]: () => void
 }
 
 /**

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,7 +1,7 @@
 import { Action, AnyAction } from './actions'
 import { Reducer } from './reducers'
 import '../utils/symbol-observable'
-import { $$dispatchSilent, $$notifyListeners, $$toggleListeners } from '../createStore'
+import { $$notifyListeners, $$toggleListeners } from '../createStore'
 
 /**
  * Extend the state

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -231,7 +231,7 @@ export interface Store<
   /**
    * Triggers listeners. Should be called after a change to state.
    * Should only be called after dispatchSilent() for better control on when listeners are notified.
-   * 
+   *
    * @private
    */
   [$$notifyListeners]: () => void

--- a/test/applyMiddleware.spec.ts
+++ b/test/applyMiddleware.spec.ts
@@ -147,4 +147,28 @@ describe('applyMiddleware', () => {
     store.dispatch(spy)
     expect(spy.mock.calls[0]).toEqual(testCallArgs)
   })
+
+  it('notifies listeners after middleware has executed', () => {
+    const testMiddleware = store => next => action => {
+      next(action)
+      spy(store.getState())
+    }
+
+    const spy = jest.fn()
+    const store = applyMiddleware(testMiddleware)(createStore)(reducers.todos)
+    let dispatched = false
+    store.subscribe(() => {
+      if (dispatched) return
+      dispatched = true
+      store.dispatch(addTodo('Flux FTW!'))
+    })
+    store.dispatch(addTodo('Use Redux'))
+    expect(spy.mock.calls).toEqual([
+      [[{ id: 1, text: 'Use Redux' }]],
+      [[
+        { id: 1, text: 'Use Redux' },
+        { id: 2, text: 'Flux FTW!' }
+      ]]
+    ])
+  })
 })

--- a/test/applyMiddleware.spec.ts
+++ b/test/applyMiddleware.spec.ts
@@ -165,10 +165,12 @@ describe('applyMiddleware', () => {
     store.dispatch(addTodo('Use Redux'))
     expect(spy.mock.calls).toEqual([
       [[{ id: 1, text: 'Use Redux' }]],
-      [[
-        { id: 1, text: 'Use Redux' },
-        { id: 2, text: 'Flux FTW!' }
-      ]]
+      [
+        [
+          { id: 1, text: 'Use Redux' },
+          { id: 2, text: 'Flux FTW!' }
+        ]
+      ]
     ])
   })
 })

--- a/test/applyMiddleware.spec.ts
+++ b/test/applyMiddleware.spec.ts
@@ -149,12 +149,12 @@ describe('applyMiddleware', () => {
   })
 
   it('notifies listeners after middleware has executed', () => {
+    const spy = jest.fn()
     const testMiddleware = store => next => action => {
       next(action)
       spy(store.getState())
     }
 
-    const spy = jest.fn()
     const store = applyMiddleware(testMiddleware)(createStore)(reducers.todos)
     let dispatched = false
     store.subscribe(() => {


### PR DESCRIPTION
---
name: :bug: Bug fix or new feature
about: Listeners being notified after 
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

I would classify it as a bug

### Why should this PR be included?

See: https://github.com/reduxjs/redux/issues/4049

## Checklist

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4049
- [X] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [X] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?

### What docs changes are needed to explain this?

I don't believe any are required

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

See: https://github.com/reduxjs/redux/issues/4049

Currently listeners are notified when you call `next()` inside middleware, if one of those listeners leads to another action being dispatched then the middleware is nested and that action is dispatched before the rest of the middleware is completed.

As a result middleware is unable to with a guarantee access the state after an action was executed, and perhaps worse in the above case middleware is called twice with the same state.

See the regression test I have added here:

https://github.com/georeith/redux/blob/22e6c3ee1dc454e34d3e4c716cbc09333863f4fc/test/applyMiddleware.spec.ts#L151

Without this change the calls are as follows:

 ```ts
 [
  [
    [
      { id: 1, text: 'Use Redux' },
      { id: 2, text: 'Flux FTW!' }
    ]
  ],
  [
    [
      { id: 1, text: 'Use Redux' },
      { id: 2, text: 'Flux FTW!' }
    ]
  ]
]
 ```

A user will run into this issue if they dispatch from React's `useLayoutEffect` for instance, which they may need to do if they need to update the store based on new information from a browser layout cycle.

### What is the expected behavior?

After the change the calls are:

```ts
[
  [
    [
      { id: 1, text: 'Use Redux' },
    ]
  ],
  [
    [
      { id: 1, text: 'Use Redux' },
      { id: 2, text: 'Flux FTW!' }
    ]
  ]
]
```

With each middleware receiving the state that resulted from the action that triggered it.


### How does this PR fix the problem?

Exposes some internal methods under symbols for controlling the notification of listeners so that `applyMiddleware` is able to control this flow better.

I looked at two different ways of doing this, my first attempt was to expose `$$dispatchSilent` and `$$notifyListeners` and have `applyMiddleware` compose `$$dispatchSilent` which worked for the most part but broke if you use Redux Dev Tools as that attempts to override `store.dispatch` for middleware. So I arrived upon this solution which should not affect further composition above the middleware.
