### PR TITLE
Add a tip pointing to code splitting

### DIFF
--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -140,7 +140,9 @@ RTK Query's functionality is based on a single method, called `createApi`. All o
 
 :::tip
 
-Your application is expected to have only one `createApi` call in it. If you're looking to split up your endpoints between multiple files, read through [this](https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#injecting-endpoints) section of the docs!
+**Your application is expected to have only one `createApi` call in it**. This one API slice should contain _all_ endpoint definitions that talk to the same base URL. For example, endpoints `/api/posts` and `/api/users` are both fetching data from the same server, so they would go in the same API slice.  If your app does fetch data from multiple servers, you can either specify full URLs in each endpoint, or if necessary create separate API slices for each server.
+
+Endpoints are normally defined directly inside the `createApi` call. If you're looking to split up your endpoints between multiple files, see [the "Injecting Endpoints" section in Part 8](https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#injecting-endpoints) section of the docs!
 
 :::
 

--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -138,6 +138,12 @@ export const { useGetPostsQuery } = apiSlice
 
 RTK Query's functionality is based on a single method, called `createApi`. All of the Redux Toolkit APIs we've seen so far are UI-agnostic, and could be used with _any_ UI layer. The RTK Query core logic is the same way. However, RTK Query also includes a React-specific version of `createApi`, and since we're using RTK and React together, we need to use that to take advantage of RTK's React integration. So, we import from `'@reduxjs/toolkit/query/react'` specifically.
 
+:::tip
+
+Your application is expected to have only one `createApi` call in it. If you're looking to split up your endpoints between multiple files, read through [this](https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#injecting-endpoints) section of the docs!
+
+:::
+
 #### API Slice Parameters
 
 When we call `createApi`, there are two fields that are required:

--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -140,7 +140,7 @@ RTK Query's functionality is based on a single method, called `createApi`. All o
 
 :::tip
 
-**Your application is expected to have only one `createApi` call in it**. This one API slice should contain _all_ endpoint definitions that talk to the same base URL. For example, endpoints `/api/posts` and `/api/users` are both fetching data from the same server, so they would go in the same API slice.  If your app does fetch data from multiple servers, you can either specify full URLs in each endpoint, or if necessary create separate API slices for each server.
+**Your application is expected to have only one `createApi` call in it**. This one API slice should contain _all_ endpoint definitions that talk to the same base URL. For example, endpoints `/api/posts` and `/api/users` are both fetching data from the same server, so they would go in the same API slice. If your app does fetch data from multiple servers, you can either specify full URLs in each endpoint, or if necessary create separate API slices for each server.
 
 Endpoints are normally defined directly inside the `createApi` call. If you're looking to split up your endpoints between multiple files, see [the "Injecting Endpoints" section in Part 8](https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#injecting-endpoints) section of the docs!
 

--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -142,7 +142,7 @@ RTK Query's functionality is based on a single method, called `createApi`. All o
 
 **Your application is expected to have only one `createApi` call in it**. This one API slice should contain _all_ endpoint definitions that talk to the same base URL. For example, endpoints `/api/posts` and `/api/users` are both fetching data from the same server, so they would go in the same API slice. If your app does fetch data from multiple servers, you can either specify full URLs in each endpoint, or if necessary create separate API slices for each server.
 
-Endpoints are normally defined directly inside the `createApi` call. If you're looking to split up your endpoints between multiple files, see [the "Injecting Endpoints" section in Part 8](https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#injecting-endpoints) section of the docs!
+Endpoints are normally defined directly inside the `createApi` call. If you're looking to split up your endpoints between multiple files, see [the "Injecting Endpoints" section in Part 8](./part-8-rtk-query-advanced.md#injecting-endpoints) section of the docs!
 
 :::
 


### PR DESCRIPTION
---
name: :book: Add a tip pointing to code splitting
about: Updating content in an existing docs page
---

## PR Type

**update an _existing_ page**

## Checklist

- [ ] Is there an existing issue for this PR?
  - [Discord thread](https://discord.com/channels/102860784329052160/103538784460615680/920489794331611136)
- [ ] Have the files been linted and formatted?
  - No, since I've edited directly in Github, but LGTM?

## What docs page is being added or updated?

- **Section**: Redux Essentials
- **Page**: RTK Query Advanced Patterns

## For Updating Existing Content

### What updates should be made to the page?
The main goal is to highlight the fact that you're expect to have only one `createApi` call in the app. (Maybe it's rather one per API, as in, if it's a different server, it's a different `createApi`?). I'm also putting a link to the advanced concept of `Injecting endpoints` that people most likely want when calling `createApi` multiple times.

### Do these updates change any of the assumptions or target audience? If so, how do they change?
I don't think so.