### PR TITLE
Fix lint error

### DIFF
--- a/examples/counter/src/App.test.js
+++ b/examples/counter/src/App.test.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from './app/store';
 import App from './App';
 
 test('renders learn react link', () => {
-  const { getByText } = render(
+  render(
     <Provider store={store}>
       <App />
     </Provider>
   );
 
-  expect(getByText(/learn/i)).toBeInTheDocument();
+  expect(screen.getByText(/learn/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
Fixes lint error in counter example.
Use `npm run examples:lint` to reproduce.
See [here](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-screen-queries.md) for error details.