### PR TITLE
Add a CodeSandbox counter app embed to the "TS Getting Started" page

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -170,6 +170,18 @@ export function Counter() {
 }
 ```
 
+### Full Counter App Example
+
+Here's the complete TS counter application as a running CodeSandbox:
+
+<iframe
+  class="codesandbox"
+  src="https://codesandbox.io/embed/github/reduxjs/redux/tree/master/examples/counter-ts/?fontsize=14&hidenavigation=1&module=%2Fsrc%2Ffeatures%2Fcounter%2FcounterSlice.ts&theme=dark&runonclick=1"
+  title="redux-counter-ts-example"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
 ## What's Next?
 
 See [the "Usage with TypeScript" page](../usage/UsageWithTypescript.md) for extended details on how to use Redux Toolkit's APIs with TypeScript.


### PR DESCRIPTION
This PR:

- Adds a CSB embed of the `counter-ts` example to the "TS Getting Started" page

and we should do the same for the other couple copies of this page on the RTK and React-Redux docs too