### PR TITLE
[Doc] crossSliceReducer example should not update slice B twice

### DIFF
--- a/docs/recipes/structuring-reducers/BeyondCombineReducers.md
+++ b/docs/recipes/structuring-reducers/BeyondCombineReducers.md
@@ -28,7 +28,8 @@ function combinedReducer(state, action) {
       return {
         // specifically pass state.b as an additional argument
         a: sliceReducerA(state.a, action, state.b),
-        b: sliceReducerB(state.b, action)
+        // do not update the other slices
+        b: state.b
       }
     }
     case 'ANOTHER_SPECIAL_ACTION': {


### PR DESCRIPTION
We do not want the slice B to be updated two times per action.


---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4070
- [ ] Have the files been linted and formatted? 
  - Not sure how to do that from github directlu

## What docs page needs to be fixed?
https://redux.js.org/recipes/structuring-reducers/beyond-combinereducers
- **Section**: recipes
- **Page**: structuring-reducers/beyond-combinereducers

## What is the problem?
The example of the 3rd approach is buggy.

## What changes does this PR make to fix the problem?
We avoid updating the sliceB twice.
