### PR TITLE
docs: fix migrating-to-modern-redux.mdx

### DIFF
--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -481,7 +481,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 export const api = createApi({
   baseQuery: fetchBaseQuery({
     // Fill in your own server starting URL here
-    url: '/'
+    baseUrl: '/'
   }),
   endpoints: build => ({})
 })
@@ -520,7 +520,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 export const api = createApi({
   baseQuery: fetchBaseQuery({
     // Fill in your own server starting URL here
-    url: '/'
+    baseUrl: '/'
   }),
   endpoints: build => ({
     // highlight-start


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Using Redux > Setup and Organization
- **Page**: https://redux.js.org/usage/migrating-to-modern-redux

## What is the problem?

```
Argument of type '{ url: string; }' is not assignable to parameter of type 'FetchBaseQueryArgs'. Object literal may only specify known properties, and 'url' does not exist in type 'FetchBaseQueryArgs'.
```

## What changes does this PR make to fix the problem?

Replace `url` with `baseUrl`
