### PR TITLE
Remove outdated content in "How do I organize nested or duplicate data in my state?"

### DIFF
--- a/docs/faq/OrganizingState.md
+++ b/docs/faq/OrganizingState.md
@@ -94,7 +94,6 @@ Data with IDs, nesting, or relationships should generally be stored in a “norm
 - [#1824: Normalising state and garbage collection](https://github.com/reduxjs/redux/issues/1824#issuecomment-228585904)
 - [Twitter: state shape should be normalized](https://twitter.com/dan_abramov/status/715507260244496384)
 - [Stack Overflow: How to handle tree-shaped entities in Redux reducers?](https://stackoverflow.com/questions/32798193/how-to-handle-tree-shaped-entities-in-redux-reducers)
-- [Stack Overflow: How to optimize small updates to props of nested components in React + Redux?](https://stackoverflow.com/questions/37264415/how-to-optimize-small-updates-to-props-of-nested-component-in-react-redux)
 
 ### Should I put form state or other UI state in my store?
 

--- a/docs/faq/OrganizingState.md
+++ b/docs/faq/OrganizingState.md
@@ -78,7 +78,6 @@ Data with IDs, nesting, or relationships should generally be stored in a “norm
 - [Examples: Real World example](../introduction/Examples.md#real-world)
 - [Using Redux: Structuring Reducers - Prerequisite Concepts](../usage/structuring-reducers/PrerequisiteConcepts.md#normalizing-data)
 - [Using Redux: Structuring Reducers - Normalizing State Shape](../usage/structuring-reducers/NormalizingStateShape.md)
-- [Examples: Tree View](https://github.com/reduxjs/redux/tree/master/examples/tree-view)
 
 **Articles**
 
@@ -92,7 +91,6 @@ Data with IDs, nesting, or relationships should generally be stored in a “norm
 - [#946: Best way to update related state fields with split reducers?](https://github.com/reduxjs/redux/issues/946)
 - [#994: How to cut the boilerplate when updating nested entities?](https://github.com/reduxjs/redux/issues/994)
 - [#1255: Normalizr usage with nested objects in React/Redux](https://github.com/reduxjs/redux/issues/1255)
-- [#1269: Add tree view example](https://github.com/reduxjs/redux/pull/1269)
 - [#1824: Normalising state and garbage collection](https://github.com/reduxjs/redux/issues/1824#issuecomment-228585904)
 - [Twitter: state shape should be normalized](https://twitter.com/dan_abramov/status/715507260244496384)
 - [Stack Overflow: How to handle tree-shaped entities in Redux reducers?](https://stackoverflow.com/questions/32798193/how-to-handle-tree-shaped-entities-in-redux-reducers)

--- a/docs/faq/OrganizingState.md
+++ b/docs/faq/OrganizingState.md
@@ -81,7 +81,6 @@ Data with IDs, nesting, or relationships should generally be stored in a “norm
 
 **Articles**
 
-- [High-Performance Redux](https://somebody32.github.io/high-performance-redux/)
 - [Querying a Redux Store](https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f)
 
 **Discussions**

--- a/docs/faq/OrganizingState.md
+++ b/docs/faq/OrganizingState.md
@@ -73,6 +73,7 @@ Data with IDs, nesting, or relationships should generally be stored in a “norm
 
 **Documentation**
 
+- [Redux Essentials: Normalizing Data](../tutorials/essentials/part-6-performance-normalization#normalizing-data)
 - [Redux Fundamentals: Async Logic and Data Flow](../tutorials/fundamentals/part-6-async-logic.md)
 - [Redux Fundamentals: Standard Redux Patterns](../tutorials/fundamentals/part-7-standard-patterns.md)
 - [Examples: Real World example](../introduction/Examples.md#real-world)


### PR DESCRIPTION
---
name: :book: Updated Documentation Content
about: Remove outdated content in "How do I organize nested or duplicate data in my state?"
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4421
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: How do I organize nested or duplicate data in my state?
- **Page**: Redux FAQ: Organizing State

## For Updating Existing Content

### What updates should be made to the page?

- Add a link to "Redux Essentials: Normalizing Data"
- Remove content that contains multiple dead/outdated links 
- Remove content focused on performance optimization with older versions of `react-redux` and `react`
  - I understand this section is about organizing state but after reading through `"High-Performance Redux"` and `"Stack Overflow: How to optimize small updates to props of nested components in React + Redux?"`, they only mention normalization briefly 
  - Their main focus was more on optimizing performance with older APIs/patterns like `makeMapStateToProps` and `shouldComponentUpdate`, which doesn't seem relevant to include anymore
