### PR TITLE
Fix code snippet in tutorial (async logic)

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -747,7 +747,7 @@ export const addNewPost = createAsyncThunk(
   // The payload creator receives the partial `{title, content, user}` object
   async initialPost => {
     // We send the initial data to the fake API server
-    const response = await client.post('/fakeApi/posts', { post: initialPost })
+    const response = await client.post('/fakeApi/posts', initialPost)
     // The response includes the complete post object, including unique ID
     return response.data
   }


### PR DESCRIPTION
The mock server expects _just_ the `initialPost` object, rather than an object with a `post` field.