### PR TITLE
Add "use modern Redux" warnings to Fundamentals pages

### DIFF
--- a/docs/components/_FundamentalsWarning.mdx
+++ b/docs/components/_FundamentalsWarning.mdx
@@ -1,10 +1,10 @@
 :::caution
 
-Note that **this tutorial intentionally shows older-style patterns that require more code than the "modern Redux" patterns we teach as the right approach for building apps with Redux today**, in order to explain the principles and concepts behind Redux. It's _not_ meant to be a production-ready project.
+Note that **this tutorial intentionally shows older-style Redux logic patterns that require more code than the "modern Redux" patterns with Redux Toolkit we teach as the right approach for building apps with Redux today**, in order to explain the principles and concepts behind Redux. It's _not_ meant to be a production-ready project.
 
 See these pages to learn how to use "modern Redux" with Redux Toolkit:
 
+- [**The full "Redux Essentials" tutorial**](../tutorials/essentials/part-1-overview-concepts.md), which teaches "how to use Redux, the right way" with Redux Toolkit for real-world apps. **We recommend that all Redux learners should read the "Essentials" tutorial!**
 - [**Redux Fundamentals, Part 8: Modern Redux with Redux Toolkit**](../tutorials/fundamentals/part-8-modern-redux.md), which shows how to convert the low-level examples from earlier sections into modern Redux Toolkit equivalents
-- [**The "Redux Essentials" tutorial**](../tutorials/essentials/part-1-overview-concepts.md), which teaches "how to use Redux, the right way" with Redux Toolkit for real-world apps,
 
 :::

--- a/docs/components/_FundamentalsWarning.mdx
+++ b/docs/components/_FundamentalsWarning.mdx
@@ -1,0 +1,10 @@
+:::caution
+
+Note that **this tutorial intentionally shows older-style patterns that require more code than the "modern Redux" patterns we teach as the right approach for building apps with Redux today**, in order to explain the principles and concepts behind Redux. It's _not_ meant to be a production-ready project.
+
+See these pages to learn how to use "modern Redux" with Redux Toolkit:
+
+- [**Redux Fundamentals, Part 8: Modern Redux with Redux Toolkit**](../tutorials/fundamentals/part-8-modern-redux.md), which shows how to convert the low-level examples from earlier sections into modern Redux Toolkit equivalents
+- [**The "Redux Essentials" tutorial**](../tutorials/essentials/part-1-overview-concepts.md), which teaches "how to use Redux, the right way" with Redux Toolkit for real-world apps,
+
+:::

--- a/docs/introduction/why-rtk-is-redux-today.md
+++ b/docs/introduction/why-rtk-is-redux-today.md
@@ -240,7 +240,7 @@ If you are using the `redux` core package by itself, your code will continue to 
 
 See these docs pages and blog posts for more details
 
-- [Redux Essentials: Redux App Structure](../tutorials/essentials/part-2-app-structure.md)
+- [Redux Essentials: Redux Toolkit App Structure](../tutorials/essentials/part-2-app-structure.md)
 - [Redux Fundamentals: Modern Redux with Redux Toolkit](../tutorials/fundamentals/part-8-modern-redux.md)
 - [Redux Style Guide: Best Practices and Recommendations](../style-guide/style-guide.md)
 - [Presentation: Modern Redux with Redux Toolkit](https://blog.isquaredsoftware.com/2022/06/presentations-modern-redux-rtk/)

--- a/docs/introduction/why-rtk-is-redux-today.md
+++ b/docs/introduction/why-rtk-is-redux-today.md
@@ -18,6 +18,16 @@ Whether you're a brand new Redux user setting up your first project, or an exper
 simplify an existing application, **[Redux Toolkit](https://redux-toolkit.js.org/)** can help you
 make your Redux code better.
 
+:::tip
+
+See these pages to learn how to use "modern Redux" with Redux Toolkit:
+
+- [**The "Redux Essentials" tutorial**](../tutorials/essentials/part-1-overview-concepts.md), which teaches "how to use Redux, the right way" with Redux Toolkit for real-world apps,
+- [**Redux Fundamentals, Part 8: Modern Redux with Redux Toolkit**](../tutorials/fundamentals/part-8-modern-redux.md), which shows how to convert the low-level examples from earlier sections of the tutorial into modern Redux Toolkit equivalents
+- [**Using Redux: Migrating to Modern Redux**](../usage/migrating-to-modern-redux.mdx), which covers how to migrate different kinds of legacy Redux logic into modern Redux equivalents
+
+:::
+
 ## How Redux Toolkit Is Different Than the Redux Core
 
 ### What Is "Redux"?

--- a/docs/redux-toolkit/overview.md
+++ b/docs/redux-toolkit/overview.md
@@ -59,7 +59,7 @@ Redux Toolkit includes:
 - [`createEntityAdapter`](https://redux-toolkit.js.org/api/createEntityAdapter): generates a set of reusable reducers and selectors to manage normalized data in the store
 - The [`createSelector` utility](https://redux-toolkit.js.org/api/createSelector) from the [Reselect](https://github.com/reduxjs/reselect) library, re-exported for ease of use.
 
-Redux Toolkit also has a new [**RTK Query data fetching API**](https://redux-toolkit.js.org/rtk-query/overview). RTK Query is a powerful data fetching and caching tool built specifically for Redux. It is designed to simplify common cases for loading data in a web application, eliminating the need to hand-write data fetching & caching logic yourself.
+Redux Toolkit also has the [**RTK Query data fetching API**](https://redux-toolkit.js.org/rtk-query/overview). RTK Query is a powerful data fetching and caching tool built specifically for Redux. It is designed to simplify common cases for loading data in a web application, eliminating the need to hand-write data fetching & caching logic yourself.
 
 ## Documentation
 

--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -459,4 +459,4 @@ Redux does have a number of new terms and concepts to remember. As a reminder, h
 
 ## What's Next?
 
-We've seen each of the individual pieces of a Redux app. Next, continue on to [Part 2: Redux App Structure](./part-2-app-structure.md), where we'll look at a full working example to see how the pieces fit together.
+We've seen each of the individual pieces of a Redux app. Next, continue on to [Part 2: Redux Toolkit App Structure](./part-2-app-structure.md), where we'll look at a full working example to see how the pieces fit together.

--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -1,15 +1,15 @@
 ---
 id: part-2-app-structure
-title: 'Redux Essentials, Part 2: Redux App Structure'
-sidebar_label: 'Redux App Structure'
-description: 'The official Redux Essentials tutorial: learn the structure of a typical React + Redux app'
+title: 'Redux Essentials, Part 2: Redux Toolkit App Structure'
+sidebar_label: 'Redux Toolkit App Structure'
+description: 'The official Redux Essentials tutorial: learn the structure of a typical React + Redux Toolkit app'
 ---
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
 :::tip What You'll Learn
 
-- The structure of a typical React + Redux app
+- The structure of a typical React + Redux Toolkit app
 - How to view state changes in the Redux DevTools Extension
 
 :::

--- a/docs/tutorials/essentials/part-3-data-flow.md
+++ b/docs/tutorials/essentials/part-3-data-flow.md
@@ -23,7 +23,7 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 
 ## Introduction
 
-In [Part 1: Redux Overview and Concepts](./part-1-overview-concepts.md), we looked at how Redux can help us build maintainable apps by giving us a single central place to put global app state. We also talked about core Redux concepts like dispatching action objects, using reducer functions that return new state values, and writing async logic using thunks. In [Part 2: Redux App Structure](./part-2-app-structure.md), we saw how APIs like `configureStore` and `createSlice` from Redux Toolkit and `Provider` and `useSelector` from React-Redux work together to let us write Redux logic and interact with that logic from our React components.
+In [Part 1: Redux Overview and Concepts](./part-1-overview-concepts.md), we looked at how Redux can help us build maintainable apps by giving us a single central place to put global app state. We also talked about core Redux concepts like dispatching action objects, using reducer functions that return new state values, and writing async logic using thunks. In [Part 2: Redux Toolkit App Structure](./part-2-app-structure.md), we saw how APIs like `configureStore` and `createSlice` from Redux Toolkit and `Provider` and `useSelector` from React-Redux work together to let us write Redux logic and interact with that logic from our React components.
 
 Now that you have some idea of what these pieces are, it's time to put that knowledge into practice. We're going to build a small social media feed app, which will include a number of features that demonstrate some real-world use cases. This will help you understand how to use Redux in your own applications.
 

--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -29,6 +29,14 @@ So far, all the data we've worked with has been directly inside of our React cli
 
 In this section, we'll convert our social media app to fetch the posts and users data from an API, and add new posts by saving them to the API.
 
+:::tip
+
+Redux Toolkit includes the [**RTK Query data fetching and caching API**](https://redux-toolkit.js.org/rtk-query/overview). RTK Query is a purpose built data fetching and caching solution for Redux apps, and **can eliminate the need to write _any_ thunks or reducers to manage data fetching**. We specifically teach RTK Query as the default approach for data fetching, and RTK Query is built on the same patterns shown in this page.
+
+We'll cover how to use RTK Query starting in [Part 7: RTK Query Basics](./part-7-rtk-query-basics.md).
+
+:::
+
 ### Example REST API and Client
 
 To keep the example project isolated but realistic, the initial project setup already includes a fake in-memory REST API for our data (configured using [the Mock Service Worker mock API tool](https://mswjs.io/)). The API uses `/fakeApi` as the base URL for the endpoints, and supports the typical `GET/POST/PUT/DELETE` HTTP methods for `/fakeApi/posts`, `/fakeApi/users`, and `fakeApi/notifications`. It's defined in `src/api/server.js`.
@@ -169,14 +177,6 @@ However, writing code using this approach is tedious. Each separate type of requ
 </DetailedExplanation>
 
 <br />
-
-:::tip
-
-Redux Toolkit has a new [**RTK Query data fetching API**](https://redux-toolkit.js.org/rtk-query/overview). RTK Query is a purpose built data fetching and caching solution for Redux apps, and **can eliminate the need to write _any_ thunks or reducers to manage data fetching**. We encourage you to try it out and see if it can help simplify the data fetching code in your own apps!
-
-We'll cover how to use RTK Query starting in [Part 7: RTK Query Basics](./part-7-rtk-query-basics.md).
-
-:::
 
 ## Loading Posts
 

--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -285,7 +285,13 @@ export const PostsList = () => {
 }
 ```
 
-Conceptually, `<PostsList>` is still doing all the same work it was before, but we were able to replace the multiple `useSelector` calls and the `useEffect` dispatch with a single call to `useGetPostsQuery()`.
+Conceptually, `<PostsList>` is still doing all the same work it was before, but **we were able to replace the multiple `useSelector` calls and the `useEffect` dispatch with a single call to `useGetPostsQuery()`**.
+
+:::tip
+
+You should normally use the query hooks to access cached data in components - you _shouldn't_ write your own `useSelector` calls to access fetched data or `useEffect` calls to trigger fetching!
+
+:::
 
 Each generated query hook returns a "result" object containing several fields, including:
 
@@ -445,13 +451,19 @@ We can see that we have a top-level `state.api` slice, as expected from the stor
 
 RTK Query creates a "cache key" for each unique endpoint + argument combination, and stores the results for each cache key separately. That means that **you can use the same query hook multiple times, pass it different query parameters, and each result will be cached separately in the Redux store**.
 
+:::tip
+
+If you need the same data in multiple components, just call the same query hook with the same arguments in each component! For example, you can call `useGetPostQuery('123')` in three different components, and RTK Query will make sure the data is only fetched once, and each component will re-render as needed.
+
+:::
+
 It's also important to note that **the query parameter must be a _single_ value!** If you need to pass through multiple parameters, you must pass an object containing multiple fields (exactly the same as with `createAsyncThunk`). RTK Query will do a "shallow stable" comparison of the fields, and re-fetch the data if any of them have changed.
 
 Notice that the names of the actions in the left-hand list are much more generic and less descriptive: `api/executeQuery/fulfilled`, instead of `posts/fetchPosts/fulfilled`. This is a tradeoff of using an additional abstraction layer. The individual actions do contain the specific endpoint name under `action.meta.arg.endpointName`, but it's not as easily viewable in the action history list.
 
 :::tip
 
-The Redux team is working on a new RTK Query view for the Redux DevTools that will specifically show RTK Query data in a more usable format. This includes info on each endpoint and cache result, stats on query timing, and much more. This will be added to the DevTools Extension in the near future. For a preview, see:
+The Redux DevTools have an "RTK Query" tab that specifically shows RTK Query data in a more usable format. This includes info on each endpoint and cache result, stats on query timing, and much more:
 
 - [Redux DevTools #750: Add RTK Query-Inspector monitor](https://github.com/reduxjs/redux-devtools/pull/750)
 - [RTK Query Monitor preview demo](https://rtk-query-monitor-demo.netlify.app/)

--- a/docs/tutorials/fundamentals/part-1-overview.md
+++ b/docs/tutorials/fundamentals/part-1-overview.md
@@ -26,9 +26,15 @@ Starting in [Part 3: State, Actions, and Reducers](./part-3-state-actions-reduce
 
 ### How to Read This Tutorial
 
-**This tutorial will teach you "how Redux works"**, as well as _why_ these patterns exist. Fair warning though - learning the concepts is different from putting them into practice in actual apps.
+**This tutorial will teach you "how Redux works"**, as well as _why_ these patterns exist.
 
-**The initial code will be less concise than the way we suggest writing real app code**, but writing it out long-hand is the best way to learn. Once you understand how everything fits together, we'll look at using Redux Toolkit to simplify things. **Redux Toolkit is the recommended way to build production apps with Redux**, and is built on all of the concepts that we will look at throughout this tutorial. Once you understand the core concepts covered here, you'll understand how to use Redux Toolkit more efficiently.
+:::tip
+
+Note that **this tutorial intentionally shows older-style patterns that require more code than the "modern Redux" patterns we teach as the right approach for building apps with Redux today**, in order to explain the principles and concepts behind Redux. **The initial code will be less concise than the way we suggest writing real app code**, but writing it out long-hand is the best way to learn.
+
+:::
+
+Once you understand how everything fits together, we'll look at using Redux Toolkit to simplify things. **Redux Toolkit is the recommended way to build production apps with Redux**, and is built on all of the concepts that we will look at throughout this tutorial. Once you understand the core concepts covered here, you'll understand how to use Redux Toolkit more efficiently.
 
 :::info
 

--- a/docs/tutorials/fundamentals/part-1-overview.md
+++ b/docs/tutorials/fundamentals/part-1-overview.md
@@ -7,6 +7,9 @@ description: 'The official Fundamentals tutorial for Redux: learn the fundamenta
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
+<!-- prettier-ignore -->
+import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
+
 # Redux Fundamentals, Part 1: Redux Overview
 
 :::tip What You'll Learn
@@ -28,22 +31,9 @@ Starting in [Part 3: State, Actions, and Reducers](./part-3-state-actions-reduce
 
 **This tutorial will teach you "how Redux works"**, as well as _why_ these patterns exist.
 
-:::tip
-
-Note that **this tutorial intentionally shows older-style patterns that require more code than the "modern Redux" patterns we teach as the right approach for building apps with Redux today**, in order to explain the principles and concepts behind Redux. **The initial code will be less concise than the way we suggest writing real app code**, but writing it out long-hand is the best way to learn.
-
-:::
+<FundamentalsWarning />
 
 Once you understand how everything fits together, we'll look at using Redux Toolkit to simplify things. **Redux Toolkit is the recommended way to build production apps with Redux**, and is built on all of the concepts that we will look at throughout this tutorial. Once you understand the core concepts covered here, you'll understand how to use Redux Toolkit more efficiently.
-
-:::info
-
-If you're looking to learn more about how Redux is used to write real-world applications, please see:
-
-- [**The "Modern Redux" page in this tutorial**](./part-8-modern-redux.md), which shows how to convert the low-level examples from earlier sections into the modern patterns we do recommend for real-world usage
-- [**The "Redux Essentials" tutorial**](../essentials/part-1-overview-concepts.md), which teaches "how to use Redux, the right way" for real-world apps, using our latest recommended patterns and practices.
-
-:::
 
 We've tried to keep these explanations beginner-friendly, but we do need to make some assumptions about what you know already so that we can focus on explaining Redux itself. **This tutorial assumes that you know**:
 

--- a/docs/tutorials/fundamentals/part-2-concepts-data-flow.md
+++ b/docs/tutorials/fundamentals/part-2-concepts-data-flow.md
@@ -7,6 +7,9 @@ description: 'The official Redux Fundamentals tutorial: learn key Redux terms an
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
+<!-- prettier-ignore -->
+import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
+
 # Redux Fundamentals, Part 2: Concepts and Data Flow
 
 :::tip What You'll Learn
@@ -22,6 +25,8 @@ In [Part 1: Redux Overview](./part-1-overview.md), we talked about what Redux is
 
 In this section, we'll look at those terms and concepts in more detail, and talk more about how data flows
 through a Redux application.
+
+<FundamentalsWarning />
 
 ## Background Concepts
 

--- a/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
+++ b/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
@@ -7,6 +7,9 @@ description: 'The official Redux Fundamentals tutorial: learn how reducers updat
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
+<!-- prettier-ignore -->
+import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
+
 # Redux Fundamentals, Part 3: State, Actions, and Reducers
 
 :::tip What You'll Learn
@@ -29,11 +32,7 @@ In [Part 2: Redux Concepts and Data Flow](./part-2-concepts-data-flow.md), we lo
 
 Now that you have some idea of what these pieces are, it's time to put that knowledge into practice. We're going to build a small example app to see how these pieces actually work together.
 
-:::caution
-
-**The example app is not meant as a complete production-ready project**. The goal is to help you learn core Redux APIs and usage patterns, and point you in the right direction using some limited examples. Also, some of the early pieces we build will be updated later on to show better ways to do things. **Please read through the whole tutorial to see all the concepts in use**.
-
-:::
+<FundamentalsWarning />
 
 ### Project Setup
 

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -7,6 +7,9 @@ description: 'The official Redux Fundamentals tutorial: learn how to create and 
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
+<!-- prettier-ignore -->
+import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
+
 # Redux Fundamentals, Part 4: Store
 
 :::tip What You'll Learn
@@ -26,6 +29,8 @@ to describe "what happened" and match the kinds of events that can happen as a u
 to create a "root reducer" based on the different "slice reducers" for each feature in our app.
 
 Now, it's time to pull those pieces together, with the central piece of a Redux app: the **store**.
+
+<FundamentalsWarning />
 
 ## Redux Store
 

--- a/docs/tutorials/fundamentals/part-5-ui-and-react.md
+++ b/docs/tutorials/fundamentals/part-5-ui-and-react.md
@@ -24,11 +24,11 @@ In this section, we'll add a User Interface for our todo app. We'll see how Redu
 
 :::caution
 
-Note that **this page and all of the "Essentials" tutorial teach using [our modern React-Redux hooks API](https://react-redux.js.org/api/hooks)**. The old-style [`connect` API](https://react-redux.js.org/api/connect) still works, but today we want all Redux users using the hooks API.
+Note that **this page and all of the "Essentials" tutorial teach how to use [our modern React-Redux hooks API](https://react-redux.js.org/api/hooks)**. The old-style [`connect` API](https://react-redux.js.org/api/connect) still works, but today we want all Redux users using the hooks API.
 
 Also, the other pages in this tutorial intentionally show older-style Redux logic patterns that require more code than the "modern Redux" patterns with Redux Toolkit we teach as the right approach for building apps with Redux today, in order to explain the principles and concepts behind Redux.
 
-See [**the "Redux Essentials" tutorial**](../tutorials/essentials/part-1-overview-concepts.md) for full examples of "how to use Redux, the right way" with Redux Toolkit and React-Redux hooks for real-world apps.
+See [**the "Redux Essentials" tutorial**](../essentials/part-1-overview-concepts.md) for full examples of "how to use Redux, the right way" with Redux Toolkit and React-Redux hooks for real-world apps.
 
 :::
 

--- a/docs/tutorials/fundamentals/part-5-ui-and-react.md
+++ b/docs/tutorials/fundamentals/part-5-ui-and-react.md
@@ -22,6 +22,16 @@ In [Part 4: Store](./part-4-store.md), we saw how to create a Redux store, dispa
 
 In this section, we'll add a User Interface for our todo app. We'll see how Redux works with a UI layer overall, and we'll specifically cover how Redux works together with React.
 
+:::caution
+
+Note that **this page and all of the "Essentials" tutorial teach using [our modern React-Redux hooks API](https://react-redux.js.org/api/hooks)**. The old-style [`connect` API](https://react-redux.js.org/api/connect) still works, but today we want all Redux users using the hooks API.
+
+Also, the other pages in this tutorial intentionally show older-style Redux logic patterns that require more code than the "modern Redux" patterns with Redux Toolkit we teach as the right approach for building apps with Redux today, in order to explain the principles and concepts behind Redux.
+
+See [**the "Redux Essentials" tutorial**](../tutorials/essentials/part-1-overview-concepts.md) for full examples of "how to use Redux, the right way" with Redux Toolkit and React-Redux hooks for real-world apps.
+
+:::
+
 ## Integrating Redux with a UI
 
 Redux is a standalone JS library. As we've already seen, you can create and use a Redux store even if you don't have a user interface set up. This also means that **you can use Redux with any UI framework** (or even without _any_ UI framework), and use it on both client and server. You can write Redux apps with React, Vue, Angular, Ember, jQuery, or vanilla JavaScript.

--- a/docs/tutorials/fundamentals/part-6-async-logic.md
+++ b/docs/tutorials/fundamentals/part-6-async-logic.md
@@ -5,6 +5,9 @@ sidebar_label: 'Async Logic and Data Fetching'
 description: 'The official Redux Fundamentals tutorial: learn how to use async logic with Redux'
 ---
 
+<!-- prettier-ignore -->
+import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
+
 # Redux Fundamentals, Part 6: Async Logic and Data Fetching
 
 :::tip What You'll Learn
@@ -29,6 +32,8 @@ In [Part 5: UI and React](./part-5-ui-and-react.md), we saw how to use the React
 So far, all the data we've worked with has been directly inside of our React+Redux client application. However, most real applications need to work with data from a server, by making HTTP API calls to fetch and save items.
 
 In this section, we'll update our todo app to fetch the todos from an API, and add new todos by saving them to the API.
+
+<FundamentalsWarning />
 
 ### Example REST API and Client
 

--- a/docs/tutorials/fundamentals/part-6-async-logic.md
+++ b/docs/tutorials/fundamentals/part-6-async-logic.md
@@ -35,6 +35,14 @@ In this section, we'll update our todo app to fetch the todos from an API, and a
 
 <FundamentalsWarning />
 
+:::tip
+
+Redux Toolkit includes the [**RTK Query data fetching and caching API**](https://redux-toolkit.js.org/rtk-query/overview). RTK Query is a purpose built data fetching and caching solution for Redux apps, and **can eliminate the need to write _any_ thunks or reducers to manage data fetching**. We specifically teach RTK Query as the default approach for data fetching, and RTK Query is built on the same patterns shown in this page.
+
+Learn how to use RTK Query for data fetching in [Redux Essentials, Part 7: RTK Query Basics](../essentials/part-7-rtk-query-basics.md).
+
+:::
+
 ### Example REST API and Client
 
 To keep the example project isolated but realistic, the initial project setup already included a fake in-memory REST API for our data (configured using [the Mirage.js mock API tool](https://miragejs.com/)). The API uses `/fakeApi` as the base URL for the endpoints, and supports the typical `GET/POST/PUT/DELETE` HTTP methods for `/fakeApi/todos`. It's defined in `src/api/server.js`.

--- a/docs/tutorials/fundamentals/part-7-standard-patterns.md
+++ b/docs/tutorials/fundamentals/part-7-standard-patterns.md
@@ -7,6 +7,9 @@ description: 'The official Fundamentals tutorial for Redux: learn the standard p
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
+<!-- prettier-ignore -->
+import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
+
 # Redux Fundamentals, Part 7: Standard Redux Patterns
 
 :::tip What You'll Learn
@@ -33,6 +36,8 @@ So far, we've covered the basics of how Redux actually works. However, real worl
 It's important to note that **none of these patterns are _required_ to use Redux!** But, there are very good reasons why each of these patterns exists, and you'll see some or all of them in almost every Redux codebase.
 
 In this section, we'll rework our existing todo app code to use some of these patterns, and talk about why they're commonly used in Redux apps. Then, in [**Part 8**](./part-8-modern-redux.md), we'll talk about "modern Redux", including **how to use our official [Redux Toolkit](https://redux-toolkit.js.org) package to simplify all the Redux logic we've written "by hand"** in our app, and why **we recommend using Redux Toolkit as the standard approach for writing Redux apps**.
+
+<FundamentalsWarning />
 
 ## Action Creators
 

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -28,7 +28,7 @@ Welcome to the Redux Toolkit Quick Start tutorial! **This tutorial will briefly 
 
 This page will focus on just how to set up a Redux application with Redux Toolkit and the main APIs you'll use. For explanations of what Redux is, how it works, and full examples of how to use Redux Toolkit, [see the tutorials linked in the "Tutorials Index" page](./tutorials-index.md).
 
-For this tutorial, we assume that you're using Redux Toolkit with React, but you can also use it with other UI layers as well. The examples are based on [a typical Create-React-App folder structure](https://create-react-app.dev/docs/folder-structure) where all the application code is in a `src`, but the patterns can be adapted to whatever project or folder setup you're using.
+For this tutorial, we assume that you're using Redux Toolkit with React, but you can also use it with other UI layers as well. The examples are based on [a typical Create-React-App folder structure](https://create-react-app.dev/docs/folder-structure) where all the application code is in a `src` folder, but the patterns can be adapted to whatever project or folder setup you're using.
 
 The [Redux+JS template for Create-React-App](https://github.com/reduxjs/cra-template-redux) comes with this same project setup already configured.
 
@@ -213,4 +213,6 @@ Here's the complete counter application as a running CodeSandbox:
 
 ## What's Next?
 
-We recommend going through [**the "Redux Essentials" and "Redux Fundamentals" tutorials in the Redux core docs**](./tutorials-index.md), which will give you a complete understanding of how Redux works, what Redux Toolkit does, and how to use it correctly.
+We recommend going through [**the full "Redux Essentials" tutorial**](./essentials/part-1-overview-concepts.md), which covers all of the key pieces included in Redux Toolkit, what problems they solve, and how to use them to build real-world applications.
+
+You may also want to read through [the "Redux Fundamentals" tutorial](./fundamentals/part-1-overview.md), which will give you a complete understanding of how Redux works, what Redux Toolkit does, and how to use it correctly.

--- a/docs/tutorials/tutorials-index.md
+++ b/docs/tutorials/tutorials-index.md
@@ -17,12 +17,12 @@ The [**Quick Start** page](./quick-start.md) briefly shows the basics of setting
 
 We have two different full-size tutorials:
 
-- The [**Redux Essentials tutorial**](./essentials/part-1-overview-concepts) is a "top-down" tutorial that teaches "how to use Redux the right way", using our latest recommended APIs and best practices.
+- The [**Redux Essentials tutorial**](./essentials/part-1-overview-concepts) is a "top-down" tutorial that teaches "how to use Redux the right way", using our latest recommended APIs and best practices (Redux Toolkit for the logic, React-Redux hooks for the UI, and "RTK Query" for fetching and caching data).
 - The [**Redux Fundamentals tutorial**](./fundamentals/part-1-overview.md) is a "bottom-up" tutorial that teaches "how Redux works" from first principles and without any abstractions, and why standard Redux usage patterns exist.
 
 :::tip
 
-**We recommend starting with the [Redux Essentials tutorial](./essentials/part-1-overview-concepts)**, since it covers the key points you need to know about how to get started using Redux to write actual applications.
+**We recommend starting with the [Redux Essentials tutorial](./essentials/part-1-overview-concepts)**, since it covers the key points you need to know about how to get started using our modern Redux Toolkit package to write actual applications.
 
 :::
 

--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -22,15 +22,13 @@ sidebar_label: TypeScript Quick Start
 
 ## Introduction
 
-Welcome to the Redux Toolkit TypeScript Quick Start tutorial! **This tutorial will briefly show how to use TypeScript with Redux Toolkit**.
+Welcome to the Redux Toolkit TypeScript Quick Start tutorial! **This tutorial will briefly show how to use TypeScript with Redux Toolkit and React-Redux**.
 
 This page focuses on just how to set up the TypeScript aspects . For explanations of what Redux is, how it works, and full examples of how to use Redux Toolkit, [see the tutorials linked in the "Tutorials Index" page](./tutorials-index.md).
 
 Redux Toolkit is already written in TypeScript, so its TS type definitions are built in.
 
-[React Redux](https://react-redux.js.org) has its type definitions in a separate [`@types/react-redux` typedefs package](https://npm.im/@types/react-redux) on NPM. In addition to typing the library functions, the types also export some helpers to make it easier to write typesafe interfaces between your Redux store and your React components.
-
-As of React Redux v7.2.3, the `react-redux` package has a dependency on `@types/react-redux`, so the type definitions will be automatically installed with the library. Otherwise, you'll need to manually install them yourself (typically `npm install @types/react-redux` ).
+[React Redux](https://react-redux.js.org) is also written in TypeScript as of version 8, and also includes its own type definitions.
 
 The [Redux+TS template for Create-React-App](https://github.com/reduxjs/cra-template-redux-typescript) comes with a working example of these patterns already configured.
 
@@ -184,4 +182,8 @@ Here's the complete TS counter application as a running CodeSandbox:
 
 ## What's Next?
 
-See [the "Usage with TypeScript" page](../usage/UsageWithTypescript.md) for extended details on how to use Redux Toolkit's APIs with TypeScript.
+We recommend going through [**the full "Redux Essentials" tutorial**](./essentials/part-1-overview-concepts.md), which covers all of the key pieces included in Redux Toolkit, what problems they solve, and how to use them to build real-world applications.
+
+You may also want to read through [the "Redux Fundamentals" tutorial](./fundamentals/part-1-overview.md), which will give you a complete understanding of how Redux works, what Redux Toolkit does, and how to use it correctly.
+
+Finally, see [the "Usage with TypeScript" page](../usage/UsageWithTypescript.md) for extended details on how to use Redux Toolkit's APIs with TypeScript.

--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -29,7 +29,7 @@ This page covers the general approaches and techniques you can use to modernize 
 For more details on how "modern Redux" with Redux Toolkit + React-Redux hooks simplifies using Redux, see these additional resources:
 
 - [Why Redux Toolkit is How to use Redux Today](../introduction/why-rtk-is-redux-today.md)
-- [Redux Essentials: Redux App Structure](../tutorials/essentials/part-2-app-structure.md)
+- [Redux Essentials: Redux Toolkit App Structure](../tutorials/essentials/part-2-app-structure.md)
 - [Redux Fundamentals: Modern Redux with Redux Toolkit](../tutorials/fundamentals/part-8-modern-redux.md)
 - [Presentation: Modern Redux with Redux Toolkit](https://blog.isquaredsoftware.com/2022/06/presentations-modern-redux-rtk/)
 
@@ -1148,7 +1148,7 @@ function TodoListItem({ todoId }: TodoListItemProps) {
 See these docs pages and blog posts for more details:
 
 - **Tutorials**
-  - [Redux Essentials: Redux App Structure](../tutorials/essentials/part-2-app-structure.md)
+  - [Redux Essentials: Redux Toolkit App Structure](../tutorials/essentials/part-2-app-structure.md)
   - [Redux Fundamentals: Modern Redux with Redux Toolkit](../tutorials/fundamentals/part-8-modern-redux.md)
   - [Redux TypeScript Quick Start](../tutorials/typescript.md)
 - **Additional Documentation**

--- a/docs/usage/side-effects-approaches.mdx
+++ b/docs/usage/side-effects-approaches.mdx
@@ -49,7 +49,7 @@ Another use case more specific to Redux is writing logic that _responds_ to a di
 
 ## Recommendations
 
-We recommend using the tools that best fit each use case (see below for further details on each tool):
+We recommend using the tools that best fit each use case (see below for the reasons for our recommendations, as well as further details on each tool):
 
 :::tip
 
@@ -70,6 +70,23 @@ We recommend using the tools that best fit each use case (see below for further 
 - **Use thunks for complex sync and moderate async logic**, including access to `getState` and dispatching multiple actions
 
 :::
+
+### Why RTK Query for Data Fetching
+
+Per [the React docs section on "alternatives for data fetching in Effects"](https://beta.reactjs.org/learn/synchronizing-with-effects#what-are-good-alternatives-to-data-fetching-in-effects), you _should_ use either data fetching approaches that are built into a server-side framework, or a client-side cache. **You should _not_ write data fetching and cache management code yourself.**
+
+RTK Query was specifically designed to be a complete data fetching and caching layer for Redux-based applications. It manages all the fetching, caching, and loading status logic for you, and covers many edge cases that are typically forgotten or hard to handle if you write data fetching code yourself, as well as having cache lifecycle management built-in. It also makes it simple to fetch and use data via the auto-generated React hooks.
+
+We specifically recommend _against_ sagas for data fetching because the complexity of sagas is not helpful, and you would still have to write all of the caching + loading status management logic yourself.
+
+### Why Listeners for Reactive Logic
+
+We've intentionally designed the RTK listener middleware to be straightforward to use. It uses standard `async/await` syntax, covers most common reactive use cases (responding to actions or state changes, debouncing, delays), and even several advanced cases (launching child tasks). It has a small bundle size (~3K), is included with Redux Toolkit, and works great with TypeScript.
+
+We specifically recommend _against_ sagas or observables for most reactive logic for multiple reasons:
+
+- Sagas: require understanding ES6 generator function syntax as well as the saga effects behaviors; add multiple levels of indirection due to needing extra actions dispatched; have poor TypeScript support; and the power and complexity is simply not needed for most Redux use cases.
+- Observables: require understanding the RxJS API and mental model; can be difficult to debug; can add significant bundle size
 
 ## Common Side Effects Approaches
 


### PR DESCRIPTION
This PR:

- Adds a "warning" callout to most "Fundamentals" pages clarifying that the page intentionally shows outdated hand-written patterns for the purpose of explanation, and that you should look at the "Essentials" tutorial to learn how to use RTK
  - Exceptions: Part 1 (already has a similar blurb), Part 5 (React-Redux usage is the same), Part 8 (already shows RTK migration)
- Updates both "Quick Start" pages to more clearly state "go to 'Essentials' next"
- Adds a recommendation reasons section with "why RTK Query / listeners, not sagas"

Fixes #4495 .

Example:

- https://deploy-preview-4496--redux-docs.netlify.app/tutorials/fundamentals/part-2-concepts-data-flow

(can't upload a picture due to lousy airplane wifi)

I'm totally open to suggestions for improving the callout text, or choosing a different color (blue for "info"?  red for "caution"?  add CSS to make it blink?)