### PR TITLE
Remove now-deleted Flow example from docs

### DIFF
--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -86,24 +86,6 @@ Or check out the [sandbox](https://codesandbox.io/s/github/reduxjs/redux/tree/ma
 
 This is a variation on the previous example. It is almost identical, but additionally shows how wrapping your reducer with [Redux Undo](https://github.com/omnidan/redux-undo) lets you add a Undo/Redo functionality to your app with a few lines of code.
 
-## Todos w/ Flow
-
-Run the [Todos w/ Flow](https://github.com/reduxjs/redux/tree/master/examples/todos-flow) example:
-
-```sh
-git clone https://github.com/reduxjs/redux.git
-
-cd redux/examples/todos-flow
-npm install
-npm start
-```
-
-Or check out the [sandbox](https://codesandbox.io/s/github/reduxjs/redux/tree/master/examples/todos-flow):
-
-<iframe class="codesandbox"src="https://codesandbox.io/embed/github/reduxjs/redux/tree/master/examples/todos-flow/?runonclick=1"sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
-
-This is like the previous Todos examples, but shows how to use Redux in conjunction with [Flow](https://flow.org/).
-
 ## TodoMVC
 
 Run the [TodoMVC](https://github.com/reduxjs/redux/tree/master/examples/todomvc) example:


### PR DESCRIPTION
The links and CodeSandbox iframe in the "Todos w/ Flow" example are broken: https://redux.js.org/introduction/examples#todos-w-flow

The actual example files were removed in a previous commit: https://github.com/reduxjs/redux/commit/ebf125297430ce33ea7b21279445bbb935092ed8#diff-c590b3c924c35c2f241746522284e4709df490d73a38aaa7d6de4ed1eac2f546

This PR just removes the references to the now-deleted example.