### PR TITLE
redux-dynamic-modules : Outdated Module

### DIFF
--- a/docs/usage/CodeSplitting.md
+++ b/docs/usage/CodeSplitting.md
@@ -158,6 +158,4 @@ To remove a reducer, one can now call `store.reducerManager.remove("asyncState")
 
 There are a few good libraries out there that can help you add the above functionality automatically:
 
-- [`redux-dynamic-modules`](https://github.com/Microsoft/redux-dynamic-modules):
-  This library introduces the concept of a 'Redux Module', which is a bundle of Redux artifacts (reducers, middleware) that should be dynamically loaded. It also exposes a React higher-order component to load 'modules' when areas of the application come online. Additionally, it has integrations with libraries like `redux-thunk` and `redux-saga` which also help dynamically load their artifacts (thunks, sagas).
 - [Redux Ecosystem Links: Reducers - Dynamic Reducer Injection](https://github.com/markerikson/redux-ecosystem-links/blob/master/reducers.md#dynamic-reducer-injection)


### PR DESCRIPTION
redux-dynamic-modules : This module is totally outdated and its breaking changes with react 18. That's the reason I have removed the line from the documentation to avoid confusion for new users.

More details here https://github.com/microsoft/redux-dynamic-modules/issues

Issue whit react 18 : 
![image](https://user-images.githubusercontent.com/6356988/210555316-ef7f0946-e6b2-4e10-93da-51c68a3882aa.png)


Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
