### PR TITLE
docs: display last update time

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -138,6 +138,7 @@ module.exports = {
           path: '../docs',
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateTime: true,
           editUrl: 'https://github.com/reduxjs/redux/edit/master/website'
         },
         theme: {


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What is the problem?

Poor UX: there's no way to tell if we are reading a new version of the docs besides reading it entirely.

## What changes does this PR make to fix the problem?

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148601214-a369c88c-bc0f-4730-9170-ecb8f20f9d8d.png)
