### PR TITLE
Type action and next as unknown

### DIFF
--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -25,6 +25,6 @@ export interface Middleware<
   D extends Dispatch = Dispatch
 > {
   (api: MiddlewareAPI<D, S>): (
-    next: D
-  ) => (action: unknown) => any
+    next: (action: unknown) => unknown
+  ) => (action: unknown) => unknown
 }

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -20,11 +20,11 @@ export interface MiddlewareAPI<D extends Dispatch = Dispatch, S = any> {
  *   installed.
  */
 export interface Middleware<
-  _DispatchExt = {}, // TODO: remove unused component (breaking change)
+  _DispatchExt = {}, // TODO: see if this can be used in type definition somehow (can't be removed, as is used to get final dispatch type)
   S = any,
   D extends Dispatch = Dispatch
 > {
   (api: MiddlewareAPI<D, S>): (
     next: D
-  ) => (action: D extends Dispatch<infer A> ? A : never) => any
+  ) => (action: unknown) => any
 }

--- a/test/applyMiddleware.spec.ts
+++ b/test/applyMiddleware.spec.ts
@@ -28,10 +28,10 @@ describe('applyMiddleware', () => {
   })
 
   it('wraps dispatch method with middleware once', () => {
-    function test(spyOnMethods: any) {
-      return (methods: any) => {
+    function test(spyOnMethods: any): Middleware {
+      return methods => {
         spyOnMethods(methods)
-        return (next: Dispatch) => (action: Action) => next(action)
+        return next => action => next(action)
       }
     }
 
@@ -53,8 +53,8 @@ describe('applyMiddleware', () => {
   })
 
   it('passes recursive dispatches through the middleware chain', () => {
-    function test(spyOnMethods: any) {
-      return () => (next: Dispatch) => (action: Action) => {
+    function test(spyOnMethods: any): Middleware {
+      return () => next => action => {
         spyOnMethods(action)
         return next(action)
       }
@@ -146,8 +146,7 @@ describe('applyMiddleware', () => {
     }
 
     function dummyMiddleware({ dispatch }: MiddlewareAPI) {
-      return (_next: Dispatch) => (action: Action) =>
-        dispatch(action, testCallArgs)
+      return (_next: unknown) => (action: any) => dispatch(action, testCallArgs)
     }
 
     const store = createStore(

--- a/test/helpers/middleware.ts
+++ b/test/helpers/middleware.ts
@@ -1,13 +1,9 @@
-import { MiddlewareAPI, Dispatch, AnyAction } from 'redux'
+import { Dispatch, Middleware } from 'redux'
 
-type ThunkAction<T extends any = any> = T extends AnyAction
-  ? AnyAction
-  : T extends Function
-  ? T
-  : never
-
-export function thunk({ dispatch, getState }: MiddlewareAPI) {
-  return (next: Dispatch) =>
-    <_>(action: ThunkAction) =>
-      typeof action === 'function' ? action(dispatch, getState) : next(action)
-}
+export const thunk: Middleware<{
+  <R>(thunk: (dispatch: Dispatch, getState: () => any) => R): R
+}> =
+  ({ dispatch, getState }) =>
+  next =>
+  action =>
+    typeof action === 'function' ? action(dispatch, getState) : next(action)

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -15,8 +15,8 @@ import {
  */
 function logger() {
   const loggerMiddleware: Middleware =
-    ({ getState }: MiddlewareAPI) =>
-    (next: Dispatch) =>
+    ({ getState }) =>
+    next =>
     action => {
       console.log('will dispatch', action)
 
@@ -41,9 +41,9 @@ type PromiseDispatch = <T extends Action>(promise: Promise<T>) => Promise<T>
 
 function promise() {
   const promiseMiddleware: Middleware<PromiseDispatch> =
-    ({ dispatch }: MiddlewareAPI) =>
+    ({ dispatch }) =>
     next =>
-    <T extends Action>(action: AnyAction | Promise<T>) => {
+    action => {
       if (action instanceof Promise) {
         action.then(dispatch)
         return action
@@ -72,13 +72,10 @@ function thunk<S, DispatchExt>() {
     ThunkDispatch<S, DispatchExt>,
     S,
     Dispatch & ThunkDispatch<S>
-  > =
-    api =>
-    (next: Dispatch) =>
-    <R>(action: AnyAction | Thunk<R, any>) =>
-      typeof action === 'function'
-        ? action(api.dispatch, api.getState)
-        : next(action)
+  > = api => next => action =>
+    typeof action === 'function'
+      ? action(api.dispatch, api.getState)
+      : next(action)
 
   return thunkMiddleware
 }
@@ -89,14 +86,13 @@ function thunk<S, DispatchExt>() {
 function customState() {
   type State = { field: 'string' }
 
-  const customMiddleware: Middleware<{}, State> =
-    api => (next: Dispatch) => action => {
-      api.getState().field
-      // @ts-expect-error
-      api.getState().wrongField
+  const customMiddleware: Middleware<{}, State> = api => next => action => {
+    api.getState().field
+    // @ts-expect-error
+    api.getState().wrongField
 
-      return next(action)
-    }
+    return next(action)
+  }
 
   return customMiddleware
 }


### PR DESCRIPTION
---
name: :bug: Bug fix or new feature
about: Fixing a problem with Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
It makes types safer for middleware.

### Why should this PR be included?
Currently, the `next` parameter is typed as the `D` type parameter passed, and `action` is typed as the`Action` extracted from the dispatch type. Neither of these are a safe assumption:

- `next` would be typed to have **all** of the dispatch extensions, including the ones earlier in the chain that would no longer apply.
  - Technically it would be *mostly* safe to type `next` as the default Dispatch implemented by the base redux store, however this would cause `next(action)` to error (as we cannot promise `action` is actually an `Action`) - and it wouldn't account for any following middlewares that return anything other than the action they're given when they see a specific action.
- `action` is not necessarily a known action, it can be literally anything - for example a thunk would be a function with no .type property (so `AnyAction` would be inaccurate)

This PR changes `next` to be `(action: unknown) => unknown` (which is accurate, we have no idea what `next` expects or will return), and changes the `action` parameter to be `unknown` (which as above, is accurate)

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - fixes #4518
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR? (TODO)
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
As stated above, the types used for `next` and `action` are inaccurate at best, and dangerous at worst.

### What is the expected behavior?
Middleware should be forced to check what the action is, before using it.

### How does this PR fix the problem?
Types `next` and `action` in a way that would force the middleware to type check before using them (`return next(action)` still works without issue)

**Note: this is a breaking change for middleware typed to expect a certain action or dispatch for next. For example:** 
```ts
// @ts-expect-error wrong next
const customMiddleware: Middleware = (api) => (next: Dispatch) => (action) => next(action);

// @ts-expect-error wrong action
const promiseMiddleware: Middleware<{
  (promise: Promise<any>): Promise<void>
}> = (api) => (next) => (action: Promise) => {
  if (action instanceof Promise) {
    return promise.then(console.log);
  }
  return next(action);
}
```
However, I would argue this is a good change - as explained above, this is inherently a lie to the compiler, and is thus unsafe.

Similar to [caught errors](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables), any middleware that (unsafely) wishes to opt out and treat `action` as `any` can still do so:
```ts
const customMiddleware: Middleware = (api) => (next) => (action: any) => next(action);
```