### PR TITLE
docs: fix typo

### DIFF
--- a/docs/tutorials/fundamentals/part-1-overview.md
+++ b/docs/tutorials/fundamentals/part-1-overview.md
@@ -79,7 +79,7 @@ Redux helps you manage "global" state - state that is needed across many parts o
 
 ### When Should I Use Redux?
 
-Redux helps you deal with shared state management, but like any tool, it has tradeoffs. There's more concepts to learn, and more code to write. It also adds some indirection to your code, and asks you to follow certain restrictions. It's a trade-off between short term and long term productivity.
+Redux helps you deal with shared state management, but like any tool, it has tradeoffs. There are more concepts to learn, and more code to write. It also adds some indirection to your code, and asks you to follow certain restrictions. It's a trade-off between short term and long term productivity.
 
 Redux is more useful when:
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?

`concepts` is plural but is referred to using `is`

## What changes does this PR make to fix the problem?

chage `is` to `are`