### PR TITLE
Replace listeners array with a Map for better performance

### DIFF
--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -91,6 +91,8 @@ export interface Unsubscribe {
   (): void
 }
 
+export type ListenerCallback = () => void
+
 declare global {
   interface SymbolConstructor {
     readonly observable: symbol
@@ -198,7 +200,7 @@ export interface Store<
    * @param listener A callback to be invoked on every dispatch.
    * @returns A function to remove this change listener.
    */
-  subscribe(listener: () => void): Unsubscribe
+  subscribe(listener: ListenerCallback): Unsubscribe
 
   /**
    * Replaces the reducer currently used by the store to calculate the state.


### PR DESCRIPTION
Redux has always used an array of listener callbacks internally.  However, as we found out with React-Redux, using `listeners.findIndex(callback)` is bad for performance ( https://github.com/reduxjs/react-redux/pull/1523 , https://github.com/reduxjs/react-redux/issues/1869 ).

React-Redux uses a custom linked list internally.  That's way more than we need here.  But, now that we're assuming modern browsers, it's safe to assume ES2015+ support, and that `Map/Set`s are available.  

I initially tried `Set<ListenerCallback>`, but found that one test failed... because it was passing in the same `jest.fn()` instance _twice_.  A `Set` compares by reference, so the callback got removed in the first `unsubscribe()` call and was no longer around for the second.

We don't have a formal statement that we support passing in the same callback more than once, but that's the implicit semantics thus far.

Given that, a `Map<number, ListenerCallback>` works equivalently, and we'll just have an incrementing counter for the key.

Also, I double-checked perf for cloning `Set`s before I switched over to `Map`s.  Somewhat surprisingly, `existing.forEach(item => newSet.add(item))` runs _faster_ than `new Set(existing)`, or using `for..of`, so I assume the same is true for `Map`s.  (I will note that I was creating `Set`s with 1M items, and the difference was like 150ms to 120ms. So I don't expect that to have any meaningful cost here.)

In practice, I don't expect this to make a lot of difference, because React-Redux's `<Provider>` normally subscribes directly to the store, and all child components subscribe to that `<Provider>`'s internal `Subscription` instance.

But getting rid of this little perf footgun is nice.
