### PR TITLE
Update docs

### DIFF
--- a/docs/usage/WritingTests.md
+++ b/docs/usage/WritingTests.md
@@ -102,7 +102,7 @@ Because reducers are pure functions, testing them should be straightforward. Cal
 #### Example
 
 ```js
-import { createReducer } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
 
 const initialState = [
   {


### PR DESCRIPTION
**Description : -**

This PR updates the wrong import for creating slice. Earlier it was importing `createReducer` but in the code `createSlice` was being used.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?

Incorrect method has been imported for creating the slice.

## What changes does this PR make to fix the problem?

Changes the import function from `createReducer` to `createSlice`