### PR TITLE
Update part-5-async-logic.md

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -455,7 +455,7 @@ The `builder` object in `extraReducers` provides methods that let us define addi
 - `builder.addMatcher(matcher, reducer)`: defines a case reducer that can run in response to any action where the `matcher` function returns `true`
 - `builder.addDefaultCase(reducer)`: defines a case reducer that will run if no other case reducers were executed for this action.
 
-You can chain these together, like `builder.addCase().addCase().addMatcher().addDefault()`. If multiple matchers match the action, they will run in the order they were defined.
+You can chain these together, like `builder.addCase().addCase().addMatcher().addDefaultCase()`. If multiple matchers match the action, they will run in the order they were defined.
 
 ```js
 import { increment } from '../features/counter/counterSlice'


### PR DESCRIPTION
Maybe it should be a addDefaultCase() not addDefault()

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ x ] Is there an existing issue for this PR?
  - _link issue here_
- [ x ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- Async Logic and Data Fetching
- **Page**:
- Detailed Explanation: Adding Extra Reducers to Slices

## What is the problem?
Incorrect function call (builder.addDefault())
## What changes does this PR make to fix the problem?

