### PR TITLE
Docs: delete extraneous full stop after exclamation mark

### DIFF
--- a/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
+++ b/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
@@ -190,7 +190,7 @@ const todoAppState = {
 }
 ```
 
-It's important to note that **it's okay to have other state values outside of Redux!**. This example is small enough so far that we actually do have all our state in the Redux store, but as we'll see later, some data really doesn't need to be kept in Redux (like "is this dropdown open?" or "current value of a form input").
+It's important to note that **it's okay to have other state values outside of Redux!** This example is small enough so far that we actually do have all our state in the Redux store, but as we'll see later, some data really doesn't need to be kept in Redux (like "is this dropdown open?" or "current value of a form input").
 
 ### Designing Actions
 


### PR DESCRIPTION




---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section** Fundamentals
- **Page**: 3

## What is the problem?

There's [no situation](https://www.thepunctuationguide.com/terminal-points.html) in which a period should follow an exclamation point, including when inside quotes, regardless of text styling.

## What changes does this PR make to fix the problem?

Change "it's okay to have other state values outside of Redux!." to "it's okay to have other state values outside of Redux!"
