### PR TITLE
[Doc] crossSliceReducer example should not update slice B twice

### DIFF
--- a/docs/recipes/structuring-reducers/BeyondCombineReducers.md
+++ b/docs/recipes/structuring-reducers/BeyondCombineReducers.md
@@ -78,7 +78,8 @@ function crossSliceReducer(state, action) {
       return {
         // specifically pass state.b as an additional argument
         a: handleSpecialCaseForA(state.a, action, state.b),
-        b: sliceReducerB(state.b, action)
+        // do not update other slice
+        b: state.b
       }
     }
     default:


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - #4070
- [ ] Have the files been linted and formatted?
 - Not sure how to do that from github ui direclty

## What docs page needs to be fixed?
https://redux.js.org/recipes/structuring-reducers/beyond-combinereducers
- **Section**: recipes/structuring-reducers
- **Page**: beyond-combinereducers

## What is the problem?
The example of the 3rd approach is buggy.

## What changes does this PR make to fix the problem?
We avoid updating the sliceB twice.
