### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/size.yaml
+++ b/.github/workflows/size.yaml
@@ -2,8 +2,16 @@ name: Bundle Size
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      checks: write  # for preactjs/compressed-size-action to create and update the checks
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for preactjs/compressed-size-action to create comments
+      pull-requests: write  # for preactjs/compressed-size-action to write a PR review
     name: Check compressed size
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Test Suite


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
