### PR TITLE
Correct Redux Batch Usage

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -212,7 +212,7 @@ const store = configureStore({
 Store enhancer that allows dispatching arrays of actions
 
 ```js
-const store = configureStore({ reducer, enhancers: [reduxBatch] })
+const store = configureStore({ reducer, enhancers: (existingEnhancersArray) => [reduxBatch, ...existingEnhancersArray, reduxBatch] })
 store.dispatch([{ type: 'INCREMENT' }, { type: 'INCREMENT' }])
 ```
 


### PR DESCRIPTION
---
name: :memo: Correct Redux Batch Usage
about: Correcting the Redux Batch example to have the enhancer on both ends
---

## Checklist

- [x] Is there an existing issue for this PR?
  - #4369 
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Introduction
- **Page**: Ecosystem

## What is the problem?
Correct [redux-batch](https://github.com/manaflair/redux-batch#usage-w-extra-middlewares) usage requires making sure that reduxBatch is at the beginning and end of the enhancers array, whereas [current docs](https://redux-toolkit.js.org/api/configureStore#full-example) only use the array config version (which would put reduxBatch after the middleware enhancer, preventing the use of middleware within batches e.g. thunks).

This [codesandbox](https://codesandbox.io/s/redux-batch-rtk-typing-yl6b0t?file=/src/index.ts) can be used to replicate the issue - change line 71 to `enhancers: [reduxBatch]`. [Replay](https://app.replay.io/recording/redux-batch-dispatch-error--b81239e0-f488-480e-8266-cdcd3b7b302e) kindly provided by @markerikson.

## What changes does this PR make to fix the problem?
Changing the example to `enhancers: (enhancers) => [reduxBatch, ...enhancers, reduxBatch]`.
