### PR TITLE
Fix typo, syntax error in Writing tests page

### DIFF
--- a/docs/usage/WritingTests.md
+++ b/docs/usage/WritingTests.md
@@ -189,7 +189,7 @@ interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   store?: AppStore
 }
 
-function renderWithProvider(
+function renderWithProviders(
   ui: React.ReactElement,
   {
     preloadedState= {},
@@ -209,7 +209,7 @@ function renderWithProvider(
 // re-export everything from RTL
 export * from '@testing-library/react'
 // Override the `render` export name with our custom function
-export { render: renderWithProvider}
+export { renderWithProviders as render }
 ```
 
 In this example, we're directly importing the same slice reducers that the real app uses to create the store. It may be helpful to create a reusable `setupStore` function that does the actual store creation with the right options and configuration, and use that in the custom render function instead.


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Code quality
- **Page**: [Writing test](https://redux.js.org/usage/writing-tests#setting-up-a-reusable-test-render-function)


## What changes does this PR make to fix the problem?

Well, just a typo and a syntax error when following it to write integration tests for https://github.com/reduxjs/cra-template-redux/pull/56