### PR TITLE
documentation-edit.md

### DIFF
--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -115,7 +115,7 @@ export const counterSlice = createSlice({
 // Action creators are generated for each case reducer function
 export const { increment, decrement, incrementByAmount } = counterSlice.actions
 
-export default counterSlice.reducer
+export default counterSlice.reducers
 ```
 
 ### Add Slice Reducers to the Store


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials/Quick Start
- **Page**:  Create a redux state slice

## What is the problem?
At line 93 we created counterSlice and gave a reducers as key on line 98
at line 118 we export default counterSlice.reducer but shouldn't it be export default counterSlice.reducers

## What changes does this PR make to fix the problem?
I changed it to counterSlice.reducers