### PR TITLE
Move miniKindOf out of if scope to fix ES5 compatibility issue

### DIFF
--- a/src/utils/kindOf.js
+++ b/src/utils/kindOf.js
@@ -1,68 +1,68 @@
+// Inlined / shortened version of `kindOf` from https://github.com/jonschlinkert/kind-of
+function miniKindOf(val) {
+  if (val === void 0) return 'undefined'
+  if (val === null) return 'null'
+
+  const type = typeof val
+  switch (type) {
+    case 'boolean':
+    case 'string':
+    case 'number':
+    case 'symbol':
+    case 'function': {
+      return type
+    }
+    default:
+      break
+  }
+
+  if (Array.isArray(val)) return 'array'
+  if (isDate(val)) return 'date'
+  if (isError(val)) return 'error'
+
+  const constructorName = ctorName(val)
+  switch (constructorName) {
+    case 'Symbol':
+    case 'Promise':
+    case 'WeakMap':
+    case 'WeakSet':
+    case 'Map':
+    case 'Set':
+      return constructorName
+    default:
+      break
+  }
+
+  // other
+  return type.slice(8, -1).toLowerCase().replace(/\s/g, '')
+}
+
+function ctorName(val) {
+  return typeof val.constructor === 'function' ? val.constructor.name : null
+}
+
+function isError(val) {
+  return (
+    val instanceof Error ||
+    (typeof val.message === 'string' &&
+      val.constructor &&
+      typeof val.constructor.stackTraceLimit === 'number')
+  )
+}
+
+function isDate(val) {
+  if (val instanceof Date) return true
+  return (
+    typeof val.toDateString === 'function' &&
+    typeof val.getDate === 'function' &&
+    typeof val.setDate === 'function'
+  )
+}
+
 export function kindOf(val) {
   let typeOfVal = typeof val
 
   if (process.env.NODE_ENV !== 'production') {
-    // Inlined / shortened version of `kindOf` from https://github.com/jonschlinkert/kind-of
-    function miniKindOf(val) {
-      if (val === void 0) return 'undefined'
-      if (val === null) return 'null'
-
-      const type = typeof val
-      switch (type) {
-        case 'boolean':
-        case 'string':
-        case 'number':
-        case 'symbol':
-        case 'function': {
-          return type
-        }
-        default:
-          break
-      }
-
-      if (Array.isArray(val)) return 'array'
-      if (isDate(val)) return 'date'
-      if (isError(val)) return 'error'
-
-      const constructorName = ctorName(val)
-      switch (constructorName) {
-        case 'Symbol':
-        case 'Promise':
-        case 'WeakMap':
-        case 'WeakSet':
-        case 'Map':
-        case 'Set':
-          return constructorName
-        default:
-          break
-      }
-
-      // other
-      return type.slice(8, -1).toLowerCase().replace(/\s/g, '')
-    }
-
-    function ctorName(val) {
-      return typeof val.constructor === 'function' ? val.constructor.name : null
-    }
-
-    function isError(val) {
-      return (
-        val instanceof Error ||
-        (typeof val.message === 'string' &&
-          val.constructor &&
-          typeof val.constructor.stackTraceLimit === 'number')
-      )
-    }
-
-    function isDate(val) {
-      if (val instanceof Date) return true
-      return (
-        typeof val.toDateString === 'function' &&
-        typeof val.getDate === 'function' &&
-        typeof val.setDate === 'function'
-      )
-    }
-
     typeOfVal = miniKindOf(val)
   }
 


### PR DESCRIPTION
---
name: :bug: Bug fix or new feature
about: Fixing a problem with Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

It fixes a bug.

### Why should this PR be included?

Currently redux cannot be run in ES5 environments even if Babel is used.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #4089
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

Please refer to #4089.

**TL;DR** There are functions declared inside an `if` statement, which ES5 forbids and Babel does not fix.

### What is the expected behavior?

Redux should run without any syntax errors, if it's being bundled and transpiled in the standard manner for ES5.

### How does this PR fix the problem?

It moves the aforementioned functions out of the if statement and into the file's scope.

The diff looks huge but it's mostly due to the indentation changing.