### PR TITLE
Run tests from source instead of building first

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,3 +35,38 @@ jobs:
 
       - name: Run test suite
         run: npm test
+
+      - name: Check build
+        run: npm run build
+
+  test-types:
+    name: Test Types with TypeScript ${{ matrix.ts }}
+
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['16.x']
+        ts: ['4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9.2-rc']
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use node ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install TypeScript ${{ matrix.ts }}
+        run: npm i --save-dev typescript@${{ matrix.ts }}
+
+      - name: Test types
+        run: |
+          npm run tsc -- --version
+          npm run check-types
+          npm run test:types

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "build": "rollup -c",
     "prepublishOnly": "npm run clean && npm run check-types && npm run format:check && npm run lint && npm test",
     "examples:lint": "eslint --ext js,ts examples",
-    "examples:test": "cross-env CI=true babel-node examples/testAll.js"
+    "examples:test": "cross-env CI=true babel-node examples/testAll.js",
+    "tsc": "tsc"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,12 +48,11 @@
     "format:check": "prettier --list-different \"{src,test}/**/*.{js,ts}\" \"**/*.md\"",
     "lint": "eslint --ext js,ts src test",
     "check-types": "tsc --noEmit",
-    "test": "jest && tsc -p test/typescript",
+    "test": "jest",
     "test:types": "tsc -p test/typescript",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "build": "rollup -c",
-    "pretest": "npm run build",
     "prepublishOnly": "npm run clean && npm run check-types && npm run format:check && npm run lint && npm test",
     "examples:lint": "eslint --ext js,ts examples",
     "examples:test": "cross-env CI=true babel-node examples/testAll.js"

--- a/test/applyMiddleware.spec.ts
+++ b/test/applyMiddleware.spec.ts
@@ -7,7 +7,7 @@ import {
   Action,
   Store,
   Dispatch
-} from '..'
+} from '../src'
 import * as reducers from './helpers/reducers'
 import { addTodo, addTodoAsync, addTodoIfEmpty } from './helpers/actionCreators'
 import { thunk } from './helpers/middleware'

--- a/test/bindActionCreators.spec.ts
+++ b/test/bindActionCreators.spec.ts
@@ -1,4 +1,4 @@
-import { bindActionCreators, createStore, ActionCreator, Store } from '..'
+import { bindActionCreators, createStore, ActionCreator, Store } from '../src'
 import { todos } from './helpers/reducers'
 import * as actionCreators from './helpers/actionCreators'
 

--- a/test/combineReducers.spec.ts
+++ b/test/combineReducers.spec.ts
@@ -5,7 +5,7 @@ import {
   Reducer,
   AnyAction,
   __DO_NOT_USE__ActionTypes as ActionTypes
-} from '..'
+} from '../src'
 
 describe('Utils', () => {
   describe('combineReducers', () => {

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -1,4 +1,4 @@
-import { compose } from '..'
+import { compose } from '../src'
 
 describe('Utils', () => {
   describe('compose', () => {

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -1,4 +1,10 @@
-import { createStore, combineReducers, StoreEnhancer, Action, Store } from '..'
+import {
+  createStore,
+  combineReducers,
+  StoreEnhancer,
+  Action,
+  Store
+} from '../src'
 import {
   addTodo,
   dispatchInMiddle,

--- a/test/helpers/actionCreators.ts
+++ b/test/helpers/actionCreators.ts
@@ -7,7 +7,7 @@ import {
   THROW_ERROR,
   UNKNOWN_ACTION
 } from './actionTypes'
-import { Action, AnyAction, Dispatch } from '../..'
+import { Action, AnyAction, Dispatch } from '../../src'
 
 export function addTodo(text: string): AnyAction {
   return { type: ADD_TODO, text }

--- a/test/helpers/middleware.ts
+++ b/test/helpers/middleware.ts
@@ -1,4 +1,4 @@
-import { MiddlewareAPI, Dispatch, AnyAction } from '../..'
+import { MiddlewareAPI, Dispatch, AnyAction } from '../../src'
 
 type ThunkAction<T extends any = any> = T extends AnyAction
   ? AnyAction

--- a/test/helpers/reducers.ts
+++ b/test/helpers/reducers.ts
@@ -6,7 +6,7 @@ import {
   UNSUBSCRIBE_IN_MIDDLE,
   THROW_ERROR
 } from './actionTypes'
-import { AnyAction } from '../..'
+import { AnyAction } from '../../src'
 
 function id(state: { id: number }[]) {
   return (

--- a/test/typescript/actionCreators.ts
+++ b/test/typescript/actionCreators.ts
@@ -4,7 +4,7 @@ import {
   Dispatch,
   bindActionCreators,
   ActionCreatorsMapObject
-} from '../..'
+} from '../../src'
 
 interface AddTodoAction extends Action {
   text: string

--- a/test/typescript/actions.ts
+++ b/test/typescript/actions.ts
@@ -1,4 +1,4 @@
-import { Action as ReduxAction } from '../..'
+import { Action as ReduxAction } from '../../src'
 
 namespace FSA {
   interface Action<P> extends ReduxAction {

--- a/test/typescript/compose.ts
+++ b/test/typescript/compose.ts
@@ -1,4 +1,4 @@
-import { compose } from '../..'
+import { compose } from '../../src'
 
 // adapted from DefinitelyTyped/compose-function
 

--- a/test/typescript/dispatch.ts
+++ b/test/typescript/dispatch.ts
@@ -1,4 +1,4 @@
-import { Dispatch } from '../..'
+import { Dispatch } from '../../src'
 
 /**
  * Default Dispatch type accepts any object with `type` property.

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -5,7 +5,7 @@ import {
   Reducer,
   createStore,
   Store
-} from '../..'
+} from '../../src'
 
 interface State {
   someField: 'string'

--- a/test/typescript/injectedDispatch.ts
+++ b/test/typescript/injectedDispatch.ts
@@ -1,4 +1,4 @@
-import { Dispatch, Action } from '../..'
+import { Dispatch, Action } from '../../src'
 
 interface Component<P> {
   props: P

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -7,7 +7,7 @@ import {
   Reducer,
   Action,
   AnyAction
-} from '../..'
+} from '../../src'
 
 /**
  * Logger middleware doesn't add any extra types to dispatch, just logs actions

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -1,4 +1,4 @@
-import { Reducer, Action, combineReducers, ReducersMapObject } from '../..'
+import { Reducer, Action, combineReducers, ReducersMapObject } from '../../src'
 
 /**
  * Simple reducer definition with no action shape checks.

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -7,7 +7,7 @@ import {
   Unsubscribe,
   Observer,
   ExtendState
-} from '../..'
+} from '../../src'
 import 'symbol-observable'
 
 type BrandedString = string & { _brand: 'type' }


### PR DESCRIPTION
Our `test` command has always done a full lint+build step every time, which is annoying.

I've reworked it so that `test` runs against `src`.

Also, apparently we don't actually do typetests against the usual range of TS versions like we do in all of our other repos.  Added that.