### PR TITLE
Docs: Update RTK Query basics to replace single quotes with double

### DIFF
--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -360,7 +360,7 @@ Instead, we're going to try adding another endpoint definition that will let us 
 
 ### Adding the Single Post Query Endpoint
 
-In `apiSlice.js`, we're going to add another query endpoint definition, called `getPost` (no 's' this time):
+In `apiSlice.js`, we're going to add another query endpoint definition, called `getPost` (no "s" this time):
 
 ```js title="features/api/apiSlice.js"
 export const apiSlice = createApi({


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Proper usage of quotation marks
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials
- **Page**: Part 7: RTK Query Basics

## What is the problem?

The sentence fragment

>  (no 's' this time)

improperly uses single quotes. Double quotes should be used in almost all instances, except when already within a fragment wrapped in double quotes: https://www.chicagomanualofstyle.org/qanda/data/faq/topics/Quotations/faq0001.html

## What changes does this PR make to fix the problem?

Changes to 

> (no "s" this time)
