### PR TITLE
Update part-7-rtk-query-basics.md

### DIFF
--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -132,7 +132,7 @@ export const apiSlice = createApi({
   })
 })
 
-// Export the auto-generated hook for the `getPost` query endpoint
+// Export the auto-generated hook for the `getPosts` query endpoint
 export const { useGetPostsQuery } = apiSlice
 ```
 


### PR DESCRIPTION
Fix a comment in a code snippet in part-7-rtk-query-basics.md

In line 135, It should have been `getPosts` instead of `getPost`. I think the og author mixed it with another endpoint called `getPost` that was introduced further down the page.
