### PR TITLE
Fix mistake in kindOf.ts

### DIFF
--- a/src/utils/kindOf.ts
+++ b/src/utils/kindOf.ts
@@ -30,7 +30,7 @@ export function miniKindOf(val: any): string {
   }
 
   // other
-  return type.slice(8, -1).toLowerCase().replace(/\s/g, '')
+  return Object.prototype.toString.call(val).slice(8, -1).toLowerCase().replace(/\s/g, '')
 }
 
 function ctorName(val: any): string | null {

--- a/src/utils/kindOf.ts
+++ b/src/utils/kindOf.ts
@@ -30,7 +30,11 @@ export function miniKindOf(val: any): string {
   }
 
   // other
-  return Object.prototype.toString.call(val).slice(8, -1).toLowerCase().replace(/\s/g, '')
+  return Object.prototype.toString
+    .call(val)
+    .slice(8, -1)
+    .toLowerCase()
+    .replace(/\s/g, '')
 }
 
 function ctorName(val: any): string | null {


### PR DESCRIPTION
In function miniKindOf: in other case, forget to invoke 'Object.prototype.toString' to get type

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
