### PR TITLE
Build package in prepack instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "test:watch": "vitest",
     "test:cov": "vitest --coverage",
     "build": "rollup -c",
-    "prepublishOnly": "yarn clean && yarn check-types && yarn format:check && yarn lint && yarn test && yarn build",
+    "prepublishOnly": "yarn clean && yarn check-types && yarn format:check && yarn lint && yarn test",
+    "prepack": "yarn build",
     "examples:lint": "eslint --ext js,ts examples",
     "examples:test": "cross-env CI=true babel-node examples/testAll.js",
     "tsc": "tsc"


### PR DESCRIPTION
From [Yarn docs about lifecycle scripts](https://yarnpkg.com/advanced/lifecycle-scripts):

> Note about yarn pack: Although rarely called directly, yarn pack is a crucial part of Yarn. Each time Yarn has to fetch a dependency from a "raw" source (such as a Git repository), it will automatically run yarn install and yarn pack on it to know which are the files to use.

> prepack is the lifecycle script called before each call to yarn pack. This is typically the place where you'll want to put scripts that build a package - such as transpiling its source.

> prepublish is called before yarn npm publish and similar commands (even before the package has been packed). This is the place where you'll want to check that the project is in an ok state. Because it's only called on prepublish, the prepublish hook shouldn't have side effects. In particular don't transpile the package sources in prepublish, as people consuming directly your repository (such as through the [git: protocol](https://yarnpkg.com/features/protocols#git)) wouldn't be able to use your project.

I have found this change to be helpful when trying to install Redux using [the Git protocol](https://yarnpkg.com/features/protocols#git) in order to test out changes on a specific branch.

`prepack` is run as part of [`npm/yarn publish`](https://docs.npmjs.com/cli/v9/using-npm/scripts#npm-publish) so this change should hopefully not change anything about publishing.