### PR TITLE
[website] text color always white on darkness BG

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -98,6 +98,14 @@ div[class*='codeBlockTitle'] {
   padding: 0.15rem var(--ifm-pre-padding);
 }
 
+:root[data-theme='dark'] .admonition code {
+  color: var(--ifm-blockquote-color);
+}
+
+:root[data-theme='dark'] blockquote code {
+  color: var(--ifm-blockquote-color);
+}
+
 code {
   background-color: var(--ifm-color-emphasis-300);
   border-radius: 0.2rem;


### PR DESCRIPTION
As same as https://github.com/reduxjs/redux-toolkit/pull/1200 I changed text color front of darkness background color.
This might be better to read.

BeforePR
<img width="943" alt="before" src="https://user-images.githubusercontent.com/5501268/123530095-b8e02a00-d731-11eb-8afe-e2588a78250c.png">

AfterPR
<img width="965" alt="after" src="https://user-images.githubusercontent.com/5501268/123530098-c5648280-d731-11eb-87d1-2a59dedcd802.png">

