### PR TITLE
docs(immutable data): nested bullet point formatting

### DIFF
--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -45,8 +45,7 @@ In particular, immutability in the context of a Web app enables sophisticated ch
 
 - Both Redux and React-Redux employ [shallow equality checking](#how-do-shallow-and-deep-equality-checking-differ). In particular:
   - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-does-redux-use-shallow-equality-checking) caused by the reducers that it calls.
-  - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
-  Such [shallow checking requires immutability](#why-will-shallow-equality-checking-not-work-with-mutable-objects) to function correctly.
+  - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render. Such [shallow checking requires immutability](#why-will-shallow-equality-checking-not-work-with-mutable-objects) to function correctly.
 - Immutable data management ultimately makes data handling safer.
 - Time-travel debugging requires that reducers be pure functions with no side effects, so that you can correctly jump between different states.
 

--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -44,8 +44,8 @@ In particular, immutability in the context of a Web app enables sophisticated ch
 ## Why is immutability required by Redux?
 
 - Both Redux and React-Redux employ [shallow equality checking](#how-do-shallow-and-deep-equality-checking-differ). In particular:
-    - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-does-redux-use-shallow-equality-checking) caused by the reducers that it calls.
-    - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
+  - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-does-redux-use-shallow-equality-checking) caused by the reducers that it calls.
+  - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
   Such [shallow checking requires immutability](#why-will-shallow-equality-checking-not-work-with-mutable-objects) to function correctly.
 - Immutable data management ultimately makes data handling safer.
 - Time-travel debugging requires that reducers be pure functions with no side effects, so that you can correctly jump between different states.

--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -43,7 +43,9 @@ In particular, immutability in the context of a Web app enables sophisticated ch
 
 ## Why is immutability required by Redux?
 
-- Both Redux and React-Redux employ [shallow equality checking](#how-do-shallow-and-deep-equality-checking-differ). In particular: - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-does-redux-use-shallow-equality-checking) caused by the reducers that it calls. - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
+- Both Redux and React-Redux employ [shallow equality checking](#how-do-shallow-and-deep-equality-checking-differ). In particular:
+    - Redux's `combineReducers` utility [shallowly checks for reference changes](#how-does-redux-use-shallow-equality-checking) caused by the reducers that it calls.
+    - React-Redux's `connect` method generates components that [shallowly check reference changes to the root state](#how-does-react-redux-use-shallow-equality-checking), and the return values from the `mapStateToProps` function to see if the wrapped components actually need to re-render.
   Such [shallow checking requires immutability](#why-will-shallow-equality-checking-not-work-with-mutable-objects) to function correctly.
 - Immutable data management ultimately makes data handling safer.
 - Time-travel debugging requires that reducers be pure functions with no side effects, so that you can correctly jump between different states.


### PR DESCRIPTION
There are list items in a bullet point marked by dashes. They are converted into nested bullet points for increased readability.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: _Why is immutability required by Redux?_
- **Page**: https://redux.js.org/faq/immutable-data 

## What is the problem?

There are dashes to mark list items in a bullet point, but they are unformatted, making it hard to read. 

<img width="1172" alt="before-edit" src="https://user-images.githubusercontent.com/28845173/144691999-c64789ac-6b8b-481f-857d-a2a376189264.png">

## What changes does this PR make to fix the problem?

This PR adds newlines and indentation so that the dashed text in the bullet point can become nested bullet points.

<img width="1088" alt="after" src="https://user-images.githubusercontent.com/28845173/144692026-30e4470b-e6b9-40a4-86c3-361acc60055f.png">

