### PR TITLE
Remove Google Analytics

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -186,9 +186,6 @@ module.exports = {
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')
-        },
-        googleAnalytics: {
-          trackingID: 'UA-130598673-1'
         }
       }
     ]


### PR DESCRIPTION
Closes #3815 

I enabled Netlify Analytics and these seem to cover our needs from the perspective of knowing which pages are most popular. Even better, they're retroactive and already have data collected. Super bonus: They're server-side and don't require a tracking script on the page (which can be blocked and is a privacy concern).