### PR TITLE
📝 Update writing tests page

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -28,7 +28,7 @@ As such, the Redux code can be treated as an implementation detail of the app, w
 The general advice for testing an app using Redux is as follows:
 
 - Use integration tests for everything working together. I.e. for a React app using Redux, render a `<Provider>` with a real store instance wrapping the component/s being tested. Interactions with the page being tested should use real Redux logic, with API calls mocked out so app code doesn't have to change, and assert that the UI is updated appropriately.
-- Use basic unit tests _where fitting_ for pure functions that deserve it. I.e. particularly complex reducers or selectors. However, in many cases, these are just implementation details that are covered by integration tests instead.
+- If needed, use basic unit tests for pure functions such as particularly complex reducers or selectors. However, in many cases, these are just implementation details that are covered by integration tests instead.
 
 :::tip
 
@@ -90,7 +90,9 @@ Our recommendation is to mock async requests at the `fetch/xhr` level using tool
 
 ### Reducers
 
-A reducer should be a pure function that returns the new state after applying the action to the previous state. In the majority of cases, the reducer is an implementation detail that does not need explicit tests. However, if your reducer contains particularly complex logic that you would like the confidence of having unit tests for, reducers can be easily tested. As a reducer should always be a pure function, it is easy to write tests for - a given input should always provide a particular output.
+Reducers pure functions that return the new state after applying the action to the previous state. In the majority of cases, the reducer is an implementation detail that does not need explicit tests. However, if your reducer contains particularly complex logic that you would like the confidence of having unit tests for, reducers can be easily tested. 
+
+Because reducers are pure functions, testing them should be straightforward.  Call the reducer with a specific input `state` and `action`, and assert that the result state matches expectations.
 
 #### Example
 
@@ -249,7 +251,7 @@ export default function App() {
 }
 ```
 
-This app involves async action creators, reducers and selectors. All of these can be tested by writing an integration test with the following in mind:
+This app involves thunks, reducers and selectors. All of these can be tested by writing an integration test with the following in mind:
 
 - Upon first loading the app, there should be no user yet - we should see 'No user' on the screen.
 - After clicking the button that says 'Fetch user', we expect it to start fetching the user. We should see 'Fetching user...' displayed on the screen.

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -2,6 +2,7 @@
 id: writing-tests
 title: Writing Tests
 hide_title: true
+description: "Recipes > Writing Tests: recommended practices and setup for testing Redux apps"
 ---
 
 &nbsp;
@@ -11,25 +12,17 @@ hide_title: true
 :::tip What You'll Learn
 
 - Recommended practices for testing apps using Redux
+- Examples of test configuration and setup
 
 :::
 
-Because most of the Redux code you write are functions, and many of them are pure, they are easy to test without mocking. However, you should consider whether each piece of your Redux code needs it's own dedicated tests.
-
-:::info
-
-See [Blogged Answers: The Evolution of Redux Testing Approaches](https://blog.isquaredsoftware.com/2021/06/the-evolution-of-redux-testing-approaches/) for Mark Erikson's thoughts on how Redux testing has evolved from 'isolation' to 'integration' over time.
-
-:::
-
-### Guiding Principles
+## Guiding Principles
 
 The guiding principles for testing Redux logic closely follow that of React Testing Library:
 
 > [The more your tests resemble the way your software is used, the more confidence they can give you.](https://twitter.com/kentcdodds/status/977018512689455106) - Kent C. Dodds
 
-In the majority of scenarios, the end-user does not know, and does not care whether Redux is used within the application at all.
-As such, the Redux code can be treated as an implementation detail of the app, without requiring explicit tests for the Redux code in many circumstances.
+Because most of the Redux code you write are functions, and many of them are pure, they are easy to test without mocking. However, you should consider whether each piece of your Redux code needs it's own dedicated tests.  In the majority of scenarios, the end-user does not know, and does not care whether Redux is used within the application at all.  As such, the Redux code can be treated as an implementation detail of the app, without requiring explicit tests for the Redux code in many circumstances.
 
 The general advice for testing an app using Redux is as follows:
 
@@ -38,11 +31,14 @@ The general advice for testing an app using Redux is as follows:
 
 :::info
 
-See [Testing Implementation Details](https://kentcdodds.com/blog/testing-implementation-details) for Kent C. Dodds' thoughts on why he recommends avoiding testing implementation details.
+For background on why we recommend integration-style tests, see:
+
+- Kent C Dodds: [Testing Implementation Details](https://kentcdodds.com/blog/testing-implementation-details): thoughts on why he recommends avoiding testing implementation details.
+- Mark Erikson: [Blogged Answers: The Evolution of Redux Testing Approaches](https://blog.isquaredsoftware.com/2021/06/the-evolution-of-redux-testing-approaches/): thoughts on how Redux testing has evolved from 'isolation' to 'integration' over time.
 
 :::
 
-### Setting Up
+## Setting Up
 
 Redux can be tested with any test runner, however in the examples below we will be using [Jest](https://facebook.github.io/jest/), a popular testing framework.
 Note that it runs in a Node environment, so you won't have access to the real DOM.
@@ -82,7 +78,7 @@ Then, add this to `scripts` in your `package.json`:
 
 and run `npm test` to run it once, or `npm run test:watch` to test on every file change.
 
-### Action Creators & Thunks
+## Action Creators & Thunks
 
 In Redux, action creators are functions which return plain objects. Our recommendation is not to write action creators manually, but instead have them generated automatically by [`createSlice`](https://redux-toolkit.js.org/api/createSlice#return-value), or created via [`createAction`](https://redux-toolkit.js.org/api/createAction) from [`@reduxjs/toolkit`](https://redux-toolkit.js.org/introduction/getting-started). As such, you should not feel the need to test action creators by themselves (the Redux Toolkit maintainers have already done that for you!).
 
@@ -100,7 +96,7 @@ If you prefer, or are otherwise required to write unit tests for your action cre
 
 :::
 
-### Reducers
+## Reducers
 
 Reducers are pure functions that return the new state after applying the action to the previous state. In the majority of cases, the reducer is an implementation detail that does not need explicit tests. However, if your reducer contains particularly complex logic that you would like the confidence of having unit tests for, reducers can be easily tested.
 
@@ -187,7 +183,7 @@ test('should handle a todo being added to an existing list', () => {
 })
 ```
 
-### Components
+## Components
 
 Our recommendation for testing components that include Redux code is via integration tests that include everything working together, with assertions aimed at verifying that the app behaves the way you expect when the user interacts with it in a given manner.
 
@@ -356,7 +352,7 @@ test('fetches & receives a user after clicking the fetch user button', async () 
 
 In this test, we have completely avoided testing any Redux code directly, treating it as an implementation detail. As a result, we are free to re-factor the _implementation_, while our tests will continue to pass and avoid false negatives (tests that fail despite the app still behaving how we want it to). We might change our state structure, convert our slice to use [RTK-Query](https://redux-toolkit.js.org/rtk-query/overview), or remove Redux entirely, and our tests will still pass. We have a strong degree of confidence that if we change some code and our tests report a failure, then our app really _is_ broken.
 
-### Middleware
+## Middleware
 
 Middleware functions wrap behavior of `dispatch` calls in Redux, so to test this modified behavior we need to mock the behavior of the `dispatch` call.
 
@@ -425,7 +421,7 @@ test('passes dispatch and getState', () => {
 
 In some cases, you will need to modify the `create` function to use different mock implementations of `getState` and `next`.
 
-### Further Information
+## Further Information
 
 - [React Testing Library](https://testing-library.com/docs/react-testing-library/intro): React Testing Library is a very light-weight solution for testing React components. It provides light utility functions on top of react-dom and react-dom/test-utils, in a way that encourages better testing practices. Its primary guiding principle is: "The more your tests resemble the way your software is used, the more confidence they can give you."
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -2,7 +2,7 @@
 id: writing-tests
 title: Writing Tests
 hide_title: true
-description: "Recipes > Writing Tests: recommended practices and setup for testing Redux apps"
+description: 'Recipes > Writing Tests: recommended practices and setup for testing Redux apps'
 ---
 
 &nbsp;
@@ -22,7 +22,7 @@ The guiding principles for testing Redux logic closely follow that of React Test
 
 > [The more your tests resemble the way your software is used, the more confidence they can give you.](https://twitter.com/kentcdodds/status/977018512689455106) - Kent C. Dodds
 
-Because most of the Redux code you write are functions, and many of them are pure, they are easy to test without mocking. However, you should consider whether each piece of your Redux code needs it's own dedicated tests.  In the majority of scenarios, the end-user does not know, and does not care whether Redux is used within the application at all.  As such, the Redux code can be treated as an implementation detail of the app, without requiring explicit tests for the Redux code in many circumstances.
+Because most of the Redux code you write are functions, and many of them are pure, they are easy to test without mocking. However, you should consider whether each piece of your Redux code needs it's own dedicated tests. In the majority of scenarios, the end-user does not know, and does not care whether Redux is used within the application at all. As such, the Redux code can be treated as an implementation detail of the app, without requiring explicit tests for the Redux code in many circumstances.
 
 The general advice for testing an app using Redux is as follows:
 


### PR DESCRIPTION
- Update page with a heavy focus on integration testing
- Remove some 'low value' unit test examples completely
- Update examples to use RTK

In general - tries to finally update the writing tests page to reflect Mark's (and hopefully the React community's) ideas on best testing practices (as written about here: https://blog.isquaredsoftware.com/2021/06/the-evolution-of-redux-testing-approaches/)

I think this PR deserve some thorough poking & criticism - some of the changes might involve my own opinions, which I'd rather get tweaked to be the community's opinions on best practices for high value tests.

For example, I shifted towards a mindset of 'You generally treat reducers/selectors as implementation details that don't need testing, but can write unit tests for them if you want'. I would appreciate some opinions around that.

---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**

Updates an existing page (Writing Tests)

## Checklist

- [x] Is there an existing issue for this PR?
  No existing issue
- [x] Have the files been linted and formatted?
  Yes

## What docs page is being added or updated?

- **Section**: All sections
- **Page**: Writing Tests

## For Updating Existing Content

### What updates should be made to the page?

Update examples & recommendations to better reflect current practices

### Do these updates change any of the assumptions or target audience? If so, how do they change?

Yes - now assumes that users prefer integration testing over unit testing.
