### PR TITLE
Fix typo in quick-start.md

### DIFF
--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -171,7 +171,7 @@ export function Counter() {
 }
 ```
 
-Now, any time you click the "Increment" and "Decrement buttons:
+Now, any time you click the "Increment" and "Decrement" buttons:
 
 - The corresponding Redux action will be dispatched to the store
 - The counter slice reducer will see the actions and update its state


### PR DESCRIPTION
Add a missing quote in "Usage Summary" section

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Usage Summary
- **Page**: Quick Start

## What is the problem?

Missing quote.

## What changes does this PR make to fix the problem?

Add missing quote.