### PR TITLE
Convert class components to functional components in the API docs examples

### DIFF
--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -173,23 +173,17 @@ store
 // I can also dispatch a thunk async action from a component
 // any time its props change to load the missing data.
 
+import React from 'react';
 import { connect } from 'react-redux'
-import { Component } from 'react'
 
-class SandwichShop extends Component {
-  componentDidMount() {
-    this.props.dispatch(makeASandwichWithSecretSauce(this.props.forPerson))
-  }
+function SandwichShop(props) {
+  const { dispatch, forPerson } = props;
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.forPerson !== this.props.forPerson) {
-      this.props.dispatch(makeASandwichWithSecretSauce(this.props.forPerson))
-    }
-  }
+  useEffect(() => {
+    dispatch(makeASandwichWithSecretSauce(forPerson));
+  }, [forPerson]);
 
-  render() {
-    return <p>{this.props.sandwiches.join('mustard')}</p>
-  }
+  return <p>{this.props.sandwiches.join('mustard')}</p>
 }
 
 export default connect(state => ({

--- a/docs/api/bindActionCreators.md
+++ b/docs/api/bindActionCreators.md
@@ -50,7 +50,7 @@ export function removeTodo(id) {
 #### `SomeComponent.js`
 
 ```js
-import { Component } from 'react'
+import React from 'react'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
@@ -61,29 +61,23 @@ console.log(TodoActionCreators)
 //   removeTodo: Function
 // }
 
-class TodoListContainer extends Component {
-  constructor(props) {
-    super(props)
+function TodoListContainer(props) {
+  // Injected by react-redux:
+  const { dispatch, todos } = props
 
-    const { dispatch } = props
+  // Here's a good use case for bindActionCreators:
+  // You want a child component to be completely unaware of Redux.
+  // We create bound versions of these functions now so we can
+  // pass them down to our child later.
 
-    // Here's a good use case for bindActionCreators:
-    // You want a child component to be completely unaware of Redux.
-    // We create bound versions of these functions now so we can
-    // pass them down to our child later.
+  const boundActionCreators = useMemo(() => bindActionCreators(TodoActionCreators, dispatch), [dispatch]);
+  console.log(boundActionCreators)
+  // {
+  //   addTodo: Function,
+  //   removeTodo: Function
+  // }
 
-    this.boundActionCreators = bindActionCreators(TodoActionCreators, dispatch)
-    console.log(this.boundActionCreators)
-    // {
-    //   addTodo: Function,
-    //   removeTodo: Function
-    // }
-  }
-
-  componentDidMount() {
-    // Injected by react-redux:
-    let { dispatch } = this.props
-
+  useEffect(() => {
     // Note: this won't work:
     // TodoActionCreators.addTodo('Use Redux')
 
@@ -93,20 +87,15 @@ class TodoListContainer extends Component {
     // This will work:
     let action = TodoActionCreators.addTodo('Use Redux')
     dispatch(action)
-  }
+  }, []);
 
-  render() {
-    // Injected by react-redux:
-    let { todos } = this.props
+  return <TodoList todos={todos} {...this.boundActionCreators} />
 
-    return <TodoList todos={todos} {...this.boundActionCreators} />
+  // An alternative to bindActionCreators is to pass
+  // just the dispatch function down, but then your child component
+  // needs to import action creators and know about them.
 
-    // An alternative to bindActionCreators is to pass
-    // just the dispatch function down, but then your child component
-    // needs to import action creators and know about them.
-
-    // return <TodoList todos={todos} dispatch={dispatch} />
-  }
+  // return <TodoList todos={todos} dispatch={dispatch} />
 }
 
 export default connect(state => ({ todos: state.todos }))(TodoListContainer)


### PR DESCRIPTION
---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4253
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**:
  - API Reference
- **Pages**:
  - [applyMiddleware](https://redux.js.org/api/applymiddleware#example-using-thunk-middleware-for-async-actions)
  - [bindActionCreators](https://redux.js.org/api/bindactioncreators#somecomponentjs)

## For Updating Existing Content

### What updates should be made to the page?

The class-based react components should be converted to functional components.

### Do these updates change any of the assumptions or target audience? If so, how do they change?

Converting the components to functional components assumes the audience understands the basics of functional react components and hooks. In contrast, the existing examples assume the audience understands the lifecycle methods of class components. Both of these concepts are foundational to modern React development. Still, functions and hooks seem to be the preferred method of defining a component (e.g., the React docs have mainly been rewritten to use functional components: https://reactjs.org/docs/lists-and-keys.html).
