### PR TITLE
Remove unnecessary key attribute

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -539,7 +539,7 @@ import { selectAllPosts, fetchPosts } from './postsSlice'
 // highlight-start
 const PostExcerpt = ({ post }) => {
   return (
-    <article className="post-excerpt" key={post.id}>
+    <article className="post-excerpt">
       <h3>{post.title}</h3>
       <div>
         <PostAuthor userId={post.user} />


### PR DESCRIPTION
Using `key` attribute here is a mistake. It makes sense only in context of an array according to official React documentation (see [here](https://reactjs.org/docs/lists-and-keys.html#extracting-components-with-keys)).