### PR TITLE
Fix code example in part-6-performance-normalization.md

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -961,11 +961,11 @@ const notificationsSlice = createSlice({
   extraReducers(builder) {
     builder.addCase(fetchNotifications.fulfilled, (state, action) => {
       // highlight-start
+      notificationsAdapter.upsertMany(state, action.payload)
       Object.values(state.entities).forEach(notification => {
         // Any notifications we've read are no longer new
         notification.isNew = !notification.read
       })
-      notificationsAdapter.upsertMany(state, action.payload)
       // highlight-end
     })
   }


### PR DESCRIPTION
This moves the call to upsertMany the new notifications before the code
which assigns the isNew boolean. Otherwise isNew is not set correctly on
new notifications and you don't get the new styles applied. This is
consistent with the previous example code before it was converted to use
createEntityAdapter.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR? No
- [x] Have the files been linted and formatted? Ran linting, don't think this line shift adjusted formatting at all though.

## What docs page needs to be fixed?

- **Section**: Redux Essentials Tutorial
- **Page**: part-6-performance-normalization

## What is the problem?
The code example which adds `createEntityAdapter` to the notifications reducer breaks the functionality where new notifications are shown in a different style.

## What changes does this PR make to fix the problem?
It moves the statements in the correct order to fix the issue. This matches the order they were in before the `createEntityAdapter` conversion. See lines 366-371 of the same file, you'll see adding of the new notifications to the state happens before we set the `isNew` variables, but before this change that is flipped when at the part about converting to `createEntityAdapter`.