### PR TITLE
Update `test-utils.tsx` location

### DIFF
--- a/docs/usage/WritingTests.md
+++ b/docs/usage/WritingTests.md
@@ -170,7 +170,7 @@ The custom render function should let us:
 
 A typical custom render function setup could look like this:
 
-```tsx title="utils/test-utils.tsx"
+```tsx title="src/test-utils.tsx"
 import React, { PropsWithChildren } from 'react'
 import { render as rtlRender } from '@testing-library/react'
 import type { RenderOptions } from '@testing-library/react'


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Code Quality
- **Page**: Writing Tests

## What is the problem?

- `utils/test-utils.tsx` should be `src/test-utils.tsx`. Since people can use absolute import and they just need to do:
```diff
-import { render, screen } from 'utils/test-utils';
+import { render, screen } from 'test-utils';
```

I guess this is a typo in docs @markerikson 