### PR TITLE
Fix typo in part-8-modern-redux.md

### DIFF
--- a/docs/tutorials/fundamentals/part-8-modern-redux.md
+++ b/docs/tutorials/fundamentals/part-8-modern-redux.md
@@ -249,7 +249,7 @@ There's several things to see in this example:
 
 - We write case reducer functions inside the `reducers` object, and give them readable names
 - **`createSlice` will automatically generate action creators** that correspond to each case reducer function we provide
-- createSlice automatically returns the existing state in the default case
+- **`createSlice` automatically returns the existing state in the default case
 - **`createSlice` allows us to safely "mutate" our state!**
 - But, we can also make immutable copies like before if we want to
 


### PR DESCRIPTION
Fix typo

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## What docs page needs to be fixed?

- **Section**: Using createSlice
- **Page**: https://redux.js.org/tutorials/fundamentals/part-8-modern-redux#using-createslice

## What is the problem?

Missing code block for `createSlice`
