### PR TITLE
Copying an array using spread operator

### DIFF
--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -200,7 +200,7 @@ const arr = ['a', 'b']
 const arr2 = arr.concat('c')
 
 // or, we can make a copy of the original array:
-const arr3 = arr.slice()
+const arr3 = [...arr]
 // and mutate the copy:
 arr3.push('c')
 ```


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---
![redux contribution spread operator way](https://user-images.githubusercontent.com/23579058/153021142-42336b33-9dc9-46f4-a4c2-5ee0323629c0.JPG)

## What docs page needs to be fixed?
- **Section**:
- 
## What is the problem?
Docs use old way of copying an array. I assume the spread operator is the way to go.

## What changes does this PR make to fix the problem?
Make the Docs up to date.