### PR TITLE
[Docs] Update Installation.md

### DIFF
--- a/docs/introduction/Installation.md
+++ b/docs/introduction/Installation.md
@@ -48,7 +48,7 @@ Most likely, you'll also need [the React bindings](https://github.com/reduxjs/re
 
 ```bash
 npm install react-redux
-npm install --save-dev redux-devtools
+npm install --save-dev @redux-devtools/core
 ```
 
 Note that unlike Redux itself, many packages in the Redux ecosystem don't provide UMD builds, so we recommend using CommonJS module bundlers like [Webpack](https://webpack.js.org/) and [Browserify](http://browserify.org/) for the most comfortable development experience.


### PR DESCRIPTION
Updating redux `devtools` package as previous one is depreciated and having dependency issues with `react ^17`

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4300
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- https://redux.js.org/introduction/installation#complementary-packages 
- **Page**:

## What is the problem?

Documentation is pointing out deprecated redux `devtool` extension that is causing 
<img width="696" alt="Screenshot 2022-03-16 at 11 56 03 AM" src="https://user-images.githubusercontent.com/1610828/158529908-e327a5b3-e6a5-46d3-bdcd-7a259e6b8f5f.png">
Above issue.

## What changes does this PR make to fix the problem?
Documentation will be updated with the latest package and avoid dependency issues during the installation of the package 