### PR TITLE
[Docs] Fixes a small typo

### DIFF
--- a/docs/tutorials/fundamentals/part-8-modern-redux.md
+++ b/docs/tutorials/fundamentals/part-8-modern-redux.md
@@ -61,7 +61,7 @@ As you've seen, many aspects of Redux involve writing some code that can be verb
 
 That's why the Redux team created [**Redux Toolkit**: our official, opinionated, "batteries included" toolset for efficient Redux development](https://redux-toolkit.js.org).
 
-Redux Toolkit contains packages and functions that we think are essential for building a Redux app. Redux Toolkit builds in our suggested best practices, simplifies most Redux tasks, prevents common mistakes, and makes it easier to write Redux applications.
+Redux Toolkit contains packages and functions that we think are essential for building a Redux app. Redux Toolkit builds on our suggested best practices, simplifies most Redux tasks, prevents common mistakes, and makes it easier to write Redux applications.
 
 Because of this, **Redux Toolkit is the standard way to write Redux application logic**. The "hand-written" Redux logic you've written so far in this tutorial is actual working code, but **you shouldn't write Redux logic by hand** - we've covered those approaches in this tutorial so that you understand _how_ Redux works. However, **for real applications, you should use Redux Toolkit to write your Redux logic.**
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## What docs page needs to be fixed?

- **Section**: Tutorials/ Redux Fudamentals
- **Page**: Part 8: Modern Redux with Redux Toolkit

Fixes a small typo in the text. Instead of `build in`, it should probably say `build on`.
