### PR TITLE
change reducer type validation place

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -68,6 +68,15 @@ export default function createStore<
   preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext {
+  
+  if (typeof reducer !== 'function') {
+    throw new Error(
+      `Expected the root reducer to be a function. Instead, received: '${kindOf(
+        reducer
+      )}'`
+    )
+  }
+
   if (
     (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
     (typeof enhancer === 'function' && typeof arguments[3] === 'function')
@@ -97,14 +106,6 @@ export default function createStore<
       reducer,
       preloadedState as PreloadedState<S>
     ) as Store<ExtendState<S, StateExt>, A, StateExt, Ext> & Ext
-  }
-
-  if (typeof reducer !== 'function') {
-    throw new Error(
-      `Expected the root reducer to be a function. Instead, received: '${kindOf(
-        reducer
-      )}'`
-    )
   }
 
   let currentReducer = reducer


### PR DESCRIPTION
change reducer type validation to be at the very start of createStore function since all operations after this condition is met are neglected, and this also forces users who pass their own enhancers to pass the reducer as a function
