### PR TITLE
Docs: remove extraArgument from code example

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -498,7 +498,7 @@ const thunkMiddleware =
   next =>
   action => {
     if (typeof action === 'function') {
-      return action(dispatch, getState, extraArgument)
+      return action(dispatch, getState)
     }
 
     return next(action)


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Detailed Explanation: Thunks and Async Logic
- **Page**: Redux Essentials, Part 2: Redux App Structure

## What is the problem?

`extraArgument` is part of the redux-thunk middleware but it's out of context for the purposes of this example.

## What changes does this PR make to fix the problem?

Remove the `extraArgument` to avoid confusion.