### PR TITLE
Got rid of the extra space

### DIFF
--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -80,7 +80,7 @@ import { createStore } from 'redux'
  * A reducer's function signature is: (state, action) => newState
  *
  * The Redux state should contain only plain JS objects, arrays, and primitives.
- * The root state value is usually an object.  It's important that you should
+ * The root state value is usually an object. It's important that you should
  * not mutate the state object, but return a new object if the state changes.
  *
  * You can use any conditional logic you want in a reducer. In this example,


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Getting Started
- **Page**: Basic Example

https://redux.js.org/introduction/getting-started#basic-example

## What is the problem?
Extra space between words of the example code.

## What changes does this PR make to fix the problem?
Removes extra space from the example code.