### PR TITLE
Updates `useAppDispatch` type definition

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -77,7 +77,7 @@ import type { RootState, AppDispatch } from './store'
 
 // highlight-start
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 // highlight-end
 ```

--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -87,7 +87,7 @@ import type { RootState, AppDispatch } from './store'
 
 // highlight-start
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 // highlight-end
 ```


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
https://github.com/reduxjs/redux/issues/4372
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
`https://redux.js.org/usage`
- **Page**:
`/usage-with-typescript#define-typed-hooks`

## What is the problem?
Type definition can be shortened

## What changes does this PR make to fix the problem?
Type definition for `useAppDispatch` is shortned per this [tweet](https://twitter.com/acemarke/status/1536794905741246464)