### PR TITLE
Update part-8-rtk-query-advanced.md

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -530,7 +530,7 @@ export const UserPage = ({ match }) => {
     // Return a unique selector instance for this page so that
     // the filtered results are correctly memoized
     return createSelector(
-      res => res.data,
+      res => res.data ?? [],
       (res, userId) => userId,
       (data, userId) => data.filter(post => post.user === userId)
     )


### PR DESCRIPTION
Currently the app will error if it tries to run the selector before posts are cached. This fixes it by returning an empty array in that case.
