### PR TITLE
Type-check tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/**'
               - 'src/**'
               - 'test/**'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16.x']
-        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9.2-rc']
+        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,4 +126,5 @@ jobs:
         run: |
           yarn tsc --version
           yarn check-types
+          yarn test:typecheck
           yarn test:types

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16.x']
-        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9']
+        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0.0-beta']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16.x']
-        ts: ['4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9.2-rc']
+        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9.2-rc']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16.x']
-        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0.0-beta']
+        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:types": "tsc -p test/typescript && echo \"Typetests passed\"",
     "test:watch": "vitest",
     "test:cov": "vitest --coverage",
+    "test:typecheck": "tsc -p test && echo \"Types passed\"",
     "build": "rollup -c",
     "prepublishOnly": "yarn clean && yarn check-types && yarn format:check && yarn lint && yarn test && yarn build",
     "examples:lint": "eslint --ext js,ts examples",


### PR DESCRIPTION
In https://github.com/reduxjs/redux/pull/4487 we switched from ts-jest (which runs type-checking on test files) to Vitest (which does not).

This PR runs type-checking on the tests to make sure they pass.