### PR TITLE
Remove useState import

### DIFF
--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -143,7 +143,7 @@ export default configureStore({
 Now we can use the React-Redux hooks to let React components interact with the Redux store. We can read data from the store with `useSelector`, and dispatch actions using `useDispatch`. Create a `src/features/counter/Counter.js` file with a `<Counter>` component inside, then import that component into `App.js` and render it inside of `<App>`.
 
 ```jsx title="features/counter/Counter.js"
-import React, { useState } from 'react'
+import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { decrement, increment } from './counterSlice'
 import styles from './Counter.module.css'

--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -155,7 +155,7 @@ const initialState = {
 In component files, import the pre-typed hooks instead of the standard hooks from React-Redux.
 
 ```tsx title="features/counter/Counter.tsx"
-import React, { useState } from 'react'
+import React from 'react'
 
 // highlight-next-line
 import { useAppSelector, useAppDispatch } from 'app/hooks'


### PR DESCRIPTION
It's imported, but not actually being used.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials
- **Page**: Quick Start/TypeScript Quick Start

## What is the problem?

useState is imported, but not actually being used.

## What changes does this PR make to fix the problem?

Remove useState import.