### PR TITLE
Revamp `rollup.config.js`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import { defineConfig } from 'rollup'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import babel from '@rollup/plugin-babel'
 import replace from '@rollup/plugin-replace'
@@ -22,7 +23,7 @@ const makeExternalPredicate = externalArr => {
   return id => pattern.test(id)
 }
 
-export default [
+export default defineConfig([
   // CommonJS
   {
     input: 'src/index.ts',
@@ -165,4 +166,4 @@ export default [
       })
     ]
   }
-]
+])

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,23 +15,17 @@ const babelRuntimeVersion = pkg.dependencies['@babel/runtime'].replace(
   ''
 )
 
-const makeExternalPredicate = externalArr => {
-  if (externalArr.length === 0) {
-    return () => false
-  }
-  const pattern = new RegExp(`^(${externalArr.join('|')})($|/)`)
-  return id => pattern.test(id)
-}
+const external = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {})
+].map(name => RegExp(`^${name}($|/)`))
 
 export default defineConfig([
   // CommonJS
   {
     input: 'src/index.ts',
     output: { file: 'lib/redux.js', format: 'cjs', indent: false },
-    external: makeExternalPredicate([
-      ...Object.keys(pkg.dependencies || {}),
-      ...Object.keys(pkg.peerDependencies || {})
-    ]),
+    external,
     plugins: [
       nodeResolve({
         extensions
@@ -52,10 +46,7 @@ export default defineConfig([
   {
     input: 'src/index.ts',
     output: { file: 'es/redux.js', format: 'es', indent: false },
-    external: makeExternalPredicate([
-      ...Object.keys(pkg.dependencies || {}),
-      ...Object.keys(pkg.peerDependencies || {})
-    ]),
+    external,
     plugins: [
       nodeResolve({
         extensions

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -98,8 +98,7 @@ export default [
         compress: {
           pure_getters: true,
           unsafe: true,
-          unsafe_comps: true,
-          warnings: false
+          unsafe_comps: true
         }
       })
     ]
@@ -161,8 +160,7 @@ export default [
         compress: {
           pure_getters: true,
           unsafe: true,
-          unsafe_comps: true,
-          warnings: false
+          unsafe_comps: true
         }
       })
     ]


### PR DESCRIPTION
This PR introduces the following improvements to the Rollup configuration file:

1. `compress.warnings` is not a valid Terser option, as can be seen in [Terser's docs](https://github.com/terser/terser/blob/v5.10.0/README.md#compress-options) and [type declarations](https://github.com/terser/terser/blob/v5.10.0/tools/terser.d.ts#L14-L69). Therefore, it has been removed.
2. To minimize the likelihood of making similar mistakes, Intellisense has been enabled for `rollup.config.js`, as recommended in  [Rollup's docs](https://github.com/rollup/rollup/blob/v2.70.0/docs/01-command-line-reference.md#config-intellisense).
3. Currrently, the `makeExternalPredicate` function involves a great deal of indirection in preparing the `external` object. The fact that Rollup can [accept an array of `RegExp`s as `external`](https://github.com/rollup/rollup/blob/v2.70.0/src/rollup/types.d.ts#L528) has made this a lot more straightforward.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?