### PR TITLE
Minor fixes in migrating to modern redux documentation

### DIFF
--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -20,7 +20,7 @@ Redux has been around since 2015, and our recommended patterns for writing Redux
 
 Many users are working on older Redux codebases that have been around since before these "modern Redux" patterns existed. Migrating those codebases to today's recommended modern Redux patterns will result in codebases that are much smaller and easier to maintain.
 
-The good news is that **you can migrate your code to modern Redux incrementally, piece by piece, with old and new Redux code coexisting and working together!**.
+The good news is that **you can migrate your code to modern Redux incrementally, piece by piece, with old and new Redux code coexisting and working together!**
 
 This page covers the general approaches and techniques you can use to modernize an existing legacy Redux codebase.
 

--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -150,7 +150,7 @@ import usersReducer from '../features/users/usersSlice'
 import { api } from '../features/api/apiSlice'
 import { serviceLayer } from '../features/api/serviceLayer'
 
-import sanitizeStateForDevtools from './devtools'
+import stateSanitizerForDevtools from './devtools'
 import customMiddleware from './someCustomMiddleware'
 
 // Can call `combineReducers` yourself if needed
@@ -167,7 +167,6 @@ const persistConfig = {
 }
 
 const persistedReducer = persistReducer(persistConfig, rootReducer)
-
 
 const store = configureStore({
   // Can create a root reducer separately and pass that in
@@ -192,8 +191,8 @@ const store = configureStore({
     return middleware
   },
   // Turn off devtools in prod, or pass options in dev
-  devTools: process.env.NODE_ENV == 'production' ? false {
-    sanitizeState: sanitizeStateForDevtools
+  devTools: process.env.NODE_ENV === 'production' ? false : {
+    stateSanitizer: stateSanitizerForDevtools
   }
 })
 ```
@@ -256,7 +255,7 @@ export default function todosReducer(state = initialState, action) {
 }
 ```
 
-**Redux Toolkit's `createSlice` API was designed to eliminate all the "boilerplate" with writing reducers, actions, and immutable updates!**.
+**Redux Toolkit's `createSlice` API was designed to eliminate all the "boilerplate" with writing reducers, actions, and immutable updates!**
 
 With Redux Toolkit, there's multiple changes to that legacy code:
 
@@ -284,7 +283,7 @@ const todosSlice = createSlice({
     todoAdded(state, action) {
       const { id, text } = action.payload
       // "Mutating" update syntax thanks to Immer, and no `return` needed
-      todos.push({
+      state.todos.push({
         id,
         text,
         completed: false
@@ -295,7 +294,7 @@ const todosSlice = createSlice({
       // Look for the specific nested object to update.
       // In this case, `action.payload` is the default field in the action,
       // and can hold the `id` value - no need for `action.id` separately
-      const matchingTodo = state.find(todo => todo.id === action.payload)
+      const matchingTodo = state.todos.find(todo => todo.id === action.payload)
 
       if (matchingTodo) {
         // Can directly "mutate" the nested object
@@ -449,7 +448,7 @@ import {
   fetchTodosStarted,
   fetchTodosSucceeded,
   fetchTodosFailed
-} from '../actions/todos
+} from '../actions/todos'
 
 // Saga to actually fetch data
 export function* fetchTodos() {
@@ -705,7 +704,7 @@ const pingSlice = createSlice({
   }
 })
 
-export const { ping } = pingSlice.actions
+export const { pong } = pingSlice.actions
 export default pingSlice.reducer
 
 // highlight-start
@@ -714,7 +713,7 @@ export default pingSlice.reducer
 // it directly in a slice file.
 startListening({
   // Match this exact action type based on the action creator
-  actionCreator: ping,
+  actionCreator: pong,
   // Run this effect callback whenever that action is dispatched
   effect: async (action, listenerApi) => {
     // Listener effect functions get a `listenerApi` object
@@ -812,7 +811,7 @@ import { CounterState } from '../reducers/counter'
 
 // omit reducer setup
 
-export const createStore(rootReducer)
+export const store = createStore(rootReducer)
 
 // ❌ Common pattern: an "action type union" of all possible actions
 export type RootAction = TodoActions | CounterActions


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR? - _No, due to minimal changes done in my opinion.  Please let me know if it is desired and I'd be happy to create one._
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Sections**
  - [Overview](https://redux.js.org/usage/migrating-to-modern-redux#overview)
  - [Store Setup with configureStore](https://redux.js.org/usage/migrating-to-modern-redux#store-setup-with-configurestore)
  - [Reducers and Actions with createSlice](https://redux.js.org/usage/migrating-to-modern-redux#reducers-and-actions-with-createslice)
  - [Data Fetching with RTK Query](https://redux.js.org/usage/migrating-to-modern-redux#data-fetching-with-rtk-query)
  - [Reactive Logic with createListenerMiddleware](https://redux.js.org/usage/migrating-to-modern-redux#reactive-logic-with-createlistenermiddleware)
  - [Migrating TypeScript for Redux Logic](https://redux.js.org/usage/migrating-to-modern-redux#migrating-typescript-for-redux-logic) 


- **Page**
  - [Migrating to Modern Redux](https://redux.js.org/usage/migrating-to-modern-redux#migrating-typescript-for-redux-logic)

## What is the problem?
  - [Overview](https://redux.js.org/usage/migrating-to-modern-redux#overview)
    - Extra period at end of sentence, `The good news is that you can migrate your code to modern Redux incrementally, piece by piece, with old and new Redux code coexisting and working together!.`.
  - [Store Setup with configureStore](https://redux.js.org/usage/migrating-to-modern-redux#store-setup-with-configurestore)
    - `devTools` field in `configureStore` options object uses `sanitizeState` when it doesn't [exist in devToolsExtension.ts in redux toolkit and I believe is meant to be stateSanitizer.](https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/src/devtoolsExtension.ts#L92)
    - Additionally, the ternary for setting the `devTools` field is syntactically incorrect since it is missing a colon and should probably use `===` instead of `==` for equality.
  - [Reducers and Actions with createSlice](https://redux.js.org/usage/migrating-to-modern-redux#reducers-and-actions-with-createslice) 
    - Extra period at end of sentence `Redux Toolkit's createSlice API was designed to eliminate all the "boilerplate" with writing reducers, actions, and immutable updates!.`.
    - I believe that the `todosSlice.js` example is missing the `state` reference when attempting to "mutate" the `todos` list.
    - I believe that in the `todoToggled`, the usage of `state.find` should be `state.todos.find` to be correct.
  - [Data Fetching with RTK Query](https://redux.js.org/usage/migrating-to-modern-redux#data-fetching-with-rtk-query)
    - In `todos.js` example describing a saga example, the `../actions/todos` import is missing a `'`.
  - [Reactive Logic with createListenerMiddleware](https://redux.js.org/usage/migrating-to-modern-redux#reactive-logic-with-createlistenermiddleware)
    - I believe that in `pingSlice.js`, instead of `ping` being exported I believe it should be `pong` based on the `createSlice` method declared above.  
    - Additionally, the `actionCreator` field in `startListening` should also be `pong` since `ping` is not a valid `actionCreator`.
  - [Migrating TypeScript for Redux Logic](https://redux.js.org/usage/migrating-to-modern-redux#migrating-typescript-for-redux-logic) 
    - In the example `src/app/store.ts` describing anti-patterns, the line `export const createStore(rootReducer)` is invalid syntax since no reference is being specified.
  
## What changes does this PR make to fix the problem?
  - [Overview](https://redux.js.org/usage/migrating-to-modern-redux#overview)
    - Remove extra period at end of sentence.
  - [Store Setup with configureStore](https://redux.js.org/usage/migrating-to-modern-redux#store-setup-with-configurestore)
    - Changes `sanitizeState` field in devTools object to [match field `stateSanitizer` in devtoolsExtension.ts in redux toolkit.](https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/src/devtoolsExtension.ts#L92)
    - Updates import to match wording of field change for consistency.
    - Adds `:` to ternary used to set the `devTools` field in `configureStore` between options and updates equality operator from `==` to `===`.
  - [Reducers and Actions with createSlice](https://redux.js.org/usage/migrating-to-modern-redux#reducers-and-actions-with-createslice) 
    - Removes extra period at end of sentence `Redux Toolkit's createSlice API was designed to eliminate all the "boilerplate" with writing reducers, actions, and immutable updates!.`.
    - In the `todosSlice.js` example, I add the missing `state` reference when attempting to "mutate" the `todos` list.
    - In the `todoToggled` actionReducer, the usage of `state.find` is changed to be `state.todos.find`.
  - [Data Fetching with RTK Query](https://redux.js.org/usage/migrating-to-modern-redux#data-fetching-with-rtk-query)
    -  Corrects import statement by adding `'` in `todos.js` example describing a saga example, for the `../actions/todos` import.
  - [Reactive Logic with createListenerMiddleware](https://redux.js.org/usage/migrating-to-modern-redux#reactive-logic-with-createlistenermiddleware)
    - Changes the exported `ActionReducer` from `ping` to `pong` in `pingSlice.js`.
    - Changes the `actionCreator` field in `startListening` to be `pong`.
  - [Migrating TypeScript for Redux Logic](https://redux.js.org/usage/migrating-to-modern-redux#migrating-typescript-for-redux-logic) 
    - Adds `store` reference to correct invalid syntax in the example `src/app/store.ts` describing anti-patterns on the line `export const createStore(rootReducer)`.
    
## PS
Huge thank you to @markerikson for recently creating this page!  It came just in time for me to learn about modern redux existing and start migrating my personal app to utilizing it from "old" redux core.