### PR TITLE
[Docs] Remove dummy content and fix header issues

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,11 +1,9 @@
 ---
 id: faq
 title: FAQ Index
-hide_title: true
+sidebar_label: FAQ Index
 description: 'FAQ Index: Frequently Asked Questions about Redux'
 ---
-
-&nbsp;
 
 # Redux FAQ
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,10 +1,7 @@
 ---
 id: api-reference
 title: API Reference
-hide_title: true
 ---
-
-&nbsp;
 
 # API Reference
 

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -1,11 +1,8 @@
 ---
 id: store
 title: Store
-hide_title: true
 description: 'API > Store: the core Redux store methods'
 ---
-
-&nbsp;
 
 # Store
 

--- a/docs/faq/Actions.md
+++ b/docs/faq/Actions.md
@@ -1,10 +1,8 @@
 ---
 id: actions
 title: Actions
-hide_title: true
+sidebar_label: Actions
 ---
-
-&nbsp;
 
 # Redux FAQ: Actions
 

--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -1,10 +1,8 @@
 ---
 id: code-structure
 title: Code Structure
-hide_title: true
+sidebar_label: Code Structure
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../components/DetailedExplanation'
 

--- a/docs/faq/DesignDecisions.md
+++ b/docs/faq/DesignDecisions.md
@@ -1,10 +1,8 @@
 ---
 id: design-decisions
 title: Design Decisions
-hide_title: true
+sidebar_label: Design Decisions
 ---
-
-&nbsp;
 
 # Redux FAQ: Design Decisions
 

--- a/docs/faq/General.md
+++ b/docs/faq/General.md
@@ -1,10 +1,8 @@
 ---
 id: general
 title: General
-hide_title: true
+sidebar_label: General
 ---
-
-&nbsp;
 
 # Redux FAQ: General
 

--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -1,10 +1,8 @@
 ---
 id: immutable-data
 title: Immutable Data
-hide_title: true
+sidebar_label: Immutable Data
 ---
-
-&nbsp;
 
 # Redux FAQ: Immutable Data
 

--- a/docs/faq/Miscellaneous.md
+++ b/docs/faq/Miscellaneous.md
@@ -1,10 +1,8 @@
 ---
 id: miscellaneous
 title: Miscellaneous
-hide_title: true
+sidebar_label: Miscellaneous
 ---
-
-&nbsp;
 
 # Redux FAQ: Miscellaneous
 

--- a/docs/faq/OrganizingState.md
+++ b/docs/faq/OrganizingState.md
@@ -1,10 +1,8 @@
 ---
 id: organizing-state
 title: Organizing State
-hide_title: true
+sidebar_label: Organizing State
 ---
-
-&nbsp;
 
 # Redux FAQ: Organizing State
 

--- a/docs/faq/Performance.md
+++ b/docs/faq/Performance.md
@@ -1,10 +1,8 @@
 ---
 id: performance
 title: Performance
-hide_title: true
+sidebar_label: Performance
 ---
-
-&nbsp;
 
 # Redux FAQ: Performance
 

--- a/docs/faq/ReactRedux.md
+++ b/docs/faq/ReactRedux.md
@@ -1,10 +1,8 @@
 ---
 id: react-redux
 title: React Redux
-hide_title: true
+sidebar_label: React Redux
 ---
-
-&nbsp;
 
 # Redux FAQ: React Redux
 

--- a/docs/faq/Reducers.md
+++ b/docs/faq/Reducers.md
@@ -1,10 +1,8 @@
 ---
 id: reducers
 title: Reducers
-hide_title: true
+sidebar_label: Reducers
 ---
-
-&nbsp;
 
 # Redux FAQ: Reducers
 

--- a/docs/faq/StoreSetup.md
+++ b/docs/faq/StoreSetup.md
@@ -1,10 +1,8 @@
 ---
 id: store-setup
 title: Store Setup
-hide_title: true
+sidebar_label: Store Setup
 ---
-
-&nbsp;
 
 # Redux FAQ: Store Setup
 

--- a/docs/introduction/CoreConcepts.md
+++ b/docs/introduction/CoreConcepts.md
@@ -2,10 +2,7 @@
 id: core-concepts
 title: Core Concepts
 description: "Introduction > Core Concepts: A quick overview of Redux's key idea, reducer functions"
-hide_title: true
 ---
-
-&nbsp;
 
 # Core Concepts
 

--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -2,10 +2,7 @@
 id: ecosystem
 title: Ecosystem
 description: 'Introduction > Ecosystem: Links to popular, recommended, and interesting Redux-related libraries'
-hide_title: true
 ---
-
-&nbsp;
 
 # Ecosystem
 

--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -2,10 +2,7 @@
 id: examples
 title: Examples
 description: 'Introduction > Examples: Redux interactive example apps'
-hide_title: true
 ---
-
-&nbsp;
 
 # Examples
 

--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -2,10 +2,7 @@
 id: getting-started
 title: Getting Started with Redux
 description: 'Introduction > Getting Started: Resources to get started learning and using Redux'
-hide_title: true
 ---
-
-&nbsp;
 
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css'
@@ -192,7 +189,7 @@ Redux maintainer Mark Erikson appeared on the "Learn with Jason" show to explain
 
 See [the "Learn Modern Redux" show notes page](https://www.learnwithjason.dev/let-s-learn-modern-redux) for a transcript and links to the example app source.
 
-<LiteYouTubeEmbed 
+<LiteYouTubeEmbed
     id="9zySeP5vH9c"
     title="Learn Modern Redux - Redux Toolkit, React-Redux Hooks, and RTK Query"
 />

--- a/docs/introduction/Installation.md
+++ b/docs/introduction/Installation.md
@@ -2,10 +2,7 @@
 id: installation
 title: Installation
 description: 'Introduction > Installation: Installation instructions for Redux and related packages'
-hide_title: true
 ---
-
-&nbsp;
 
 # Installation
 

--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -2,10 +2,7 @@
 id: learning-resources
 title: Learning Resources
 description: 'Introduction > Learning Resources: Additional articles and resources for learning Redux'
-hide_title: true
 ---
-
-&nbsp;
 
 # Learning Resources
 

--- a/docs/recipes/CodeSplitting.md
+++ b/docs/recipes/CodeSplitting.md
@@ -1,10 +1,7 @@
 ---
 id: code-splitting
 title: Code Splitting
-hide_title: true
 ---
-
-&nbsp;
 
 # Code Splitting
 

--- a/docs/recipes/ComputingDerivedData.md
+++ b/docs/recipes/ComputingDerivedData.md
@@ -1,10 +1,7 @@
 ---
 id: computing-derived-data
 title: Computing Derived Data
-hide_title: true
 ---
-
-&nbsp;
 
 # Computing Derived Data
 

--- a/docs/recipes/ConfiguringYourStore.md
+++ b/docs/recipes/ConfiguringYourStore.md
@@ -1,10 +1,8 @@
 ---
 id: configuring-your-store
 title: Configuring Your Store
-hide_title: true
+sidebar_label: Configuring Your Store
 ---
-
-&nbsp;
 
 # Configuring Your Store
 

--- a/docs/recipes/ImplementingUndoHistory.md
+++ b/docs/recipes/ImplementingUndoHistory.md
@@ -1,10 +1,7 @@
 ---
 id: implementing-undo-history
 title: Implementing Undo History
-hide_title: true
 ---
-
-&nbsp;
 
 # Implementing Undo History
 

--- a/docs/recipes/IsolatingSubapps.md
+++ b/docs/recipes/IsolatingSubapps.md
@@ -1,10 +1,7 @@
 ---
 id: isolating-redux-sub-apps
 title: Isolating Redux Sub-Apps
-hide_title: true
 ---
-
-&nbsp;
 
 # Isolating Redux Sub-Apps
 

--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -1,10 +1,7 @@
 ---
 id: migrating-to-redux
 title: Migrating to Redux
-hide_title: true
 ---
-
-&nbsp;
 
 # Migrating to Redux
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,10 +1,8 @@
 ---
 id: recipe-index
-title: 'Recipes: Index'
-hide_title: true
+title: Recipes Index
+sidebar_label: Recipes Index
 ---
-
-&nbsp;
 
 # Recipes
 

--- a/docs/recipes/ReducingBoilerplate.md
+++ b/docs/recipes/ReducingBoilerplate.md
@@ -1,10 +1,7 @@
 ---
 id: reducing-boilerplate
 title: Reducing Boilerplate
-hide_title: true
 ---
-
-&nbsp;
 
 # Reducing Boilerplate
 

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -1,10 +1,7 @@
 ---
 id: server-rendering
 title: Server Rendering
-hide_title: true
 ---
-
-&nbsp;
 
 # Server Rendering
 

--- a/docs/recipes/Troubleshooting.md
+++ b/docs/recipes/Troubleshooting.md
@@ -1,10 +1,7 @@
 ---
 id: troubleshooting
 title: Troubleshooting
-hide_title: true
 ---
-
-&nbsp;
 
 # Troubleshooting
 

--- a/docs/recipes/UsageWithTypescript.md
+++ b/docs/recipes/UsageWithTypescript.md
@@ -1,10 +1,7 @@
 ---
 id: usage-with-typescript
 title: Usage With TypeScript
-hide_title: true
 ---
-
-&nbsp;
 
 # Usage with TypeScript
 

--- a/docs/recipes/UsingObjectSpreadOperator.md
+++ b/docs/recipes/UsingObjectSpreadOperator.md
@@ -1,10 +1,7 @@
 ---
 id: using-object-spread-operator
 title: Using Object Spread Operator
-hide_title: true
 ---
-
-&nbsp;
 
 # Using Object Spread Operator
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -1,11 +1,8 @@
 ---
 id: writing-tests
 title: Writing Tests
-hide_title: true
 description: 'Recipes > Writing Tests: recommended practices and setup for testing Redux apps'
 ---
-
-&nbsp;
 
 # Writing Tests
 

--- a/docs/recipes/structuring-reducers/BasicReducerStructure.md
+++ b/docs/recipes/structuring-reducers/BasicReducerStructure.md
@@ -1,11 +1,9 @@
 ---
 id: basic-reducer-structure
 title: Basic Reducer Structure
+sidebar_label: Basic Reducer Structure
 description: 'Structuring Reducers > Basic Reducer Structure: Overview of how reducer functions work with Redux state'
-hide_title: true
 ---
-
-&nbsp;
 
 # Basic Reducer Structure and State Shape
 

--- a/docs/recipes/structuring-reducers/ImmutableUpdatePatterns.md
+++ b/docs/recipes/structuring-reducers/ImmutableUpdatePatterns.md
@@ -2,10 +2,7 @@
 id: immutable-update-patterns
 title: Immutable Update Patterns
 description: 'Structuring Reducers > Immutable Update Patterns: How to correctly update state immutably, with examples of common mistakes'
-hide_title: true
 ---
-
-&nbsp;
 
 # Immutable Update Patterns
 

--- a/docs/recipes/structuring-reducers/InitializingState.md
+++ b/docs/recipes/structuring-reducers/InitializingState.md
@@ -2,10 +2,7 @@
 id: initializing-state
 title: Initializing State
 description: 'Structuring Reducers > Initializing State: How Redux state is initialized'
-hide_title: true
 ---
-
-&nbsp;
 
 # Initializing State
 

--- a/docs/recipes/structuring-reducers/NormalizingStateShape.md
+++ b/docs/recipes/structuring-reducers/NormalizingStateShape.md
@@ -2,10 +2,7 @@
 id: normalizing-state-shape
 title: Normalizing State Shape
 description: 'Structuring Reducers > Normalizing State Shape: Why and how to store data items for lookup based on ID'
-hide_title: true
 ---
-
-&nbsp;
 
 # Normalizing State Shape
 

--- a/docs/recipes/structuring-reducers/PrerequisiteConcepts.md
+++ b/docs/recipes/structuring-reducers/PrerequisiteConcepts.md
@@ -1,11 +1,9 @@
 ---
 id: prerequisite-concepts
 title: Prerequisite Concepts
+sidebar_label: Prerequisite Concepts
 description: 'Structuring Reducers > Prerequisite Concepts: Key concepts to understand when using Redux'
-hide_title: true
 ---
-
-&nbsp;
 
 # Prerequisite Reducer Concepts
 

--- a/docs/recipes/structuring-reducers/RefactoringReducersExample.md
+++ b/docs/recipes/structuring-reducers/RefactoringReducersExample.md
@@ -1,11 +1,9 @@
 ---
 id: refactoring-reducer-example
 title: Refactoring Reducers Example
+sidebar_label: Refactoring Reducers Example
 description: 'Structuring Reducers > Refactoring Reducers: Examples of ways to refactor reducer logic'
-hide_title: true
 ---
-
-&nbsp;
 
 # Refactoring Reducer Logic Using Functional Decomposition and Reducer Composition
 

--- a/docs/recipes/structuring-reducers/ReusingReducerLogic.md
+++ b/docs/recipes/structuring-reducers/ReusingReducerLogic.md
@@ -2,10 +2,7 @@
 id: reusing-reducer-logic
 title: Reusing Reducer Logic
 description: 'Structuring Reducers > Reusing Reducer Logic: Patterns for creating reusable reducers'
-hide_title: true
 ---
-
-&nbsp;
 
 # Reusing Reducer Logic
 

--- a/docs/recipes/structuring-reducers/SplittingReducerLogic.md
+++ b/docs/recipes/structuring-reducers/SplittingReducerLogic.md
@@ -1,11 +1,9 @@
 ---
 id: splitting-reducer-logic
 title: Splitting Reducer Logic
+sidebar_label: Splitting Reducer Logic
 description: 'Structuring Reducers > Splitting Reducer Logic: Terms for different reducer use cases'
-hide_title: true
 ---
-
-&nbsp;
 
 # Splitting Up Reducer Logic
 

--- a/docs/recipes/structuring-reducers/StructuringReducers.md
+++ b/docs/recipes/structuring-reducers/StructuringReducers.md
@@ -2,10 +2,7 @@
 id: structuring-reducers
 title: Structuring Reducers
 description: 'Structuring Reducers > Intro: overview and contents'
-hide_title: true
 ---
-
-&nbsp;
 
 # Structuring Reducers
 

--- a/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
+++ b/docs/recipes/structuring-reducers/UpdatingNormalizedData.md
@@ -1,11 +1,9 @@
 ---
 id: updating-normalized-data
 title: Updating Normalized Data
+sidebar_label: Updating Normalized Data
 description: 'Structuring Reducers > Updating Normalized Data: Patterns for updating normalized data'
-hide_title: true
 ---
-
-&nbsp;
 
 # Managing Normalized Data
 

--- a/docs/redux-toolkit/overview.md
+++ b/docs/redux-toolkit/overview.md
@@ -5,8 +5,6 @@ description: 'Redux Toolkit is the recommended way to write Redux logic'
 hide_title: true
 ---
 
-&nbsp;
-
 ## What is Redux Toolkit?
 
 **[Redux Toolkit](https://redux-toolkit.js.org)** is our official, opinionated, batteries-included toolset for efficient Redux development. It is intended to be the standard way to write Redux logic, and we strongly recommend that you use it.

--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -6,8 +6,6 @@ hide_title: true
 sidebar_label: 'Style Guide: Best Practices'
 ---
 
-&nbsp;
-
 import { DetailedExplanation } from '../components/DetailedExplanation'
 
 <div class="style-guide">

--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -2,11 +2,8 @@
 id: part-1-overview-concepts
 title: 'Redux Essentials, Part 1: Redux Overview and Concepts'
 sidebar_label: 'Redux Overview and Concepts'
-hide_title: true
 description: 'The official Essentials tutorial for Redux: learn how to use Redux, the right way'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -2,11 +2,8 @@
 id: part-2-app-structure
 title: 'Redux Essentials, Part 2: Redux App Structure'
 sidebar_label: 'Redux App Structure'
-hide_title: true
 description: 'The official Redux Essentials tutorial: learn the structure of a typical React + Redux app'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/essentials/part-3-data-flow.md
+++ b/docs/tutorials/essentials/part-3-data-flow.md
@@ -2,11 +2,8 @@
 id: part-3-data-flow
 title: 'Redux Essentials, Part 3: Basic Redux Data Flow'
 sidebar_label: 'Basic Redux Data Flow'
-hide_title: true
 description: 'The official Redux Essentials tutorial: learn how data flows in a React + Redux app'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -2,11 +2,8 @@
 id: part-4-using-data
 title: 'Redux Essentials, Part 4: Using Redux Data'
 sidebar_label: 'Using Redux Data'
-hide_title: true
 description: 'The official Redux Essentials tutorial: learn how to work with complex Redux state in React components'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -2,11 +2,8 @@
 id: part-5-async-logic
 title: 'Redux Essentials, Part 5: Async Logic and Data Fetching'
 sidebar_label: 'Async Logic and Data Fetching'
-hide_title: true
 description: 'The official Redux Essentials tutorial: learn how async logic works in Redux apps'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -2,11 +2,8 @@
 id: part-6-performance-normalization
 title: 'Redux Essentials, Part 6: Performance and Normalizing Data'
 sidebar_label: 'Performance and Normalizing Data'
-hide_title: true
 description: 'The official Redux Essentials tutorial: learn how to improve app performance and structure data correctly'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/fundamentals/part-1-overview.md
+++ b/docs/tutorials/fundamentals/part-1-overview.md
@@ -2,11 +2,8 @@
 id: part-1-overview
 title: 'Redux Fundamentals, Part 1: Redux Overview'
 sidebar_label: 'Redux Overview'
-hide_title: true
 description: 'The official Fundamentals tutorial for Redux: learn the fundamentals of using Redux'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/fundamentals/part-2-concepts-data-flow.md
+++ b/docs/tutorials/fundamentals/part-2-concepts-data-flow.md
@@ -2,11 +2,8 @@
 id: part-2-concepts-data-flow
 title: 'Redux Fundamentals, Part 2: Concepts and Data Flow'
 sidebar_label: 'Redux Concepts and Data Flow'
-hide_title: true
 description: 'The official Redux Fundamentals tutorial: learn key Redux terms and how data flows in a Redux app'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
+++ b/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
@@ -2,11 +2,8 @@
 id: part-3-state-actions-reducers
 title: 'Redux Fundamentals, Part 3: State, Actions, and Reducers'
 sidebar_label: 'State, Actions, and Reducers'
-hide_title: true
 description: 'The official Redux Fundamentals tutorial: learn how reducers update state in response to actions'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
@@ -700,7 +697,7 @@ values are the slice reducer functions that know how to update those slices of t
 
 Here's the contents of our app so far:
 
-<iframe 
+<iframe
   class="codesandbox"
   src="https://codesandbox.io/embed/github/reduxjs/redux-fundamentals-example-app/tree/checkpoint-1-combinedReducers/?fontsize=14&hidenavigation=1&module=%2Fsrc%2Freducer.js&theme=dark&runonclick=1"
   title="redux-fundamentals-example-app"

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -2,11 +2,8 @@
 id: part-4-store
 title: 'Redux Fundamentals, Part 4: Store'
 sidebar_label: 'Store'
-hide_title: true
 description: 'The official Redux Fundamentals tutorial: learn how to create and use a Redux store'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/fundamentals/part-5-ui-and-react.md
+++ b/docs/tutorials/fundamentals/part-5-ui-and-react.md
@@ -2,11 +2,8 @@
 id: part-5-ui-react
 title: 'Redux Fundamentals, Part 5: UI and React'
 sidebar_label: 'UI and React'
-hide_title: true
 description: 'The official Redux Fundamentals tutorial: learn how to use Redux with React'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/fundamentals/part-6-async-logic.md
+++ b/docs/tutorials/fundamentals/part-6-async-logic.md
@@ -2,11 +2,8 @@
 id: part-6-async-logic
 title: 'Redux Fundamentals, Part 6: Async Logic and Data Fetching'
 sidebar_label: 'Async Logic and Data Fetching'
-hide_title: true
 description: 'The official Redux Fundamentals tutorial: learn how to use async logic with Redux'
 ---
-
-&nbsp;
 
 # Redux Fundamentals, Part 6: Async Logic and Data Fetching
 

--- a/docs/tutorials/fundamentals/part-7-standard-patterns.md
+++ b/docs/tutorials/fundamentals/part-7-standard-patterns.md
@@ -2,11 +2,8 @@
 id: part-7-standard-patterns
 title: 'Redux Fundamentals, Part 7: Standard Redux Patterns'
 sidebar_label: 'Standard Redux Patterns'
-hide_title: true
 description: 'The official Fundamentals tutorial for Redux: learn the standard patterns used in real-world Redux apps'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/fundamentals/part-8-modern-redux.md
+++ b/docs/tutorials/fundamentals/part-8-modern-redux.md
@@ -2,11 +2,8 @@
 id: part-8-modern-redux
 title: 'Redux Fundamentals, Part 8: Modern Redux with Redux Toolkit'
 sidebar_label: 'Modern Redux with Redux Toolkit'
-hide_title: true
 description: 'The official Fundamentals tutorial for Redux: learn the modern way to write Redux logic'
 ---
-
-&nbsp;
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -2,10 +2,7 @@
 id: quick-start
 title: Quick Start
 sidebar_label: Quick Start
-hide_title: true
 ---
-
-&nbsp;
 
 # Redux Toolkit Quick Start
 

--- a/docs/tutorials/tutorials-index.md
+++ b/docs/tutorials/tutorials-index.md
@@ -3,11 +3,8 @@ id: tutorials-index
 slug: index
 title: 'Redux Tutorials Index'
 sidebar_label: 'Tutorials Index'
-hide_title: true
 description: 'Overview of the Redux tutorial pages'
 ---
-
-&nbsp;
 
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css'
@@ -35,7 +32,7 @@ We have two different full-size tutorials:
 
 Redux maintainer Mark Erikson appeared on the "Learn with Jason" show to explain how we recommend using Redux today. The show includes a live-coded example app that shows how to use Redux Toolkit and React-Redux hooks with Typescript, as well as the new RTK Query data fetching APIs:
 
-<LiteYouTubeEmbed 
+<LiteYouTubeEmbed
     id="9zySeP5vH9c"
     title="Learn Modern Redux - Redux Toolkit, React-Redux Hooks, and RTK Query"
 />

--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -2,10 +2,7 @@
 id: typescript-quick-start
 title: TypeScript Quick Start
 sidebar_label: TypeScript Quick Start
-hide_title: true
 ---
-
-&nbsp;
 
 # Redux Toolkit TypeScript Quick Start
 

--- a/docs/understanding/history-and-design/PriorArt.md
+++ b/docs/understanding/history-and-design/PriorArt.md
@@ -2,10 +2,7 @@
 id: prior-art
 title: Prior Art
 description: 'Introduction > Prior Art: Influences on the design of Redux'
-hide_title: true
 ---
-
-&nbsp;
 
 # Prior Art
 

--- a/docs/understanding/history-and-design/middleware.md
+++ b/docs/understanding/history-and-design/middleware.md
@@ -2,10 +2,7 @@
 id: middleware
 title: Middleware
 description: 'History and Design > Middleware: How middleware enable adding additional capabilities to the Redux store'
-hide_title: true
 ---
-
-&nbsp;
 
 # Middleware
 

--- a/docs/understanding/thinking-in-redux/Glossary.md
+++ b/docs/understanding/thinking-in-redux/Glossary.md
@@ -1,10 +1,7 @@
 ---
 id: glossary
 title: Glossary
-hide_title: true
 ---
-
-&nbsp;
 
 # Glossary
 

--- a/docs/understanding/thinking-in-redux/Motivation.md
+++ b/docs/understanding/thinking-in-redux/Motivation.md
@@ -2,10 +2,7 @@
 id: motivation
 title: Motivation
 description: 'Introduction > Motivation: What problems does Redux try to solve?'
-hide_title: true
 ---
-
-&nbsp;
 
 # Motivation
 

--- a/docs/understanding/thinking-in-redux/ThreePrinciples.md
+++ b/docs/understanding/thinking-in-redux/ThreePrinciples.md
@@ -2,10 +2,7 @@
 id: three-principles
 title: Three Principles
 description: 'Introduction > Three Principles: Three key principles for using Redux'
-hide_title: true
 ---
-
-&nbsp;
 
 # Three Principles
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [v] Have the files been linted and formatted?

## What docs page needs to be fixed?

All

## What is the problem?

From Docusaurus v2, `hide_title: true` frontmatter hides h1 title from their page. 

Recent commits 264c21779f328093d6711d10f41140a35ca631dc and 757377326a48403203a44fa4d0f3b26072d002ea adds dummy content to work around this issue. But I recommend removing `hide_title: true` and using `sidebar_label` when we need it.

