### PR TITLE
Update Redux Essentials Part 2, app/store.js code

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -125,14 +125,15 @@ Let's start by looking at how the Redux store is created.
 Open up `app/store.js`, which should look like this:
 
 ```js title="app/store.js"
-import { configureStore } from '@reduxjs/toolkit'
-import counterReducer from '../features/counter/counterSlice'
+import { configureStore } from "@reduxjs/toolkit";
+import counterReducer from "../features/counter/counterSlice";
 
-export default configureStore({
+export const store = configureStore({
   reducer: {
-    counter: counterReducer
-  }
-})
+    counter: counterReducer,
+  },
+});
+
 ```
 
 The Redux store is created using the `configureStore` function from Redux Toolkit. `configureStore` requires that we pass in a `reducer` argument.


### PR DESCRIPTION
**I'm updating the DOC!, NOT the actual code!**
https://redux.js.org/tutorials/essentials/part-2-app-structure

In this Redux Essentials tutorial, app/store.js,
`export default configureStore` should be changed to
`export const store = configureStore` to match [the current code](https://github.com/reduxjs/cra-template-redux/blob/master/template/src/app/store.js)

Otherwise, it will throw ["Attempted import error"](https://stackoverflow.com/questions/53328408/receiving-attempted-import-error-in-react-app)

Thanks for the PR!