### PR TITLE
Tutorial Documentation edit - Being explicit about storeAPI object

### DIFF
--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -452,6 +452,17 @@ Here's the same example as above, using arrow functions:
 ```js
 const anotherExampleMiddleware = storeAPI => next => action => {
   // Do something in here, when each action is dispatched
+  // Access the store with storeAPI.getState()
+
+  return next(action)
+}
+```
+
+Alternatively, StoreAPI can be decomposed
+```js
+const anotherExampleMiddleware = {dispatch, getState} => next => action => {
+  // Do something in here, when each action is dispatched
+  // Access the store with getState()
 
   return next(action)
 }

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -458,7 +458,7 @@ const anotherExampleMiddleware = storeAPI => next => action => {
 }
 ```
 
-Alternatively, StoreAPI can be decomposed
+Alternatively, storeAPI can be decomposed
 ```js
 const anotherExampleMiddleware = {dispatch, getState} => next => action => {
   // Do something in here, when each action is dispatched

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -452,18 +452,6 @@ Here's the same example as above, using arrow functions:
 ```js
 const anotherExampleMiddleware = storeAPI => next => action => {
   // Do something in here, when each action is dispatched
-  // Access the store with storeAPI.getState()
-
-  return next(action)
-}
-```
-
-Alternatively, storeAPI can be decomposed
-
-```js
-const anotherExampleMiddleware = ({dispatch, getState}) => next => action => {
-  // Do something in here, when each action is dispatched
-  // Access the store with getState()
 
   return next(action)
 }

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -461,7 +461,7 @@ const anotherExampleMiddleware = storeAPI => next => action => {
 Alternatively, storeAPI can be decomposed
 
 ```js
-const anotherExampleMiddleware = {dispatch, getState} => next => action => {
+const anotherExampleMiddleware = ({dispatch, getState}) => next => action => {
   // Do something in here, when each action is dispatched
   // Access the store with getState()
 

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -459,6 +459,7 @@ const anotherExampleMiddleware = storeAPI => next => action => {
 ```
 
 Alternatively, storeAPI can be decomposed
+
 ```js
 const anotherExampleMiddleware = {dispatch, getState} => next => action => {
   // Do something in here, when each action is dispatched

--- a/docs/tutorials/fundamentals/part-6-async-logic.md
+++ b/docs/tutorials/fundamentals/part-6-async-logic.md
@@ -86,7 +86,7 @@ const fetchTodosMiddleware = storeAPI => next => action => {
     // Make an API call to fetch todos from the server
     client.get('todos').then(todos => {
       // Dispatch an action with the todos we received
-      dispatch({ type: 'todos/todosLoaded', payload: todos })
+      storeAPI.dispatch({ type: 'todos/todosLoaded', payload: todos })
     })
   }
 


### PR DESCRIPTION
Adding a small fix and some extra clarity to a point of friction I found in the tutorial

- [:memo: Documentation Fix](?template=documentation-edit.md)
