### PR TITLE
[Tutorial Docs] Fixing a grammar mistake

### DIFF
--- a/docs/tutorials/fundamentals/part-5-ui-and-react.md
+++ b/docs/tutorials/fundamentals/part-5-ui-and-react.md
@@ -274,7 +274,7 @@ export default Header
 
 Our components can now read state from the store, and dispatch actions to the store. However, we're still missing something. Where and how are the React-Redux hooks finding the right Redux store? A hook is a JS function, so it can't automatically import a store from `store.js` by itself.
 
-Instead, we have to specifically tell React-Redux what store we want to use in our components. We do this by **rendering a `<Provider>` component around our entire `<App>`, and passing the Redux store as a prop to `<Provider>`**. After we do this once, every component in the application will be able to access the Redux store if needs to.
+Instead, we have to specifically tell React-Redux what store we want to use in our components. We do this by **rendering a `<Provider>` component around our entire `<App>`, and passing the Redux store as a prop to `<Provider>`**. After we do this once, every component in the application will be able to access the Redux store if it needs to.
 
 Let's add that to our main `index.js` file:
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a grammar mistake in an existing docs page
---

## Checklist

- [] Is there an existing issue for this PR? no
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials/fundamentals
- **Page**: part-5-ui-react

## What is the problem?
Missing 'it' pronoun.

## What changes does this PR make to fix the problem?
Add 'it' pronoun.
