### PR TITLE
Middlewares TypeChecking problem and Redux Toolkit 

### DIFF
--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -267,6 +267,21 @@ const rootReducer = combineReducers({ ... });
 type RootState = ReturnType<typeof rootReducer>;
 ```
 
+Switching the type definition of `RootState` with Redux Toolkit example:
+
+```ts
+//instead of defining the reducers in the reducer field of configureStore, combine them here:
+const rootReducer = combineReducers({ counter: counterReducer });
+
+//then set rootReducer as the reducer object of configureStore
+const store = configureStore({
+  reducer: rootReducer,
+  middleware: [...],
+});
+
+type RootState = ReturnType<typeof rootReducer>;
+```
+
 ### Type Checking Redux Thunks
 
 [Redux Thunk](https://github.com/reduxjs/redux-thunk) is the standard middleware for writing sync and async logic that interacts with the Redux store. A thunk function receives `dispatch` and `getState` as its parameters. Redux Thunk has a built in `ThunkAction` type which we can use to define types for those arguments:


### PR DESCRIPTION


---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: usage
- **Page**: UsageWithTypescript.md

## What is the problem?
As a Redux Toolkit user, when i stumbled upon the circular depency problem when TypeChecking the middlwares and read this page, i was confused by the current snippet and explanation. By setting a store with the Redux Toolkit quick start example (https://redux-toolkit.js.org/tutorials/quick-start), you never use `combineReducers` and so i did not really know what to change (i had to do further research). 

## What changes does this PR make to fix the problem?
I added a code snippet (how i solved the problem in my app) for Redux Toolkit hoping that it can be more clear for users them and save some searches on google. Let me know what you think please!