### PR TITLE
Fix broken in-page links in immutable data FAQ

### DIFF
--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -43,8 +43,8 @@ In particular, immutability in the context of a Web app enables sophisticated ch
 
 ## Why is immutability required by Redux?
 
-- Both Redux and React-Redux employ [shallow equality checking](#shallow-and-deep-equality-checking). In particular: - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-redux-uses-shallow-checking) caused by the reducers that it calls. - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-react-redux-uses-shallow-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
-  Such [shallow checking requires immutability](#redux-shallow-checking-requires-immutability) to function correctly.
+- Both Redux and React-Redux employ [shallow equality checking](#how-do-shallow-and-deep-equality-checking-differ). In particular: - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-does-redux-use-shallow-equality-checking) caused by the reducers that it calls. - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
+  Such [shallow checking requires immutability](#why-will-shallow-equality-checking-not-work-with-mutable-objects) to function correctly.
 - Immutable data management ultimately makes data handling safer.
 - Time-travel debugging requires that reducers be pure functions with no side effects, so that you can correctly jump between different states.
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Broken in-page links on Immutable Data FAQ 
---

## Checklist

- [x] Is there an existing issue for this PR?
  - #4083 
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: FAQ
- **Page**: Immutable Data

## What is the problem?

All of the in-page anchor links on the first bullet point here are pointing to IDs that don't exist on the page:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/4130722/118308842-0d955180-b4b2-11eb-8921-9c15d50ea620.png">

## What changes does this PR make to fix the problem?

It looks like these headings were rephrased at some point so I updated the links to point to the newer headings.
