### PR TITLE
fix: update the footer usage guide link to the right value

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -73,7 +73,7 @@ module.exports = {
               label: 'Getting Started',
               to: 'introduction/getting-started'
             },
-            { label: 'Usage Guide', type: 'doc', to: 'usage/index' },
+            { label: 'Usage Guide', type: 'doc', to: 'usage' },
             {
               label: 'Tutorial',
               to: 'tutorials/essentials/part-1-overview-concepts'


### PR DESCRIPTION
---
name: :bug: Bug fix 
about: Fixing a problem with Website footer link navigation
---

## PR Type
Bug fix

### Does this PR add a new _feature_, or fix a _bug_?
Fixed a bug

### Why should this PR be included?
It fixes the issue with routing to the Usage Guides from the Footer links on the Docs website

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the current behavior, and the steps to reproduce the issue?
- Visit the [website](https://redux.js.org/usage/index)
- Scroll down to the footer section and click on the Usage Guide link
- This routes to /usage/index, which ends up in "Page not Found"

### What is the expected behavior?
- Clicking on the Usage Guide link in the footer section, should route to https://redux.js.org/usage/

### How does this PR fix the problem?
- This PR updates the Usage Guide path in the docusaurus config file to the right value