### PR TITLE
docs: fix memoized selectors code snippet

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -509,7 +509,7 @@ export const Navbar = () => {
 
 ## Improving Render Performance
 
-Our application is looking useful, but we've actually got a couple flaws in when and how our components re-render. Let's look at those problems, and talk about some ways to improve the performance.
+Our application is looking useful, but we've got a couple of flaws in when and how our components re-render. Let's look at those problems, and talk about some ways to improve the performance.
 
 ### Investigating Render Behavior
 
@@ -592,13 +592,17 @@ selectPostsByUser(state1, 'user1')
 // Output selector runs, because `userId` changed
 selectPostsByUser(state1, 'user2')
 
-dispatch(reactionAdded())
+dispatch(reactionAdded({ postId: post.id, reaction: "heart" }))
 const state2 = getState()
 // Output selector does not run, because `posts` and `userId` are the same
 selectPostsByUser(state2, 'user2')
 
 // Add some more posts
-dispatch(addNewPost())
+dispatch(addNewPost({
+  title: post.title,
+  content: post.content,
+  user: userId
+}))
 const state3 = getState()
 // Output selector runs, because `posts` has changed
 selectPostsByUser(state3, 'user2')


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in Memoizing Selector Functions page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - Issue #4295 
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: https://redux.js.org/tutorials/essentials/part-6-performance-normalization#memoizing-selector-functions
- **Page**: https://redux.js.org/tutorials/essentials/part-6-performance-normalization

## What is the problem?

Dispatching the post reactionAdded action with no arguments makes it so it throws an error, so the user can't see
the output of a memoizing selector.

## What changes does this PR make to fix the problem?
- Add arguments to `reactionAdded` and `addNewPost` actions 