### PR TITLE
Enable strict mode for TypeScript tests

### DIFF
--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -120,7 +120,11 @@ export type Observer<T> = {
  * @template A the type of actions which may be dispatched by this store.
  * @template StateExt any extension to state from store enhancers
  */
-export interface Store<S = any, A extends Action = AnyAction, StateExt = {}> {
+export interface Store<
+  S = any,
+  A extends Action = AnyAction,
+  StateExt extends {} = {}
+> {
   /**
    * Dispatches an action. It is the only way to trigger a state change.
    *

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -3,8 +3,7 @@ import {
   Action,
   AnyAction,
   Reducer,
-  createStore,
-  Store
+  createStore
 } from '../../src'
 
 interface State {
@@ -157,17 +156,23 @@ function replaceReducerExtender() {
       }
     }
 
+  interface PartialState {
+    someField?: 'string'
+    test?: boolean
+  }
+
+  const initialReducer: Reducer<PartialState, Action<unknown>> = () => ({
+    someField: 'string'
+  })
   const store = createStore<
-    { someField?: 'string'; test?: boolean },
+    PartialState,
     Action<unknown>,
     { method(): string },
     ExtraState
-  >(reducer, enhancer)
+  >(initialReducer, enhancer)
 
-  const newReducer = (
-    state: { test: boolean } = { test: true },
-    _: AnyAction
-  ) => state
+  const newReducer = (state: PartialState = { test: true }, _: AnyAction) =>
+    state
 
   store.replaceReducer(newReducer)
   store.getState().test
@@ -234,23 +239,27 @@ function mhelmersonExample() {
         }
       }
 
-    const store = createStore<
-      { someField?: 'string'; test?: boolean },
-      Action<unknown>,
-      {},
-      ExtraState
-    >(reducer, enhancer)
-    store.replaceReducer(reducer)
+    interface PartialState {
+      someField?: 'string'
+      test?: boolean
+    }
+
+    const initialReducer: Reducer<PartialState, Action<unknown>> = () => ({
+      someField: 'string'
+    })
+    const store = createStore<PartialState, Action<unknown>, {}, ExtraState>(
+      initialReducer,
+      enhancer
+    )
+    store.replaceReducer(initialReducer)
 
     store.getState().extraField
     // @ts-expect-error
     store.getState().wrongField
     store.getState().test
 
-    const newReducer = (
-      state: { test: boolean } = { test: true },
-      _: AnyAction
-    ) => state
+    const newReducer = (state: PartialState = { test: true }, _: AnyAction) =>
+      state
 
     store.replaceReducer(newReducer)
     store.getState().test
@@ -304,21 +313,25 @@ function finalHelmersonExample() {
       }
   }
 
-  const store = createStore<
-    { someField?: 'string'; test?: boolean },
-    Action<unknown>,
-    {},
-    ExtraState
-  >(reducer, createPersistEnhancer('hi'))
+  interface PartialState {
+    someField?: 'string'
+    test?: boolean
+  }
+
+  const initialReducer: Reducer<PartialState, Action<unknown>> = () => ({
+    someField: 'string'
+  })
+  const store = createStore<PartialState, Action<unknown>, {}, ExtraState>(
+    initialReducer,
+    createPersistEnhancer('hi')
+  )
 
   store.getState().foo
   // @ts-expect-error
   store.getState().wrongField
 
-  const newReducer = (
-    state: { test: boolean } = { test: true },
-    _: AnyAction
-  ) => state
+  const newReducer = (state: PartialState = { test: true }, _: AnyAction) =>
+    state
 
   store.replaceReducer(newReducer)
   store.getState().test

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -150,9 +150,9 @@ function discriminated() {
 
   const cs = combined(undefined, { type: 'INCREMENT' })
   combined(cs, { type: 'MULTIPLY' })
-  // TODO // @ts-expect-error
+  // @ts-expect-error
   combined(cs, { type: 'init' })
-  // TODO // @ts-expect-error
+  // @ts-expect-error
   combined(cs, { type: 'SOME_OTHER_TYPE' })
 
   // Combined reducer can be made to only accept known actions.

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "emitDeclarationOnly": false,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "target": "esnext",
     "jsx": "react",


### PR DESCRIPTION
The PR says it all.

Update tests that were failing due to the lack of strict mode.