### PR TITLE
Update why-rtk-is-redux-today.md

### DIFF
--- a/docs/introduction/why-rtk-is-redux-today.md
+++ b/docs/introduction/why-rtk-is-redux-today.md
@@ -81,7 +81,7 @@ export const todosReducer = (state = [], action) => {
       })
     case TODO_TOGGLED:
       return state.map(todo => {
-        if (todo.id !== action.payload) return
+        if (todo.id !== action.payload.id) return todo
 
         return {
           ...todo,


### PR DESCRIPTION
`state.map` should return `todo` object when `todo.id !== action.payload.id` condition is met or else the currently iterating todo will be replaced with `undefined`

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
