### PR TITLE
Fix inconsistent semi-colons in faq section

### DIFF
--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -202,9 +202,9 @@ axiosInstance.interceptors.request.use(config => {
 Then, in your entry point file, inject the store into the API setup file:
 
 ```js title="index.js"
-import store from "./app/store".
-import {injectStore} from "./common/api";
-injectStore(store);
+import store from "./app/store"
+import {injectStore} from "./common/api"
+injectStore(store)
 ```
 
 This way, the application setup is the only code that has to import the store, and the file dependency graph avoids circular dependencies.


### PR DESCRIPTION
---
name: :memo: Docs FAQ Section Fix
about: Fixing inconsistent use of semi-colons
---
- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

When reading the docs I noticed inconsistent use of semi-colons in the code examples.
I found out the docs do not use them and decided to remove them.