### PR TITLE
📝 Update Type Checking Middleware for preventing RootState circular type references

### DIFF
--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -241,6 +241,7 @@ export const exampleMiddleware: Middleware<
 The dispatch generic should likely only be needed if you are dispatching additional thunks within the middleware.
 
 In cases where `type RootState = ReturnType<typeof store.getState>` is used, a [circular type reference between the middleware and store definitions](https://github.com/reduxjs/redux/issues/4267) can be avoided by switching the type definition of `RootState` to:
+
 ```ts
 const rootReducer = combineReducers({ ... });
 type RootState = ReturnType<typeof rootReducer>;

--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -240,6 +240,12 @@ export const exampleMiddleware: Middleware<
 
 The dispatch generic should likely only be needed if you are dispatching additional thunks within the middleware.
 
+In cases where `type RootState = ReturnType<typeof store.getState>` is used, a [circular type reference between the middleware and store definitions](https://github.com/reduxjs/redux/issues/4267) can be avoided by switching the type definition of `RootState` to:
+```ts
+const rootReducer = combineReducers({ ... });
+type RootState = ReturnType<typeof rootReducer>;
+```
+
 ### Type Checking Redux Thunks
 
 [Redux Thunk](https://github.com/reduxjs/redux-thunk) is the standard middleware for writing sync and async logic that interacts with the Redux store. A thunk function receives `dispatch` and `getState` as its parameters. Redux Thunk has a built in `ThunkAction` type which we can use to define types for those arguments:


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [X] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4267
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Type Checking Middleware
- **Page**: https://redux.js.org/usage/usage-with-typescript

## What is the problem?
When using TypeScript with RTK and adding types to a custom middleware following from https://redux.js.org/usage/usage-with-typescript#type-checking-middleware, for example:
```typescript
import { Middleware } from 'redux';
import { RootState } from '../store';

export const simpleMiddleware: Middleware<unknown, RootState> = api => next => action => {
    const result = next(action);
    if (action.type === 'cards/fetchById') {
        console.group(action.type);
        console.log(`dispatching`, action);
        console.log('next state', api.getState());
        console.groupEnd();
    }
    return result;
}
```
And setting the `RootState` type following https://redux.js.org/usage/usage-with-typescript#define-root-state-and-dispatch-types, i.e.:
```typescript
export type RootState = ReturnType<typeof store.getState>
```
Then the following circular type reference error is thrown:
```typescript
'simpleMiddleware' is referenced directly or indirectly in its own type annotation. ts(2502)
```
This issue occurs because the middleware needs the `RootState` type, but that type isn't defined and available until the store is created, and the store needs the middleware in order to do that.

## What changes does this PR make to fix the problem?
Per @markerikson on [Reactiflux Discord](https://discord.com/invite/reactiflux), this can be fixed by switching the definition of `RootState` to be:
```typescript
const rootReducer = combineReducers({ ... });
type RootState = ReturnType<typeof rootReducer>;
```

This PR adds the suggested fix to the bottom of the [Type Checking Middleware](https://redux.js.org/usage/usage-with-typescript#type-checking-middleware) section.