### PR TITLE
Allow preloaded state types to contain nested `unknown` fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ export type PreloadedState<S> = Required<S> extends EmptyObject
       }
     : never
   : {
-      [K in keyof S]: S[K] extends string | number | boolean | symbol
+      [K in keyof S]: S[K] extends string | number | boolean | symbol | unknown
         ? S[K]
         : PreloadedState<S[K]>
     }


### PR DESCRIPTION
This PR:

- Updates the `PreloadedState` type to allow terminating on an `unknown` field in addition to other primitives

Without this, a state type that contains a nested `unknown` field
will cause errors like:

> Types of property 'x' are incompatible.
> Type 'unknown' is not assignable to type 'undefined'.ts(2345)

