### PR TITLE
example doesn't export named store

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -125,14 +125,14 @@ Let's start by looking at how the Redux store is created.
 Open up `app/store.js`, which should look like this:
 
 ```js title="app/store.js"
-import { configureStore } from '@reduxjs/toolkit'
-import counterReducer from '../features/counter/counterSlice'
+import { configureStore } from '@reduxjs/toolkit';
+import counterReducer from '../features/counter/counterSlice';
 
-export default configureStore({
+export const store = configureStore({
   reducer: {
-    counter: counterReducer
-  }
-})
+    counter: counterReducer,
+  },
+});
 ```
 
 The Redux store is created using the `configureStore` function from Redux Toolkit. `configureStore` requires that we pass in a `reducer` argument.


### PR DESCRIPTION

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Creating the Redux Store
- **Page**: https://redux.js.org/tutorials/essentials/part-2-app-structure#creating-the-redux-store

## What is the problem?
The example snippet doesn't align with the redux-essentials-example code.  It doesn't export store, required if you don't use the essentials template

## What changes does this PR make to fix the problem?
If someone is following along from the essentials page, they won't receive an error that store isn't exported.