### PR TITLE
Fix typo in comments of src/types/store.ts

### DIFF
--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -35,7 +35,7 @@ declare const $CombinedState: unique symbol
  * (i.e. not exported), and internally we never check its value. Since it's a
  * symbol property, it's not expected to be enumerable, and the value is
  * typed as always undefined, so its never expected to have a meaningful
- * value anyway. It just makes this type distinquishable from plain `{}`.
+ * value anyway. It just makes this type distinguishable from plain `{}`.
  */
 export type CombinedState<S> = { readonly [$CombinedState]?: undefined } & S
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - No
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- In code comments, not a dedicated documentation page

## What is the problem?

Misspelled word

## What changes does this PR make to fix the problem?

Spells the word correctly