### PR TITLE
Documentation Fix for WritingTests.mdx

### DIFF
--- a/docs/usage/WritingTests.mdx
+++ b/docs/usage/WritingTests.mdx
@@ -456,7 +456,6 @@ export type AppDispatch = AppStore['dispatch']
 import React, { PropsWithChildren } from 'react'
 import { render } from '@testing-library/react'
 import type { RenderOptions } from '@testing-library/react'
-import { configureStore } from '@reduxjs/toolkit'
 import type { PreloadedState } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 
@@ -530,7 +529,6 @@ export type AppDispatch = AppStore['dispatch']
 import React, { PropsWithChildren } from 'react'
 import { render } from '@testing-library/react'
 import type { RenderOptions } from '@testing-library/react'
-import { configureStore } from '@reduxjs/toolkit'
 import type { PreloadedState } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix for WritingTests.mdx
about: Remove unused configureStore imports from code examples
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Using Redux -> Code Quality -> Writing Tests -> Setting Up a Reusable Test Render Function
- **Page**: https://redux.js.org/usage/writing-tests#setting-up-a-reusable-test-render-function

## What is the problem?

Unused `configureStore` import in code example as seen in the following screenshot:
![image](https://user-images.githubusercontent.com/20701635/214662676-52757af8-8722-4093-a831-ed48a95a15cc.png)


## What changes does this PR make to fix the problem?
This PR removes unused imports from the mdx file