### PR TITLE
Convert postId param to number before using

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -249,7 +249,7 @@ import { useHistory } from 'react-router-dom'
 import { postUpdated } from './postsSlice'
 
 export const EditPostForm = ({ match }) => {
-  const { postId } = match.params
+  const  postId  = Number(match.params.postId)
 
   const post = useSelector(state =>
     state.posts.find(post => post.id === postId)


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR? 
  - _link issue here_
- [ x] Have the files been linted and formatted? 

## What docs page needs to be fixed?

- **Section**: Redux Essentials Tutorial
- **Page**: Part 4

## What is the problem?
Going through this tutorial in the docs (Redux Essentials Part 4), reading the code example for the SinglePostPage component, I found that `match.params.postId` is a string, whereas the postId on the post object is a number (line 252).


e.g `2 === '2' `returns false in line 255.

## What changes does this PR make to fix the problem?

Propose wrapping this in the `Number()` function to avoid `state.posts.find(post => post.id === postId)` returning undefined. 

