### PR TITLE
docs: fix typos in essentials tutorial

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -373,7 +373,7 @@ export const fetchPosts = createAsyncThunk('posts/fetchPosts', async () => {
 
 The payload creator will usually make an AJAX call of some kind, and can either return the `Promise` from the AJAX call directly, or extract some data from the API response and return that. We typically write this using the JS `async/await` syntax, which lets us write functions that use `Promise`s while using standard `try/catch` logic instead of `somePromise.then()` chains.
 
-In this case, we pass in `'posts/fetchPosts'` as the action type prefix. Our payload creation callback waits for the API call to return a response. The response object looks like `{posts: []}`, and we want our dispatched Redux action to have a payload that is _just_ the array of posts. So, we extract `response.data`, and return that from the callback.
+In this case, we pass in `'posts/fetchPosts'` as the action type prefix. Our payload creation callback waits for the API call to return a response. The response object looks like `{data: []}`, and we want our dispatched Redux action to have a payload that is _just_ the array of posts. So, we extract `response.data`, and return that from the callback.
 
 If we try calling `dispatch(fetchPosts())`, the `fetchPosts` thunk will first dispatch an action type of `'posts/fetchPosts/pending'`:
 

--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -66,7 +66,7 @@ export const apiSlice = createApi({
     // highlight-start
     editPost: builder.mutation({
       query: post => ({
-        url: `posts/${post.id}`,
+        url: `/posts/${post.id}`,
         method: 'PATCH',
         body: post
       })
@@ -308,7 +308,7 @@ This dispatch happens automatically inside the query hooks, but we can start it 
 
 :::caution
 
-Manually dispatching an RTKQ request thunk will create a subscription entry, but it's then up to you to [unsubscribe from that data later](https://redux-toolkit.js.org/rtk-query/usage/usage-without-react-hooks#removing-a-subscription) - otherwise the data stays in the cache permanently. In this case, we always need user data, so we can skip unsuscribing.
+Manually dispatching an RTKQ request thunk will create a subscription entry, but it's then up to you to [unsubscribe from that data later](https://redux-toolkit.js.org/rtk-query/usage/usage-without-react-hooks#removing-a-subscription) - otherwise the data stays in the cache permanently. In this case, we always need user data, so we can skip unsubscribing.
 
 :::
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing typos in Essentials Tutorials
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - no
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Essentials Tutorial
- **Page**: page 5, page 8

## What is the problem?
There are some typos in the aforementioned pages.

## What changes does this PR make to fix the problem?
Typos have been fixed.
