### PR TITLE
Typo fix in WritingTests.md

### DIFF
--- a/docs/usage/WritingTests.md
+++ b/docs/usage/WritingTests.md
@@ -19,7 +19,7 @@ The guiding principles for testing Redux logic closely follow that of React Test
 
 > [The more your tests resemble the way your software is used, the more confidence they can give you.](https://twitter.com/kentcdodds/status/977018512689455106) - Kent C. Dodds
 
-Because most of the Redux code you write are functions, and many of them are pure, they are easy to test without mocking. However, you should consider whether each piece of your Redux code needs it's own dedicated tests. In the majority of scenarios, the end-user does not know, and does not care whether Redux is used within the application at all. As such, the Redux code can be treated as an implementation detail of the app, without requiring explicit tests for the Redux code in many circumstances.
+Because most of the Redux code you write are functions, and many of them are pure, they are easy to test without mocking. However, you should consider whether each piece of your Redux code needs its own dedicated tests. In the majority of scenarios, the end-user does not know, and does not care whether Redux is used within the application at all. As such, the Redux code can be treated as an implementation detail of the app, without requiring explicit tests for the Redux code in many circumstances.
 
 The general advice for testing an app using Redux is as follows:
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - _https://github.com/reduxjs/redux/issues/4263_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: code quality
- **Page**: Writing tests

## What is the problem?
- "Redux code needs it's own dedicated tests", **it's** should be replaced by **its**.

## What changes does this PR make to fix the problem?
- "Redux code needs it's own dedicated tests" -> "Redux code needs its own dedicated tests"