### PR TITLE
Fixing broken links to redux-thunk github

### DIFF
--- a/docs/usage/writing-logic-thunks.mdx
+++ b/docs/usage/writing-logic-thunks.mdx
@@ -23,7 +23,7 @@ The word "thunk" is a programming term that means ["a piece of code that does so
 
 For Redux specifically, **"thunks" are a pattern of writing functions with logic inside that can interact with a Redux store's `dispatch` and `getState` methods**.
 
-Using thunks requires the [`redux-thunk` middleware](https://github.com/redujs/redux-thunk) to be added to the Redux store as part of its configuration.
+Using thunks requires the [`redux-thunk` middleware](https://github.com/reduxjs/redux-thunk) to be added to the Redux store as part of its configuration.
 
 Thunks are [the standard approach for writing async logic in Redux apps](../style-guide/style-guide.md#use-thunks-for-async-logic), and are commonly used for data fetching. However, they can be used for a variety of tasks, and can contain both synchronous and asynchronous logic.
 
@@ -109,7 +109,7 @@ Thunks are "one-shot" functions, with no sense of a lifecycle. They also cannot 
 
 ## Redux Thunk Middleware
 
-Dispatching thunk functions requires that the [`redux-thunk` middleware](https://github.com/redujs/redux-thunk) has been added to the Redux store as part of its configuration.
+Dispatching thunk functions requires that the [`redux-thunk` middleware](https://github.com/reduxjs/redux-thunk) has been added to the Redux store as part of its configuration.
 
 ### Adding the Middleware
 


### PR DESCRIPTION
---
name: :memo: Fixing broken links to redux-thunk github
about: Fixing broken links to redux-thunk github
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - N/A
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Using Redux
- **Page**: [Writing Logic with Thunks](https://redux.js.org/usage/writing-logic-thunks)

## What is the problem?
There are 2 broken Github links to the redux-thunk documentation in this document - they are both missing the `x` in `redux-thunk`.

## What changes does this PR make to fix the problem?
It adds in the 2 x's :)
