### PR TITLE
fix(docs): update and remove broken links

### DIFF
--- a/docs/faq/ImmutableData.md
+++ b/docs/faq/ImmutableData.md
@@ -475,6 +475,5 @@ In contrast, immutable libraries such as Immer can employ structural sharing, wh
 **Articles**
 
 - [A deep dive into Clojure’s data structures](https://www.slideshare.net/mohitthatte/a-deep-dive-into-clojures-data-structures-euroclojure-2015)
-- [JavaScript and Immutability](https://t4d.io/javascript-and-immutability/)
 - [Immutable Javascript using ES6 and beyond](https://wecodetheweb.com/2016/02/12/immutable-javascript-using-es6-and-beyond/)
 - [Pros and Cons of using immutability with React.js - React Kung Fu](https://reactkungfu.com/2015/08/pros-and-cons-of-using-immutability-with-react-js/)

--- a/docs/faq/Performance.md
+++ b/docs/faq/Performance.md
@@ -112,7 +112,6 @@ However, you _do_ need to create a copied and updated object for each level of n
 - [#758: Why can't state be mutated?](https://github.com/reduxjs/redux/issues/758)
 - [#994: How to cut the boilerplate when updating nested entities?](https://github.com/reduxjs/redux/issues/994)
 - [Twitter: common misconception - deep cloning](https://twitter.com/dan_abramov/status/688087202312491008)
-- [Cloning Objects in JavaScript](https://www.zsoltnagy.eu/cloning-objects-in-javascript/)
 
 ### How can I reduce the number of store update events?
 

--- a/docs/redux-toolkit/overview.md
+++ b/docs/redux-toolkit/overview.md
@@ -35,7 +35,7 @@ This is good in some cases, because it gives you flexibility, but that flexibili
 - "I have to add a lot of packages to get Redux to do anything useful"
 - "Redux requires too much boilerplate code"
 
-We can't solve every use case, but in the spirit of [`create-react-app`](https://github.com/facebook/create-react-app) and [`apollo-boost`](https://dev-blog.apollodata.com/zero-config-graphql-state-management-27b1f1b3c2c3), we can provide an official recommended set of tools that handle the most common use cases and reduce the need to make extra decisions.
+We can't solve every use case, but in the spirit of [`create-react-app`](https://github.com/facebook/create-react-app) and [`apollo-boost`](https://www.apollographql.com/blog/announcement/frontend/zero-config-graphql-state-management/), we can provide an official recommended set of tools that handle the most common use cases and reduce the need to make extra decisions.
 
 ## Why You Should Use Redux Toolkit
 


### PR DESCRIPTION
---
broken links: :memo: Documentation Fix
about: Update and delete broken links
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: [FAQ](https://redux.js.org/faq) & [Redux Toolkit](https://redux.js.org/redux-toolkit/overview)
- **Page**: [Immutable Data](https://redux.js.org/faq/immutable-data), [Performance](https://redux.js.org/faq/performance), and [Redux Toolkit Overview](https://redux.js.org/redux-toolkit/overview)

## What is the problem?
Broken links for external resources:
- [JavaScript and Immutability](https://t4d.io/javascript-and-immutability/)
- [Cloning Objects in JavaScript](https://www.zsoltnagy.eu/cloning-objects-in-javascript/)
- [`apollo-boost`](https://dev-blog.apollodata.com/zero-config-graphql-state-management-27b1f1b3c2c3)

## What changes does this PR make to fix the problem?
Update apollo-boost link and delete links for article [JavaScript and Immutability](https://t4d.io/javascript-and-immutability/), [Cloning Objects in JavaScript](https://www.zsoltnagy.eu/cloning-objects-in-javascript/)
