### PR TITLE
docs: Remove line that breaks code from Redux Essentials Tutorial

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -749,7 +749,6 @@ export const extendedApi = apiSlice.injectEndpoints({
   endpoints: builder => ({
     getNotifications: builder.query({
       query: () => '/notifications',
-      transformResponse: res => res.notifications,
       async onCacheEntryAdded(
         arg,
         { updateCachedData, cacheDataLoaded, cacheEntryRemoved }


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials
- **Page**: Part 8: RTK Query Advanced Patterns

## What is the problem?
In this part: https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#streaming-cache-updates , there is a line (see below) in that transform data received in query response, but we receive a plain array with notification objects, there is no nesting.

```javascript
transformResponse: (res) => res.notifications
```

It breaks code because it will return `undefined`.

## What changes does this PR make to fix the problem?
It removes `transformResponse` method from the query builder.