### PR TITLE
docs: Remove redundant line from Redux Essentials Tutorial

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -785,8 +785,6 @@ We can have our component logic wait for the async thunk to finish, and check th
 ```js title="features/posts/AddPostForm.js"
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-// highlight-next-line
-import { unwrapResult } from '@reduxjs/toolkit'
 
 // highlight-next-line
 import { addNewPost } from './postsSlice'


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: https://redux.js.org/tutorials/essentials/part-5-async-logic#checking-thunk-results-in-components
- **Page**: https://redux.js.org/tutorials/essentials/part-5-async-logic

## What is the problem?
There is a redundant line in the section. This now is obsolete, and `.unwrap()` method on the dispatch is being used to unwrap the Promise.

```jsx
import { unwrapResult } from '@reduxjs/toolkit'
```

## What changes does this PR make to fix the problem?
Remove the corresponding line from documentation, to avoid confusion.