### PR TITLE
recommend use of an api cache library in the style guide

### DIFF
--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -96,6 +96,12 @@ Writing immutable update logic by hand is frequently difficult and prone to erro
 
 <a id="structure-files-as-feature-folders-or-ducks"></a>
 
+### Avoid hand-writing API Caching Logic
+
+When writing API caching logic by hand, you might end up with a lot of very repetitive code and no real "business logic" in that code.  
+Use [RTK Query](https://redux-toolkit.js.org/rtk-query/overview) (which is part of Redux Toolkit) or another API cache library like [React Query](https://react-query.tanstack.com/), [SWR](https://swr.vercel.app/), [urql](https://formidable.com/open-source/urql/) or [Apollo Client](https://www.apollographql.com/docs/react/) to handle cache state for you instead.  
+Only handle caching logic yourself when you have specific business logic attached to that data that cannot be sufficiently covered by one of those libraries.
+
 ### Structure Files as Feature Folders with Single-File Logic
 
 Redux itself does not care about how your application's folders and files are structured. However, co-locating logic for a given feature in one place typically makes it easier to maintain that code.


### PR DESCRIPTION
---
name: :book: Recommend use of an api cache library in the style guide
about: Add a section to the style guide to use RTK Query or an alternative library.
---

## PR Type

**Update an _existing_ page**

## Checklist

- [ ] Is there an existing issue for this PR?
- [ ] Have the files been linted and formatted?
No, the linter runs amok on my local machine and tries to format everything differently.

## What docs page is being added or updated?

- **Section**: Style Guide

## For Updating Existing Content

### What updates should be made to the page?

Add a section to the style guide to use RTK Query or an alternative library.

### Do these updates change any of the assumptions or target audience? If so, how do they change?

They add more emphasis that api cache logic should usually not be written by hand.


@markerikson generally I am very open to pretty much rewording *anything* in here, but we should probably get RTK-Q mentioned in the style guide.
