### PR TITLE
Add optimistically updating 'getPost' cache

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -705,10 +705,19 @@ export const apiSlice = createApi({
             }
           })
         )
+        
+        // Also patch the separately cached single post
+        const patchSingleResult = dispatch(
+          apiSlice.util.updateQueryData('getPost', postId, draft => {
+            draft.reactions[reaction]++
+          })
+        )
+        
         try {
           await queryFulfilled
         } catch {
           patchResult.undo()
+          patchSingleResult.undo()
         }
       }
       // highlight-end


### PR DESCRIPTION
Currently the optimistic update code for reactions doesn't update the cache at `'getPost'`. This is a problem when reacting from the SinglePostPage or when reacting from the PostsList when the single post is already cached. I added a second `updateQueryData` to fix this.