### PR TITLE
Added => for arrow function definition

### DIFF
--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -490,7 +490,7 @@ Whenever an action is dispatched:
 Any middleware can return any value, and the return value from the first middleware in the pipeline is actually returned when you call `store.dispatch()`. For example:
 
 ```js
-const alwaysReturnHelloMiddleware = storeAPI => next => action {
+const alwaysReturnHelloMiddleware = storeAPI => next => action => {
   const originalResult = next(action);
   // Ignore the original result, return something else
   return 'Hello!'


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials/fundamentals/part-4-store
- **Page**: your-first-custom-middleware

## What is the problem? 
The problem is in definition of alwaysReturnHelloMiddleware function
=> is missed

## What changes does this PR make to fix the problem?
Adds => to the definition of alwaysReturnHelloMiddleware
