### PR TITLE
fix: miniKindOf returns 'object' for plain object

### DIFF
--- a/src/utils/kindOf.ts
+++ b/src/utils/kindOf.ts
@@ -3,7 +3,7 @@ export function miniKindOf(val: any): string {
   if (val === void 0) return 'undefined'
   if (val === null) return 'null'
 
-  const type = typeof val
+  let type = typeof val
   switch (type) {
     case 'boolean':
     case 'string':
@@ -30,7 +30,7 @@ export function miniKindOf(val: any): string {
   }
 
   // other
-  return type.slice(8, -1).toLowerCase().replace(/\s/g, '')
+  return Object.prototype.toString.call(val).slice(8, -1).toLowerCase().replace(/\s/g, '')
 }
 
 function ctorName(val: any): string | null {


### PR DESCRIPTION
### name: "miniKindOf returns 'object' for plain object"
### about: miniKindOf returns 'object' for plain object
## PR Type
---
## Does this PR add a new feature, or fix a bug?
Fix a bug.

## Why should this PR be included?
Reference link：https://github.com/jonschlinkert/kind-of/blob/abab085d65f7ee978011da8f135291892fcd97db/index.js#L54
When I read the redux source code, its incorrect behavior confused me.

## Checklist
 Have you added an explanation of what your changes do and why you'd like us to include them?
 Is there an existing issue for this PR?
 Have the files been linted and formatted?
 Have the docs been updated to match the changes in the PR?
 Have the tests been updated to match the changes in the PR?
 Have you run the tests locally to confirm they pass?
## Bug Fixes
What is the current behavior, and the steps to reproduce the issue?
For a plain object,miniKindOf  should returns  ""

What is the expected behavior?
For a plain object,miniKindOf  should returns "object"  instead of ""

How does this PR fix the problem?
use `Object.prototype.toString.call()` to get the correct type of plain object instead of `typeof`

