### PR TITLE
Fix Typo

### DIFF
--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -170,7 +170,7 @@ obj.b = 3
 const arr = ['a', 'b']
 // In the same way, we can change the contents of this array
 arr.push('c')
-arr[1] = 'd'
+arr[1] = 'b'
 ```
 
 This is called _mutating_ the object or array. It's the same object or array reference in memory, but now the contents inside the object have changed.


### PR DESCRIPTION
In the "Immutability" section of the Essentials tutorial: first code-block second array example: arr[1] is 'b' not 'd'.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Immutability: first code-block second example (array example). 
- **Page**: https://redux.js.org/tutorials/essentials/part-1-overview-concepts#immutability

## What is the problem?
There's a typo: arr[1] is 'b' not 'd'.

## What changes does this PR make to fix the problem?
Changed the typo for the correct character.
