### PR TITLE
Fix preloaded state type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ export type PreloadedState<S> = Required<S> extends EmptyObject
     ? {
         [K in keyof S1]?: S1[K] extends object ? PreloadedState<S1[K]> : S1[K]
       }
-    : never
+    : S
   : {
       [K in keyof S]: S[K] extends string | number | boolean | symbol
         ? S[K]

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -8,6 +8,8 @@ import {
   StoreEnhancerStoreCreator,
   Unsubscribe,
   Observer,
+  PreloadedState,
+  CombinedState
 } from 'redux'
 // @ts-ignore
 import $$observable from '../src/utils/symbol-observable'
@@ -151,3 +153,24 @@ const observer: Observer<State> = {
 }
 const unsubscribeFromObservable = observable.subscribe(observer).unsubscribe
 unsubscribeFromObservable()
+
+// some type tests for PreloadedState
+const ANY: any = {}
+const notNever: PreloadedState<{ key: unknown }>['key'] = ANY as unknown
+// typings:expect-error
+const isNever: PreloadedState<{ key: never }>['key'] = ANY as unknown
+const is5: 5 = ANY as PreloadedState<{ key: 5 }>['key']
+// typings:expect-error
+const isNot5: 5 = ANY as PreloadedState<{ key: 6 }>['key']
+const isNumber: number = ANY as PreloadedState<{ key: number }>['key']
+const isString: string = ANY as PreloadedState<{ key: string }>['key']
+const isNested: { nested: string } = ANY as PreloadedState<{
+  key: { nested: string }
+}>['key']
+const isNestedOptional: { nested?: string } = ANY as PreloadedState<{
+  key: CombinedState<{ nested: string }>
+}>['key']
+// typings:expect-error
+const isNestedReallyOptional: { nested: string } = ANY as PreloadedState<{
+  key: CombinedState<{ nested: string }>
+}>['key']


### PR DESCRIPTION
---
name: :bug: fix PreloadedState type on `unknown`
about: Fixes a type problem brought up in https://github.com/reduxjs/redux/issues/4076
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

Fixes a bug

### Why should this PR be included?

Fixes a slight misbehavior of `PreloadedState` in the case the original state type contained `unknown` at some point.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4076
- [ ] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

Unfortunately, locally the formatter runs amok and linter/tests don't wanna run. I hope everything is alright.

## Bug Fixes

Before, `PreloadedState<{state: unknown}>` returned `{ state: never }`, now it returns `{ state: unknown }`

### How does this PR fix the problem?

Return the original type `S` in the inner condition instead of `never`. Seems to be more reasonable.