### PR TITLE
Add explanation for returning payload

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -702,12 +702,15 @@ const usersSlice = createSlice({
 export default usersSlice.reducer
 ```
 
-You may noticed that our reducer is not using the `state` variable at all.
-Instead, we are returning the action payload directly.
-This has the effect that the existing state is completely replaced with whatever we are returning.
-In our case, we are replacing the initial state that was empty and therefore `state.push(...action.payload)` would have the same result.
-But, this could introduce subtle bug is we are not sure that the client state is empty and we want to synchronize the client with the server state.
-To learn more about how state updates with Immer work, see the ["Writing Reducers with Immer" section in the RTK docs](https://redux-toolkit.js.org/usage/immer-reducers#immer-usage-patterns).
+You may have noticed that this time the case reducer isn't using the `state` variable at all. Instead, we're returning the `action.payload` directly. Immer lets us update state in two ways: either _mutating_ the existing state value, or _returning_ a new result. If we return a new value, that will replace the existing state completely with whatever we return. (Note that if you want to manually return a new value, it's up to you to write any immutable update logic that might be needed.)
+
+In this case, the initial state was an empty array, and we probably could have done `state.push(...action.payload)` to mutate it. But, in our case we really want to replace the list of users with whatever the server returned, and this avoids any chance of accidentally duplicating the list of users in state.
+
+:::info
+
+To learn more about how state updates with Immer work, see the ["Writing Reducers with Immer" guide in the RTK docs](https://redux-toolkit.js.org/usage/immer-reducers#immer-usage-patterns).
+
+:::
 
 We only need to fetch the list of users once, and we want to do it right when the application starts. We can do that in our `index.js` file, and directly dispatch the `fetchUsers` thunk because we have the `store` right there:
 

--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -702,6 +702,13 @@ const usersSlice = createSlice({
 export default usersSlice.reducer
 ```
 
+You may noticed that our reducer is not using the `state` variable at all.
+Instead, we are returning the action payload directly.
+This has the effect that the existing state is completely replaced with whatever we are returning.
+In our case, we are replacing the initial state that was empty and therefore `state.push(...action.payload)` would have the same result.
+But, this could introduce subtle bug is we are not sure that the client state is empty and we want to synchronize the client with the server state.
+To learn more about how state updates with Immer work, see the ["Writing Reducers with Immer" section in the RTK docs](https://redux-toolkit.js.org/usage/immer-reducers#immer-usage-patterns).
+
 We only need to fetch the list of users once, and we want to do it right when the application starts. We can do that in our `index.js` file, and directly dispatch the `fetchUsers` thunk because we have the `store` right there:
 
 ```js title="index.js"


### PR DESCRIPTION
This is to address the difference between the reducer used in the
"loading users" section and the rest of the reducers used in the
tutorial up to that point.

See the discussion in:
https://github.com/reduxjs/redux/issues/4317

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4317
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Loading users
- **Page**:  https://github.com/reduxjs/redux/blob/master/docs/tutorials/essentials/part-5-async-logic.md

## What is the problem?

The reducer in this section returns a value instead of updating the existing state. This is the first time this technique is used in the tutorial, all previously used reducers update the existing state. While this works and is the correct solution, it is used without any comment as of why this approach is chosen over the update. To a beginner without much Redux and especially Immer experience this can be quite surprising and confusing. 

## What changes does this PR make to fix the problem?

This PR adds a short explanation pointing out that a different approach was taken and why. 