### PR TITLE
Grammar fixes

### DIFF
--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -504,7 +504,7 @@ console.log(dispatchResult)
 // log: 'Hello!'
 ```
 
-Let's try one more example. Middleware often look for a specific action, and then do something when that action is dispatched. Middleware also have the ability to run async logic inside. We can write a middleware that prints something on a delay when it sees a certain action:
+Let's try one more example. Middleware often looks for a specific action, and then does something when that action is dispatched. Middleware also has the ability to run async logic inside. We can write a middleware that prints something on a delay when it sees a certain action:
 
 ```js
 const delayedMessageMiddleware = storeAPI => next => action => {


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials/fundamentals/part-4-store
- **Page**: your-first-custom-middleware

## What is the problem? 
The problem is using verbs without s at the end with the noun middleware

## What changes does this PR make to fix the problem?
Correct form of the verb is used
