### PR TITLE
Fix incorrect component/file name

### DIFF
--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -506,9 +506,9 @@ Like with query endpoints, the API slice automatically generates a React hook fo
 
 ### Using Mutation Hooks in Components
 
-Our `<AddNewPostForm>` is already dispatching an async thunk to add a post whenever we click the "Save Post" button. To do that, it has to import `useDispatch` and the `addNewPost` thunk. The mutation hooks replace both of those, and the usage pattern is very similar.
+Our `<AddPostForm>` is already dispatching an async thunk to add a post whenever we click the "Save Post" button. To do that, it has to import `useDispatch` and the `addNewPost` thunk. The mutation hooks replace both of those, and the usage pattern is very similar.
 
-```js title="features/posts/AddNewPostForm"
+```js title="features/posts/AddPostForm"
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials
- **Page**: RTK-Query Basics

## What is the problem?
Typo in docs text that has incorrect component/file name as compared with the code repo and snippet.

## What changes does this PR make to fix the problem?
Rename the component name in the text and Markdown code notation to the correct component.
