### PR TITLE
[DOC] wording: fetchTodoThunk => fetchTodoByIdThunk

### DIFF
--- a/docs/usage/writing-logic-thunks.mdx
+++ b/docs/usage/writing-logic-thunks.mdx
@@ -47,7 +47,7 @@ In the same way that Redux code normally uses [action creators to generate actio
 // fetchTodoById is the "thunk action creator"
 export function fetchTodoById(todoId) {
   // fetchTodoByIdThunk is the "thunk function"
-  return async function fetchTodosThunk(dispatch, getState) {
+  return async function fetchTodoByIdThunk(dispatch, getState) {
     const response = await client.get(`/fakeApi/todo/${todoId}`)
     dispatch(todosLoaded(response.todos))
   }


### PR DESCRIPTION
- update function name `fetchTodoThunk` => `fetchTodoByIdThunk`

matched the function name to the comment name at line 49, and a little bit reasonable.

That's it! Maybe I missed something, if so. Just ignore this pr.

- [:memo: Documentation Fix](https://github.com/reduxjs/redux/compare/master...benben6515:redux:patch-1#diff-4160c89fb9a8145b89def858ba4a51bb5beaadf787556d91cbc018dba78c1c70)
