### PR TITLE
Mark `createStore` as deprecated, and add `legacy_createStore` alias

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -372,34 +372,134 @@ export interface StoreCreator {
 }
 
 /**
+ * @deprecated
+ *
+ * **We recommend using the `configureStore` method
+ * of the `@reduxjs/toolkit` package**, which replaces `createStore`.
+ *
+ * Redux Toolkit is our recommended approach for writing Redux logic today,
+ * including store setup, reducers, data fetching, and more.
+ *
+ * **For more details, please read this Redux docs page:**
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
+ * `configureStore` from Redux Toolkit is an improved version of `createStore` that
+ * simplifies setup and helps avoid common bugs.
+ *
+ * You should not be using the `redux` core package by itself today, except for learning purposes.
+ * The `createStore` method from the core `redux` package will not be removed, but we encourage
+ * all users to migrate to using Redux Toolkit for all Redux code.
+ *
+ * If you want to use `createStore` without this visual deprecation warning, use
+ * the `legacy_createStore` import instead:
+ *
+ * `import { legacy_createStore as createStore} from 'redux'`
+ *
+ */
+export declare function createStore<S, A extends Action, Ext, StateExt>(
+  reducer: Reducer<S, A>,
+  enhancer?: StoreEnhancer<Ext, StateExt>
+): Store<S & StateExt, A> & Ext
+/**
+ * @deprecated
+ *
+ * **We recommend using the `configureStore` method
+ * of the `@reduxjs/toolkit` package**, which replaces `createStore`.
+ *
+ * Redux Toolkit is our recommended approach for writing Redux logic today,
+ * including store setup, reducers, data fetching, and more.
+ *
+ * **For more details, please read this Redux docs page:**
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
+ * `configureStore` from Redux Toolkit is an improved version of `createStore` that
+ * simplifies setup and helps avoid common bugs.
+ *
+ * You should not be using the `redux` core package by itself today, except for learning purposes.
+ * The `createStore` method from the core `redux` package will not be removed, but we encourage
+ * all users to migrate to using Redux Toolkit for all Redux code.
+ *
+ * If you want to use `createStore` without this visual deprecation warning, use
+ * the `legacy_createStore` import instead:
+ *
+ * `import { legacy_createStore as createStore} from 'redux'`
+ *
+ */
+export declare function createStore<S, A extends Action, Ext, StateExt>(
+  reducer: Reducer<S, A>,
+  preloadedState?: PreloadedState<S>,
+  enhancer?: StoreEnhancer<Ext>
+): Store<S & StateExt, A> & Ext
+
+/**
  * Creates a Redux store that holds the state tree.
+ *
+ * **We recommend using `configureStore` from the
+ * `@reduxjs/toolkit` package**, which replaces `createStore`:
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
  * The only way to change the data in the store is to call `dispatch()` on it.
  *
  * There should only be a single store in your app. To specify how different
- * parts of the state tree respond to actions, you may combine several
- * reducers
+ * parts of the state tree respond to actions, you may combine several reducers
  * into a single reducer function by using `combineReducers`.
  *
- * @template S State object type.
+ * @param {Function} reducer A function that returns the next state tree, given
+ * the current state tree and the action to handle.
  *
- * @param reducer A function that returns the next state tree, given the
- *   current state tree and the action to handle.
+ * @param {any} [preloadedState] The initial state. You may optionally specify it
+ * to hydrate the state from the server in universal apps, or to restore a
+ * previously serialized user session.
+ * If you use `combineReducers` to produce the root reducer function, this must be
+ * an object with the same shape as `combineReducers` keys.
  *
- * @param [preloadedState] The initial state. You may optionally specify it to
- *   hydrate the state from the server in universal apps, or to restore a
- *   previously serialized user session. If you use `combineReducers` to
- *   produce the root reducer function, this must be an object with the same
- *   shape as `combineReducers` keys.
+ * @param {Function} [enhancer] The store enhancer. You may optionally specify it
+ * to enhance the store with third-party capabilities such as middleware,
+ * time travel, persistence, etc. The only store enhancer that ships with Redux
+ * is `applyMiddleware()`.
  *
- * @param [enhancer] The store enhancer. You may optionally specify it to
- *   enhance the store with third-party capabilities such as middleware, time
- *   travel, persistence, etc. The only store enhancer that ships with Redux
- *   is `applyMiddleware()`.
- *
- * @returns A Redux store that lets you read the state, dispatch actions and
- *   subscribe to changes.
+ * @returns {Store} A Redux store that lets you read the state, dispatch actions
+ * and subscribe to changes.
  */
-export const createStore: StoreCreator
+export declare function legacy_createStore<S, A extends Action, Ext, StateExt>(
+  reducer: Reducer<S, A>,
+  enhancer?: StoreEnhancer<Ext, StateExt>
+): Store<S & StateExt, A> & Ext
+/**
+ * Creates a Redux store that holds the state tree.
+ *
+ * **We recommend using `configureStore` from the
+ * `@reduxjs/toolkit` package**, which replaces `createStore`:
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
+ * The only way to change the data in the store is to call `dispatch()` on it.
+ *
+ * There should only be a single store in your app. To specify how different
+ * parts of the state tree respond to actions, you may combine several reducers
+ * into a single reducer function by using `combineReducers`.
+ *
+ * @param {Function} reducer A function that returns the next state tree, given
+ * the current state tree and the action to handle.
+ *
+ * @param {any} [preloadedState] The initial state. You may optionally specify it
+ * to hydrate the state from the server in universal apps, or to restore a
+ * previously serialized user session.
+ * If you use `combineReducers` to produce the root reducer function, this must be
+ * an object with the same shape as `combineReducers` keys.
+ *
+ * @param {Function} [enhancer] The store enhancer. You may optionally specify it
+ * to enhance the store with third-party capabilities such as middleware,
+ * time travel, persistence, etc. The only store enhancer that ships with Redux
+ * is `applyMiddleware()`.
+ *
+ * @returns {Store} A Redux store that lets you read the state, dispatch actions
+ * and subscribe to changes.
+ */
+export declare function legacy_createStore<S, A extends Action, Ext, StateExt>(
+  reducer: Reducer<S, A>,
+  preloadedState?: PreloadedState<S>,
+  enhancer?: StoreEnhancer<Ext>
+): Store<S & StateExt, A> & Ext
 
 /**
  * A store enhancer is a higher-order function that composes a store creator

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "4.1.1",
+      "name": "redux",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -5,31 +5,31 @@ import isPlainObject from './utils/isPlainObject'
 import { kindOf } from './utils/kindOf'
 
 /**
- * Creates a Redux store that holds the state tree.
- * The only way to change the data in the store is to call `dispatch()` on it.
+ * @deprecated
  *
- * There should only be a single store in your app. To specify how different
- * parts of the state tree respond to actions, you may combine several reducers
- * into a single reducer function by using `combineReducers`.
+ * **We recommend using the `configureStore` method
+ * of the `@reduxjs/toolkit` package**, which replaces `createStore`.
  *
- * @param {Function} reducer A function that returns the next state tree, given
- * the current state tree and the action to handle.
+ * Redux Toolkit is our recommended approach for writing Redux logic today,
+ * including store setup, reducers, data fetching, and more.
  *
- * @param {any} [preloadedState] The initial state. You may optionally specify it
- * to hydrate the state from the server in universal apps, or to restore a
- * previously serialized user session.
- * If you use `combineReducers` to produce the root reducer function, this must be
- * an object with the same shape as `combineReducers` keys.
+ * **For more details, please read this Redux docs page:**
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
  *
- * @param {Function} [enhancer] The store enhancer. You may optionally specify it
- * to enhance the store with third-party capabilities such as middleware,
- * time travel, persistence, etc. The only store enhancer that ships with Redux
- * is `applyMiddleware()`.
+ * `configureStore` from Redux Toolkit is an improved version of `createStore` that
+ * simplifies setup and helps avoid common bugs.
  *
- * @returns {Store} A Redux store that lets you read the state, dispatch actions
- * and subscribe to changes.
+ * You should not be using the `redux` core package by itself today, except for learning purposes.
+ * The `createStore` method from the core `redux` package will not be removed, but we encourage
+ * all users to migrate to using Redux Toolkit for all Redux code.
+ *
+ * If you want to use `createStore` without this visual deprecation warning, use
+ * the `legacy_createStore` import instead:
+ *
+ * `import { legacy_createStore as createStore} from 'redux'`
+ *
  */
-export default function createStore(reducer, preloadedState, enhancer) {
+export function createStore(reducer, preloadedState, enhancer) {
   if (
     (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
     (typeof enhancer === 'function' && typeof arguments[3] === 'function')
@@ -313,3 +313,35 @@ export default function createStore(reducer, preloadedState, enhancer) {
     [$$observable]: observable,
   }
 }
+
+/**
+ * Creates a Redux store that holds the state tree.
+ *
+ * **We recommend using `configureStore` from the
+ * `@reduxjs/toolkit` package**, which replaces `createStore`:
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
+ * The only way to change the data in the store is to call `dispatch()` on it.
+ *
+ * There should only be a single store in your app. To specify how different
+ * parts of the state tree respond to actions, you may combine several reducers
+ * into a single reducer function by using `combineReducers`.
+ *
+ * @param {Function} reducer A function that returns the next state tree, given
+ * the current state tree and the action to handle.
+ *
+ * @param {any} [preloadedState] The initial state. You may optionally specify it
+ * to hydrate the state from the server in universal apps, or to restore a
+ * previously serialized user session.
+ * If you use `combineReducers` to produce the root reducer function, this must be
+ * an object with the same shape as `combineReducers` keys.
+ *
+ * @param {Function} [enhancer] The store enhancer. You may optionally specify it
+ * to enhance the store with third-party capabilities such as middleware,
+ * time travel, persistence, etc. The only store enhancer that ships with Redux
+ * is `applyMiddleware()`.
+ *
+ * @returns {Store} A Redux store that lets you read the state, dispatch actions
+ * and subscribe to changes.
+ */
+export const legacy_createStore = createStore

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import createStore from './createStore'
+import { createStore, legacy_createStore } from './createStore'
 import combineReducers from './combineReducers'
 import bindActionCreators from './bindActionCreators'
 import applyMiddleware from './applyMiddleware'
@@ -28,6 +28,7 @@ if (
 
 export {
   createStore,
+  legacy_createStore,
   combineReducers,
   bindActionCreators,
   applyMiddleware,


### PR DESCRIPTION
This PR marks the `createStore` API as deprecated, and adds a new `legacy_createStore` API as an alias without the deprecation notice.

- Updated `createStore`'s doc description to mark it as `@deprecated`,
  so that it shows up with a visual strikethrough in editors.
- Added new descriptive text to `createStore` to encourage users to
  migrate to RTK, and pointing to the "RTK is Redux Today" docs page
- Rewrote TS typedefs for `createStore` to define it as a function with
  overloads, rather than a varible, to get correct docs tooltips when
  hovering over variable usages
- Added `legacy_createStore` API as an alias without the deprecation

## Goal

Redux Toolkit (the `@reduxjs/toolkit` package) is the right way for Redux users to write Redux code today:

https://redux.js.org/introduction/why-rtk-is-redux-today

Unfortunately, many tutorials are still showing legacy "hand-written" Redux patterns, which result in a much worse experience for users. New learners going through a bootcamp or an outdated Udemy course just follow the examples they're being shown, don't know that RTK is the better and recommended approach, and don't even think to look at our docs.

Given that, the goal of this PR is to provide them with a visual indicator in their editor, like ~~createStore~~ .  When users hover over the `createStore` import or function call, the doc tooltip recommends using `configureStore` from RTK instead, and points them to that docs page.  We hope that new learners will see the strikethrough, read the tooltip, read the docs page, learn about RTK, and begin using it.

To be _extremely_ clear:

**WE ARE _NOT_ GOING TO ACTUALLY REMOVE THE `createStore` API, AND ALL YOUR EXISTING CODE WILL STILL CONTINUE TO WORK AS-IS!**

We are just marking `createStore` as ["deprecated"](https://en.wikipedia.org/wiki/Deprecation#Software):

> "the discouragement of use of some feature or practice, typically because it has been superseded or is no longer considered efficient or safe, without completely removing it or prohibiting its use"

## Rationale

- RTK provides a vastly improved Redux usage experience, with APIs that simplify standard usage patterns and eliminate common bugs like accidental mutations
- We've had suggestions to merge all of RTK into the `redux` core package, or fully deprecate the entire `redux` package and rename it to `@reduxjs/core`.  Unfortunately, those bring up too many complexities:
  - We already had a package rename from `redux-starter-kit` to `@reduxjs/toolkit`, and all of our docs and tutorials have pointed to it for the last three years. I don't want to put users through another whiplash package transition for no real benefit
  - Merging or rearranging our packages would effectively require merging all of the Redux repos into a single monorepo.  That would require hundreds of hours of effort from us maintainers, including needing to somehow merge all of our docs sites together.  We don't have the time to do that.
- I don't want to add _runtime_ warnings that would be really annoying

So, this is the minimum possible approach we can take to reach out to users who otherwise would never know that they are following outdated patterns, while avoiding breaking running user code or having to completely rewrite our package and repo structure.

## Results

When a user imports `createStore` in their editor, they will see a visual strikethrough.  Hovering over it will show a doc tooltip that encourages them to use `configureStore` from RTK, and points to an explanatory docs page:

![image](https://user-images.githubusercontent.com/1128784/163880823-85d27c38-1562-45a7-9c99-6810e8790c96.png)


Again, _no_ broken code, and _no_ runtime warnings.  

If users do not want to see that strikethrough, they have three options:

- Follow our suggestion to switch over to Redux Toolkit and `configureStore`
- Do nothing. It's just a visual strikethrough, and it doesn't affect how your code behaves. Ignore it.
- Switch to using the `legacy_createStore` API that is now exported, which is the exact same function but with no `@deprecation` tag. The simplest option is to do an aliased import rename:

![image](https://user-images.githubusercontent.com/1128784/163880638-5dcd2046-a417-4515-be26-b98de002f4c4.png)

## Plan

I intend to release this as Redux 4.2.0 as soon as this is merged.

## More Details

See the extensive additional discussion in #4325 .
