### PR TITLE
Fix typo for arrow function syntax

### DIFF
--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -190,7 +190,7 @@ You can expose an `injectStore` function from the interceptor file instead:
 ```js title="common/api.js"
 let store
 
-export const injectStore(_store) {
+export const injectStore = (_store) => {
   store = _store
 }
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**: [FAQ Code Structure Page](https://redux.js.org/faq/code-structure#how-can-i-use-the-redux-store-in-non-component-files)

## What is the problem?

There's a typo for arrow function syntax

## What changes does this PR make to fix the problem?

I fixed the syntax
