### PR TITLE
Update typescript.md

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -46,7 +46,7 @@ Since those are types, it's safe to export them directly from your store setup f
 import { configureStore } from '@reduxjs/toolkit'
 // ...
 
-const store = configureStore({
+export const store = configureStore({
   reducer: {
     posts: postsReducer,
     comments: commentsReducer,


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Added missing export statement
---

## Checklist

- [] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials
- **Page**: typescript.md

## What is the problem?
I think there is an export statement missing. Otherwise you can't access the store in other ts-files.

## What changes does this PR make to fix the problem?
Added the missing export statement