### PR TITLE
Remove unnecessary space in style guide

### DIFF
--- a/docs/style-guide/style-guide.md
+++ b/docs/style-guide/style-guide.md
@@ -232,7 +232,7 @@ Use of static typing does make this kind of code safer and somewhat more accepta
 
 ### Name State Slices Based On the Stored Data
 
-As mentioned in [Reducers Should Own the State Shape ](#reducers-should-own-the-state-shape), the standard approach for splitting reducer logic is based on "slices" of state. Correspondingly, `combineReducers` is the standard function for joining those slice reducers into a larger reducer function.
+As mentioned in [Reducers Should Own the State Shape](#reducers-should-own-the-state-shape), the standard approach for splitting reducer logic is based on "slices" of state. Correspondingly, `combineReducers` is the standard function for joining those slice reducers into a larger reducer function.
 
 The key names in the object passed to `combineReducers` will define the names of the keys in the resulting state object. Be sure to name these keys after the data that is kept inside, and avoid use of the word "reducer" in the key names. Your object should look like `{users: {}, posts: {}}`, rather than `{usersReducer: {}, postsReducer: {}}`.
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - No
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Style Guide
- **Page**: Style Guide: Best Practices

## What is the problem?
Unnecessary space after link.

## What changes does this PR make to fix the problem?
Removes the space.
