### PR TITLE
remove listener with more semantic code

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -204,8 +204,7 @@ export default function createStore<
       isSubscribed = false
 
       ensureCanMutateNextListeners()
-      const index = nextListeners.indexOf(listener)
-      nextListeners.splice(index, 1)
+      nextListeners = nextListeners.filter(x => x !== listener)
       currentListeners = null
     }
   }


### PR DESCRIPTION
## Little Change
A little change for source code. I think use `filter` can make the code more
semantic and easier to read than using `slice`
