### PR TITLE
[DOCS] Fix incorrect component/file name

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -36,7 +36,7 @@ Some of the changes in this section aren't strictly necessary - they're included
 
 ## Editing Posts
 
-We've already added a mutation endpoint to save new Post entries to the server, and used that in our `<AddNewPostForm>`. Next, we need to handle updating the `<EditPostForm>` to let us edit an existing post.
+We've already added a mutation endpoint to save new Post entries to the server, and used that in our `<AddPostForm>`. Next, we need to handle updating the `<EditPostForm>` to let us edit an existing post.
 
 ### Updating the Edit Post Form
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials
- **Page**: RTK Query Advanced Patterns

## What is the problem?
Typo in docs text that has incorrect component/file name as compared with the code repo and snippet.

## What changes does this PR make to fix the problem?
Rename the component name in the text to the correct component.