### PR TITLE
Add PreloadedState generic

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -2,7 +2,6 @@ import $$observable from './utils/symbol-observable'
 
 import {
   Store,
-  PreloadedState,
   StoreEnhancer,
   Dispatch,
   Observer,
@@ -77,20 +76,22 @@ export function createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
-  reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S>,
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext
 export function createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
-  reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | StoreEnhancer<Ext, StateExt> | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext {
   if (typeof reducer !== 'function') {
@@ -128,12 +129,14 @@ export function createStore<
 
     return enhancer(createStore)(
       reducer,
-      preloadedState as PreloadedState<S>
-    ) as Store<S, A, StateExt> & Ext
+      preloadedState as PreloadedState | undefined
+    )
   }
 
   let currentReducer = reducer
-  let currentState = preloadedState as S
+  let currentState: S | PreloadedState | undefined = preloadedState as
+    | PreloadedState
+    | undefined
   let currentListeners: Map<number, ListenerCallback> | null = new Map()
   let nextListeners = currentListeners
   let listenerIdCounter = 0
@@ -315,7 +318,7 @@ export function createStore<
       )
     }
 
-    currentReducer = nextReducer
+    currentReducer = nextReducer as unknown as Reducer<S, A, PreloadedState>
 
     // This action has a similar effect to ActionTypes.INIT.
     // Any reducers that existed in both the new and old rootReducer
@@ -456,20 +459,22 @@ export function legacy_createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
-  reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S>,
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext
 export function legacy_createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
   reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
+  preloadedState?: PreloadedState | StoreEnhancer<Ext, StateExt> | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext {
   return createStore(reducer, preloadedState as any, enhancer)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,6 @@ import __DO_NOT_USE__ActionTypes from './utils/actionTypes'
 // types
 // store
 export {
-  CombinedState,
-  PreloadedState,
   Dispatch,
   Unsubscribe,
   Observable,
@@ -23,11 +21,12 @@ export {
 // reducers
 export {
   Reducer,
-  ReducerFromReducersMapObject,
   ReducersMapObject,
   StateFromReducersMapObject,
+  ReducerFromReducersMapObject,
   ActionFromReducer,
-  ActionFromReducersMapObject
+  ActionFromReducersMapObject,
+  PreloadedStateShapeFromReducersMapObject
 } from './types/reducers'
 // action creators
 export { ActionCreator, ActionCreatorsMapObject } from './types/actions'

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -3,7 +3,8 @@ import {
   combineReducers,
   StoreEnhancer,
   Action,
-  Store
+  Store,
+  Reducer
 } from 'redux'
 import { vi } from 'vitest'
 import {
@@ -844,20 +845,27 @@ describe('createStore', () => {
     const originalConsoleError = console.error
     console.error = vi.fn()
 
+    const reducer: Reducer<number> = (s = 0) => s
+
+    const yReducer = combineReducers<{
+      z: typeof reducer
+      w?: typeof reducer
+    }>({
+      z: reducer,
+      w: reducer
+    })
+
     const store = createStore(
-      combineReducers<{ x?: number; y: { z: number; w?: number } }>({
-        x: (s = 0, _) => s,
-        y: combineReducers({
-          z: (s = 0, _) => s,
-          w: (s = 0, _) => s
-        })
+      combineReducers<{ x?: typeof reducer; y: typeof yReducer }>({
+        x: reducer,
+        y: yReducer
       })
     )
 
     store.replaceReducer(
       combineReducers({
         y: combineReducers({
-          z: (s = 0, _) => s
+          z: reducer
         })
       })
     )

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -156,7 +156,7 @@ function discriminated() {
   combined(cs, { type: 'SOME_OTHER_TYPE' })
 
   // Combined reducer can be made to only accept known actions.
-  const strictCombined = combineReducers<{ sub: State }, MyAction0>({
+  const strictCombined = combineReducers({
     sub: reducer0
   })
 

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -5,7 +5,8 @@ import {
   Action,
   StoreEnhancer,
   Unsubscribe,
-  Observer
+  Observer,
+  combineReducers
 } from 'redux'
 import 'symbol-observable'
 
@@ -73,6 +74,70 @@ const storeWithBadPreloadedState: Store<State> = createStore(reducer, {
   b: { c: 'c' },
   e: brandedString
 })
+
+const reducerA: Reducer<string> = (state = 'a') => state
+const reducerB: Reducer<{ c: string; d: string }> = (
+  state = { c: 'c', d: 'd' }
+) => state
+const reducerE: Reducer<BrandedString> = (state = brandedString) => state
+
+const combinedReducer = combineReducers({
+  a: reducerA,
+  b: reducerB,
+  e: reducerE
+})
+
+const storeWithCombineReducer = createStore(combinedReducer, {
+  b: { c: 'c', d: 'd' },
+  e: brandedString
+})
+// @ts-expect-error
+const storeWithCombineReducerAndBadPreloadedState = createStore(
+  combinedReducer,
+  {
+    b: { c: 'c' },
+    e: brandedString
+  }
+)
+
+const nestedCombinedReducer = combineReducers({
+  a: (state: string = 'a') => state,
+  b: combineReducers({
+    c: (state: string = 'c') => state,
+    d: (state: string = 'd') => state
+  }),
+  e: (state: BrandedString = brandedString) => state
+})
+
+// @ts-expect-error
+const storeWithNestedCombineReducer = createStore(nestedCombinedReducer, {
+  b: { c: 5 },
+  e: brandedString
+})
+
+const simpleCombinedReducer = combineReducers({
+  c: (state: string = 'c') => state,
+  d: (state: string = 'd') => state
+})
+
+// @ts-expect-error
+const storeWithSimpleCombinedReducer = createStore(simpleCombinedReducer, {
+  c: 5
+})
+
+// Note: It's not necessary that the errors occur on the lines specified, just as long as something errors somewhere
+// since the preloaded state doesn't match the reducer type.
+
+const simpleCombinedReducerWithImplicitState = combineReducers({
+  c: (state = 'c') => state,
+  d: (state = 'd') => state
+})
+
+// @ts-expect-error
+const storeWithSimpleCombinedReducerWithImplicitState = createStore(
+  simpleCombinedReducerWithImplicitState,
+  { c: 5 }
+)
 
 const storeWithActionReducer = createStore(reducerWithAction)
 const storeWithActionReducerAndPreloadedState = createStore(reducerWithAction, {


### PR DESCRIPTION
## Summary

The main change to pay attention to here is the update to the `Reducer` type. Before this PR `Reducer` has a type of:

```
type Reducer<S, A extends Action> = (
  state: S | undefined,
  action: A
) => S
```

After this PR `Reducer` has this type:

```
type Reducer<S, A extends Action, PreloadedState = S> = (
  state: S | PreloadedState | undefined,
  action: A
) => S
```

### Explanation

Why the need for this change? When the store is first created by `createStore`, the initial state is set to whatever is passed as the `preloadedState` argument (or `undefined` if nothing is passed). That means that the first time that the reducer is called, it is called with the `preloadedState`. After the first call, the reducer is always passed the current state (which is `S`).

For most normal reducers, `S | undefined` accurately describes what can be passed in for the `preloadedState`. However the `combineReducers` function allows for a preloaded state of `Partial<S> | undefined`.

The solution is to have a separate generic that represents what the reducer accepts for its preloaded state. That way `createStore` can then use that generic for its `preloadedState` argument.

### Previous work

Up until now, this has been accounted for with the `$CombinedState` type which is a way to "mark" a type as returned by `combineReducers`. The `PreloadedState` type then looks to see if the type has that "mark" and then accepts `Partial<S>` if it has that "mark."

One of the problems this can cause is that if there are multiple copies of Redux in `node_modules`, then the "mark" for one copy of Redux is different than the "mark" for the other copy, and therefore they won't recognize each other.

This also seems to be causing some problems in https://github.com/reduxjs/redux-toolkit/issues/2068.

This PR removes the need for `$CombinedState` altogether.

## Upgrade Impact

This change does include some breaking changes, but overall should not have a huge impact on users upgrading in user-land.

### Additional generic arguments

The `Reducer`, `ReducersMapObject`, and `createStore` types/function take an additional `PreloadedState` generic which defaults to `S`.

### `combineReducers`

The overloads for `combineReducers` are removed in favor of a single function definition that takes the `ReducersMabObject` as its generic parameter. Removing the overloads was necessary with these changes, since sometimes it was choosing the wrong overload.

### Enhancers

Enhancers that explicitly list the generics for the reducer will need to add the third generic.