### PR TITLE
Docs: fix info box in ImplementingUndoHistory

### DIFF
--- a/docs/recipes/ImplementingUndoHistory.md
+++ b/docs/recipes/ImplementingUndoHistory.md
@@ -6,7 +6,7 @@ hide_title: true
 
 # Implementing Undo History
 
-:::Prerequisites
+:::important Prerequisites
 
 - Completion of the ["Redux Fundamentals" tutorial](../tutorials/fundamentals/part-1-overview.md)
 - Understanding of ["reducer composition"](../tutorials/fundamentals/part-3-state-actions-reducers.md#splitting-reducers)


### PR DESCRIPTION
The Prerequisites box in ImplementingUndoHistory.md did not render because it was missing the 'important'.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:  https://redux.js.org/recipes/implementing-undo-history#implementing-undo-history
- **Page**:  https://redux.js.org/recipes/implementing-undo-history

## What is the problem?
The Prerequisites box not rendering.

## What changes does this PR make to fix the problem?

Makes the Prerequisites box render.
