### PR TITLE
docs: Fix link to Elm creator's Twitter account

### DIFF
--- a/docs/understanding/history-and-design/PriorArt.md
+++ b/docs/understanding/history-and-design/PriorArt.md
@@ -22,7 +22,7 @@ For what it's worth, Flux's creators [approve](https://twitter.com/jingc/status/
 
 ### Elm
 
-[Elm](https://elm-lang.org/) is a functional programming language inspired by Haskell and created by [Evan Czaplicki](https://twitter.com/czaplic). It enforces [a “model view update” architecture](https://github.com/evancz/elm-architecture-tutorial/), where the update has the following signature: `(action, state) => state`. Elm “updaters” serve the same purpose as reducers in Redux.
+[Elm](https://elm-lang.org/) is a functional programming language inspired by Haskell and created by [Evan Czaplicki](https://twitter.com/evancz). It enforces [a “model view update” architecture](https://github.com/evancz/elm-architecture-tutorial/), where the update has the following signature: `(action, state) => state`. Elm “updaters” serve the same purpose as reducers in Redux.
 
 Unlike Redux, Elm is a language, so it is able to benefit from many things like enforced purity, static typing, out of the box immutability, and pattern matching (using the `case` expression). Even if you don't plan to use Elm, you should read about the Elm architecture, and play with it. There is an interesting [JavaScript library playground implementing similar ideas](https://github.com/paldepind/noname-functional-frontend-framework). We should look there for inspiration on Redux! One way that we can get closer to the static typing of Elm is by [using a gradual typing solution like Flow](https://github.com/reduxjs/redux/issues/290).
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: "Understanding Redux" -> "History and Design"
- **Page**: "Prior Art"

## What is the problem?

The link to the Elm creator's Twitter account is broken.

## What changes does this PR make to fix the problem?

It updates that link to point to the [correct Twitter account](https://twitter.com/evancz).
