### PR TITLE
📝 Update MSW usage

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -31,7 +31,7 @@ In this section, we'll convert our social media app to fetch the posts and users
 
 ### Example REST API and Client
 
-To keep the example project isolated but realistic, the initial project setup already included a fake in-memory REST API for our data (configured using [the Mock Service Worker mock API tool](https://mswjs.io/)). The API uses `/fakeApi` as the base URL for the endpoints, and supports the typical `GET/POST/PUT/DELETE` HTTP methods for `/fakeApi/posts`, `/fakeApi/users`, and `fakeApi/notifications`. It's defined in `src/api/server.js`.
+To keep the example project isolated but realistic, the initial project setup already includes a fake in-memory REST API for our data (configured using [the Mock Service Worker mock API tool](https://mswjs.io/)). The API uses `/fakeApi` as the base URL for the endpoints, and supports the typical `GET/POST/PUT/DELETE` HTTP methods for `/fakeApi/posts`, `/fakeApi/users`, and `fakeApi/notifications`. It's defined in `src/api/server.js`.
 
 The project also includes a small HTTP API client object that exposes `client.get()` and `client.post()` methods, similar to popular HTTP libraries like `axios`. It's defined in `src/api/client.js`.
 
@@ -705,27 +705,30 @@ export default usersSlice.reducer
 We only need to fetch the list of users once, and we want to do it right when the application starts. We can do that in our `index.js` file, and directly dispatch the `fetchUsers` thunk because we have the `store` right there:
 
 ```js title="index.js"
-// omit imports
+// omit other imports
 
 // highlight-next-line
 import { fetchUsers } from './features/users/usersSlice'
 
 import { worker } from './api/server'
 
-// Start our mock API server
-worker.start({ onUnhandledRequest: 'bypass' })
+async function main() {
+  // Start our mock API server
+  await worker.start({ onUnhandledRequest: 'bypass' })
 
-// highlight-next-line
-store.dispatch(fetchUsers())
+  // highlight-next-line
+  store.dispatch(fetchUsers())
 
-ReactDOM.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>,
-  document.getElementById('root')
-)
+  ReactDOM.render(
+    <React.StrictMode>
+      <Provider store={store}>
+        <App />
+      </Provider>
+    </React.StrictMode>,
+    document.getElementById('root')
+  )
+}
+main()
 ```
 
 Now, each of the posts should be showing a username again, and we should also have that same list of users shown in the "Author" dropdown in our `<AddPostForm>`.

--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -288,20 +288,23 @@ If we want to fetch the list of users outside of React, we can dispatch the `get
 // highlight-next-line
 import { apiSlice } from './features/api/apiSlice'
 
-// Start our mock API server
-worker.start({ onUnhandledRequest: 'bypass' })
+async function main() {
+  // Start our mock API server
+  await worker.start({ onUnhandledRequest: 'bypass' })
 
-// highlight-next-line
-store.dispatch(apiSlice.endpoints.getUsers.initiate())
+  // highlight-next-line
+  store.dispatch(apiSlice.endpoints.getUsers.initiate())
 
-ReactDOM.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>,
-  document.getElementById('root')
-)
+  ReactDOM.render(
+    <React.StrictMode>
+      <Provider store={store}>
+        <App />
+      </Provider>
+    </React.StrictMode>,
+    document.getElementById('root')
+  )
+}
+main()
 ```
 
 This dispatch happens automatically inside the query hooks, but we can start it manually if needed.
@@ -405,15 +408,35 @@ export const selectUsersResult = extendedApiSlice.endpoints.getUsers.select()
 
 At the moment, the only file that references the `getUsers` endpoint is our index file, which is dispatching the `initiate` thunk. We need to update that to import the extended API slice instead:
 
-```js title="index.js"
-// highlight-next-line
-import { extendedApiSlice } from './features/users/usersSlice'
+```diff title="index.js"
+  // omit other imports
+  // highlight-start
+- import { apiSlice } from './features/api/apiSlice'
++ import { extendedApiSlice } from './features/users/usersSlice'
+  // highlight-end
 
-// Start our mock API server
-worker.start({ onUnhandledRequest: 'bypass' })
 
-// highlight-next-line
-store.dispatch(extendedApiSlice.endpoints.getUsers.initiate())
+  async function main() {
+    // Start our mock API server
+    await worker.start({ onUnhandledRequest: 'bypass' })
+
+
+    // highlight-start
+-   store.dispatch(apiSlice.endpoints.getUsers.initiate())
++   store.dispatch(extendedApiSlice.endpoints.getUsers.initiate())
+    // highlight-end
+
+
+    ReactDOM.render(
+      <React.StrictMode>
+        <Provider store={store}>
+          <App />
+        </Provider>
+      </React.StrictMode>,
+      document.getElementById('root')
+    )
+  }
+  main()
 ```
 
 Alternately, you could just export the specific endpoints themselves from the slice file.


### PR DESCRIPTION
- show MSW usage as awaiting service worker registration
  in case of race conditions with other workers
- minor text updates

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  N/A - No existing issue
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials/Redux-Essentials
- **Page**: 
  - Redux Essentials, Part 5: Async Logic and Data Fetching
  - Redux Essentials, Part 8: RTK Query Advanced Patterns

## What is the problem?

MSW by default will defer network requests while starting the worker (see [start#waituntilready](https://mswjs.io/docs/api/setup-worker/start#waituntilready)). However, @msutkowski has pointed out if service worker registration fights with another, it won't kick in. The result is flaky behaviour - sometimes the requests will be attempted prior to the service worker registration, causing failed requests.

e.g. the 'posts' in the corresponding codesandbox examples won't necessarily be mocked: https://codesandbox.io/s/github/reduxjs/redux-essentials-example-app/tree/checkpoint-6-rtkqConversion/?from-embed

## What changes does this PR make to fix the problem?

This PR updates the tutorial snippets to show `awaiting` the service worker registration prior to firing initial requests or mounting the app.

Note that this does _not_ inherently update the codesandbox examples themselves, which are instead hosted on the [redux-essentials-example-app](https://github.com/reduxjs/redux-essentials-example-app) repo. @markerikson; given that the codesandbox demos use tag-based references for multiple stages of the example app, I'm not sure what the best way to update each of them would be.