### PR TITLE
docs(essentials-tutorial): Handle URL /:postId edge case for EditPostForm

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -239,7 +239,7 @@ export default postsSlice.reducer
 
 ### Creating an Edit Post Form
 
-Our new `<EditPostForm>` component will look similar to the `<AddPostForm>`, but the logic needs to be a bit different. We need to retrieve the right `post` object from the store, then use that to initialize the state fields in the component so the user can make changes. We'll save the changed title and content values back to the store after the user is done. We'll also use React Router's history API to switch over to the single post page and show that post.
+Our new `<EditPostForm>` component will look similar to the `<AddPostForm>`, but the logic needs to be a bit different. We need to retrieve the right `post` object from the store, then use that to initialize the state fields in the component so the user can make changes. We'll save the changed title and content values back to the store after the user is done. We'll also use React Router's history API to switch over to the single post page and show that post. If the id contained in the URL is not present in the slice posts in the store, we use optional chaining (so that no error occurs at runtime when setting the initialization values of the local state) and display a message to the user stating that the post was not found.
 
 ```jsx title="features/posts/EditPostForm.js"
 import React, { useState } from 'react'
@@ -255,8 +255,8 @@ export const EditPostForm = ({ match }) => {
     state.posts.find(post => post.id === postId)
   )
 
-  const [title, setTitle] = useState(post.title)
-  const [content, setContent] = useState(post.content)
+  const [title, setTitle] = useState(post?.title)
+  const [content, setContent] = useState(post?.content)
 
   const dispatch = useDispatch()
   const history = useHistory()
@@ -269,6 +269,14 @@ export const EditPostForm = ({ match }) => {
       dispatch(postUpdated({ id: postId, title, content }))
       history.push(`/posts/${postId}`)
     }
+  }
+  
+  if (!post) {
+    return (
+      <section>
+        <h2>Post not found!</h2>
+      </section>
+    )
   }
 
   return (

--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -541,12 +541,10 @@ export const AddPostForm = () => {
   const onAuthorChanged = e => setUserId(e.target.value)
 
   const onSavePostClicked = () => {
-    if (title && content) {
-      // highlight-next-line
-      dispatch(postAdded(title, content, userId))
-      setTitle('')
-      setContent('')
-    }
+    // highlight-next-line
+    dispatch(postAdded(title, content, userId))
+    setTitle('')
+    setContent('')
   }
 
   // highlight-start


### PR DESCRIPTION
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page - handling case when `postId` in the URL is not matching ids for `posts` slice (`EditPostForm` component)
---

## Checklist

- [ x ] Is there an existing issue for this PR?
  - No issue opened related to that issue.
- [ x ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: [Creating an Edit Post Form](https://redux.js.org/tutorials/essentials/part-4-using-data#creating-an-edit-post-form), [Adding authors for posts](https://redux.js.org/tutorials/essentials/part-4-using-data#adding-authors-for-posts)
- **Page**: [Redux Essentials - Part 4: Using Redux Data](https://redux.js.org/tutorials/essentials/part-4-using-data)

## What is the problem?
`EditPostForm.js` will throw an exception if the `postId` in the URL does not match the id of the data in the slice `posts` in the store.
Additionally, there is not need for `if` statement in docs section "Adding authors for posts" (`canSave` is validating post addition).

## What changes does this PR make to fix the problem?
Modifies the code snippet that handles the edge case of an incorrect id and includes a short description.
**I assume this involves changes to the tutorial source code (Codesandbox, Tutorial repository).**