### PR TITLE
Update references to devtools extension repository

### DIFF
--- a/docs/faq/ReactRedux.md
+++ b/docs/faq/ReactRedux.md
@@ -202,7 +202,7 @@ Both Redux and React's Context API deal with "prop drilling". That said, they bo
 
 **Differences**
 
-With Redux, you get the power of [Redux Dev Tools Extension](https://github.com/zalmoxisus/redux-devtools-extension). It automatically logs every action your app performs, and it allows time traveling – you can click on any past action and jump to that point in time. Redux also supports the concept of middleware, where you may bind customized function calls on every action dispatch. Such examples include an automatic event logger, interception of certain actions, etc.
+With Redux, you get the power of [Redux Dev Tools Extension](https://github.com/reduxjs/redux-devtools/tree/main/extension). It automatically logs every action your app performs, and it allows time traveling – you can click on any past action and jump to that point in time. Redux also supports the concept of middleware, where you may bind customized function calls on every action dispatch. Such examples include an automatic event logger, interception of certain actions, etc.
 
 With React's Context API, you deal with a pair of components speaking only to each other. This gives you nice isolation between irrelevant data. You also have the flexibility of how you may use the data with your components, i.e., you can provide the state of a parent component, and you may pass context data as props to wrapped components.
 

--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -504,13 +504,13 @@ However, try to find an appropriate balance of granularity. If a single componen
 
 ### Use the Redux DevTools Extension for Debugging
 
-**Configure your Redux store to enable [debugging with the Redux DevTools Extension](https://github.com/zalmoxisus/redux-devtools-extension)**. It allows you to view:
+**Configure your Redux store to enable [debugging with the Redux DevTools Extension](https://github.com/reduxjs/redux-devtools/tree/main/extension)**. It allows you to view:
 
 - The history log of dispatched actions
 - The contents of each action
 - The final state after an action was dispatched
 - The diff in the state after an action
-- The [function stack trace showing the code where the action was actually dispatched](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Features/Trace.md)
+- The [function stack trace showing the code where the action was actually dispatched](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/Features/Trace.md)
 
 In addition, the DevTools allows you to do "time-travel debugging", stepping back and forth in the action history to see the entire app state and UI at different points in time.
 

--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -99,7 +99,7 @@ Redux can integrate with any UI framework, and is most frequently used with Reac
 
 #### Redux DevTools Extension
 
-The [**Redux DevTools Extension**](https://github.com/zalmoxisus/redux-devtools-extension) shows a history of the changes to the state in your Redux store over time. This allows you to debug your applications effectively, including using powerful techniques like "time-travel debugging".
+The [**Redux DevTools Extension**](https://github.com/reduxjs/redux-devtools/tree/main/extension) shows a history of the changes to the state in your Redux store over time. This allows you to debug your applications effectively, including using powerful techniques like "time-travel debugging".
 
 ## Redux Terms and Concepts
 

--- a/docs/tutorials/fundamentals/part-1-overview.md
+++ b/docs/tutorials/fundamentals/part-1-overview.md
@@ -112,7 +112,7 @@ Redux can integrate with any UI framework, and is most frequently used with Reac
 
 #### Redux DevTools Extension
 
-The [**Redux DevTools Extension**](https://github.com/zalmoxisus/redux-devtools-extension) shows a history of the changes to the state in your Redux store over time. This allows you to debug your applications effectively, including using powerful techniques like "time-travel debugging".
+The [**Redux DevTools Extension**](https://github.com/reduxjs/redux-devtools/tree/main/extension) shows a history of the changes to the state in your Redux store over time. This allows you to debug your applications effectively, including using powerful techniques like "time-travel debugging".
 
 ## Redux Basics
 

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -550,7 +550,7 @@ Once that's installed, open up the browser's DevTools window. You should now see
 
 Once the extension is installed, we need to configure the store so that the DevTools can see what's happening inside. The DevTools require a specific store enhancer to be added to make that possible.
 
-The [Redux DevTools Extension docs](https://github.com/zalmoxisus/redux-devtools-extension) have some instructions on how to set up the store, but the steps listed are a bit complicated. However, there's an NPM package called `redux-devtools-extension` that takes care of the complicated part. That package exports a specialized `composeWithDevTools` function that we can use instead of the original Redux `compose` function.
+The [Redux DevTools Extension docs](https://github.com/reduxjs/redux-devtools/tree/main/extension) have some instructions on how to set up the store, but the steps listed are a bit complicated. However, there's an NPM package called `redux-devtools-extension` that takes care of the complicated part. That package exports a specialized `composeWithDevTools` function that we can use instead of the original Redux `compose` function.
 
 Here's how that looks:
 

--- a/docs/usage/ConfiguringYourStore.md
+++ b/docs/usage/ConfiguringYourStore.md
@@ -201,7 +201,7 @@ This also makes our `createStore` function easier to reason about - each step is
 
 Another common feature which you may wish to add to your app is the `redux-devtools-extension` integration.
 
-The extension is a suite of tools which give you absolute control over your Redux store - it allows you to inspect and replay actions, explore your state at different times, dispatch actions directly to the store, and much more. [Click here to read more about the available features.](https://github.com/zalmoxisus/redux-devtools-extension)
+The extension is a suite of tools which give you absolute control over your Redux store - it allows you to inspect and replay actions, explore your state at different times, dispatch actions directly to the store, and much more. [Click here to read more about the available features.](https://github.com/reduxjs/redux-devtools/tree/main/extension)
 
 There are several ways to integrate the extension, but we will use the most convenient option.
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Update doc links to the new devtools extension repository
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: 
- **Page**:
  - [Redux Essentials, Part 1: Redux Overview and Concepts](https://redux.js.org/tutorials/essentials/part-1-overview-concepts)
  - [Redux Fundamentals, Part 1: Redux Overview](https://redux.js.org/tutorials/fundamentals/part-1-overview)
  - [Redux Fundamentals, Part 4: Store](https://redux.js.org/tutorials/fundamentals/part-4-store)
  - [Configuring Your Store](https://redux.js.org/usage/configuring-your-store)
  - [Redux FAQ: React Redux](https://redux.js.org/faq/react-redux)
  - [Redux Style Guide](https://redux.js.org/style-guide/style-guide)
 
## What is the problem?
The devtools extension repository links are pointing to deprecated repository.

## What changes does this PR make to fix the problem?
Just update the links to the new devtools extension repository.