### PR TITLE
Update side-effects-approaches.mdx

### DIFF
--- a/docs/usage/side-effects-approaches.mdx
+++ b/docs/usage/side-effects-approaches.mdx
@@ -209,7 +209,7 @@ function* fetchResource(resource) {
 
 The [Redux-Observable middleware](https://redux-observable.js.org/) lets you use RxJS observables to create processing pipelines called "epics".
 
-Since RxJS is a framework-agnostic library, observable users point to the fact that you can reuse knowledge of how to use it across different as a major selling point. In addition, RxJS lets you construct declarative pipelines that handle timing cases like cancellation or debouncing.
+Since RxJS is a framework-agnostic library, observable users point to the fact that you can reuse knowledge of how to use it across different platforms as a major selling point. In addition, RxJS lets you construct declarative pipelines that handle timing cases like cancellation or debouncing.
 
 #### Observable Use Cases
 


### PR DESCRIPTION
Fix missing word (grammar)

Was: 

> Since RxJS is a framework-agnostic library, observable users point to the fact that you can reuse knowledge of how to use it **_across different as_** a major selling point.

Propose: 

> Since RxJS is a framework-agnostic library, observable users point to the fact that you can reuse knowledge of how to use it across different platforms as a major selling point.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
