### PR TITLE
Encourage use of Action or UnknownAction instead of AnyAction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ coverage
 dist
 lib
 es
-types
 
 # Yarn
 .cache

--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -202,9 +202,9 @@ axiosInstance.interceptors.request.use(config => {
 Then, in your entry point file, inject the store into the API setup file:
 
 ```js title="index.js"
-import store from "./app/store".
-import {injectStore} from "./common/api";
-injectStore(store);
+import store from "./app/store"
+import {injectStore} from "./common/api"
+injectStore(store)
 ```
 
 This way, the application setup is the only code that has to import the store, and the file dependency graph avoids circular dependencies.

--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -207,10 +207,10 @@ You could add this to your ESLint config as an example:
 
 [Reducers](../tutorials/fundamentals/part-3-state-actions-reducers.md) are pure functions that receive the current `state` and incoming `action` as arguments, and return a new state.
 
-If you are using Redux Toolkit's `createSlice`, you should rarely need to specifically type a reducer separately. If you do actually write a standalone reducer, it's typically sufficient to declare the type of the `initialState` value, and type the `action` as `AnyAction`:
+If you are using Redux Toolkit's `createSlice`, you should rarely need to specifically type a reducer separately. If you do actually write a standalone reducer, it's typically sufficient to declare the type of the `initialState` value, and type the `action` as `UnknownAction`:
 
 ```ts
-import { AnyAction } from 'redux'
+import { UnknownAction } from 'redux'
 
 interface CounterState {
   value: number
@@ -222,7 +222,7 @@ const initialState: CounterState = {
 
 export default function counterReducer(
   state = initialState,
-  action: AnyAction
+  action: UnknownAction
 ) {
   // logic here
 }
@@ -297,16 +297,16 @@ export type ThunkAction<
 > = (dispatch: ThunkDispatch<S, E, A>, getState: () => S, extraArgument: E) => R
 ```
 
-You will typically want to provide the `R` (return type) and `S` (state) generic arguments. Unfortunately, TS does not allow only providing _some_ generic arguments, so the usual values for the other arguments are `unknown` for `E` and `AnyAction` for `A`:
+You will typically want to provide the `R` (return type) and `S` (state) generic arguments. Unfortunately, TS does not allow only providing _some_ generic arguments, so the usual values for the other arguments are `unknown` for `E` and `UnknownAction` for `A`:
 
 ```ts
-import { AnyAction } from 'redux'
+import { UnknownAction } from 'redux'
 import { sendMessage } from './store/chat/actions'
 import { RootState } from './store'
 import { ThunkAction } from 'redux-thunk'
 
 export const thunkSendMessage =
-  (message: string): ThunkAction<void, RootState, unknown, AnyAction> =>
+  (message: string): ThunkAction<void, RootState, unknown, UnknownAction> =>
   async dispatch => {
     const asyncResp = await exampleAPI()
     dispatch(
@@ -330,7 +330,7 @@ export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
   RootState,
   unknown,
-  AnyAction
+  UnknownAction
 >
 ```
 

--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -846,7 +846,7 @@ const store = configureStore({
 // Inferred state type: {todos: TodosState, counter: CounterState}
 export type RootState = ReturnType<typeof store.getState>
 
-// Inferred dispatch type: Dispatch & ThunkDispatch<RootState, undefined, AnyAction>
+// Inferred dispatch type: Dispatch & ThunkDispatch<RootState, undefined, UnknownAction>
 export type AppDispatch = typeof store.dispatch
 // highlight-end
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "Predictable state container for JavaScript apps",
   "license": "MIT",
   "homepage": "http://redux.js.org",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "test:watch": "vitest",
     "test:cov": "vitest --coverage",
     "build": "rollup -c",
-    "prepublishOnly": "yarn clean && yarn check-types && yarn format:check && yarn lint && yarn test && yarn build",
+    "prepublishOnly": "yarn clean && yarn check-types && yarn format:check && yarn lint && yarn test",
+    "prepack": "yarn build",
     "examples:lint": "eslint --ext js,ts examples",
     "examples:test": "cross-env CI=true babel-node examples/testAll.js",
     "tsc": "tsc"

--- a/src/bindActionCreators.ts
+++ b/src/bindActionCreators.ts
@@ -1,12 +1,8 @@
 import { Dispatch } from './types/store'
-import {
-  AnyAction,
-  ActionCreator,
-  ActionCreatorsMapObject
-} from './types/actions'
+import { ActionCreator, ActionCreatorsMapObject, Action } from './types/actions'
 import { kindOf } from './utils/kindOf'
 
-function bindActionCreator<A extends AnyAction = AnyAction>(
+function bindActionCreator<A extends Action>(
   actionCreator: ActionCreator<A>,
   dispatch: Dispatch
 ) {

--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -1,4 +1,4 @@
-import { AnyAction, Action } from './types/actions'
+import { Action } from './types/actions'
 import {
   ActionFromReducersMapObject,
   PreloadedStateShapeFromReducersMapObject,
@@ -156,7 +156,7 @@ export default function combineReducers(reducers: {
 
   return function combination(
     state: StateFromReducersMapObject<typeof reducers> = {},
-    action: AnyAction
+    action: Action
   ) {
     if (shapeAssertionError) {
       throw shapeAssertionError

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -2,7 +2,6 @@ import $$observable from './utils/symbol-observable'
 
 import {
   Store,
-  PreloadedState,
   StoreEnhancer,
   Dispatch,
   Observer,
@@ -77,20 +76,22 @@ export function createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
-  reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S>,
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext
 export function createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
-  reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | StoreEnhancer<Ext, StateExt> | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext {
   if (typeof reducer !== 'function') {
@@ -128,12 +129,14 @@ export function createStore<
 
     return enhancer(createStore)(
       reducer,
-      preloadedState as PreloadedState<S>
-    ) as Store<S, A, StateExt> & Ext
+      preloadedState as PreloadedState | undefined
+    )
   }
 
   let currentReducer = reducer
-  let currentState = preloadedState as S
+  let currentState: S | PreloadedState | undefined = preloadedState as
+    | PreloadedState
+    | undefined
   let currentListeners: Map<number, ListenerCallback> | null = new Map()
   let nextListeners = currentListeners
   let listenerIdCounter = 0
@@ -315,7 +318,7 @@ export function createStore<
       )
     }
 
-    currentReducer = nextReducer
+    currentReducer = nextReducer as unknown as Reducer<S, A, PreloadedState>
 
     // This action has a similar effect to ActionTypes.INIT.
     // Any reducers that existed in both the new and old rootReducer
@@ -456,20 +459,22 @@ export function legacy_createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
-  reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S>,
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext
 export function legacy_createStore<
   S,
   A extends Action,
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends {} = {},
+  PreloadedState = S
 >(
   reducer: Reducer<S, A>,
-  preloadedState?: PreloadedState<S> | StoreEnhancer<Ext, StateExt>,
+  preloadedState?: PreloadedState | StoreEnhancer<Ext, StateExt> | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
 ): Store<S, A, StateExt> & Ext {
   return createStore(reducer, preloadedState as any, enhancer)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export { ActionCreator, ActionCreatorsMapObject } from './types/actions'
 // middleware
 export { MiddlewareAPI, Middleware } from './types/middleware'
 // actions
-export { Action, AnyAction } from './types/actions'
+export { Action, UnknownAction, AnyAction } from './types/actions'
 
 export {
   createStore,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,6 @@ import __DO_NOT_USE__ActionTypes from './utils/actionTypes'
 // types
 // store
 export {
-  CombinedState,
-  PreloadedState,
   Dispatch,
   Unsubscribe,
   Observable,
@@ -23,11 +21,12 @@ export {
 // reducers
 export {
   Reducer,
-  ReducerFromReducersMapObject,
   ReducersMapObject,
   StateFromReducersMapObject,
+  ReducerFromReducersMapObject,
   ActionFromReducer,
-  ActionFromReducersMapObject
+  ActionFromReducersMapObject,
+  PreloadedStateShapeFromReducersMapObject
 } from './types/reducers'
 // action creators
 export { ActionCreator, ActionCreatorsMapObject } from './types/actions'

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -15,7 +15,7 @@
  *
  * @template T the type of the action's `type` tag.
  */
-export interface Action<T = any> {
+export interface Action<T = unknown> {
   type: T
 }
 
@@ -24,6 +24,18 @@ export interface Action<T = any> {
  * This is mainly for the use of the `Reducer` type.
  * This is not part of `Action` itself to prevent types that extend `Action` from
  * having an index signature.
+ */
+export interface UnknownAction extends Action {
+  // Allows any extra properties to be defined in an action.
+  [extraProps: string]: unknown
+}
+
+/**
+ * An Action type which accepts any other properties.
+ * This is mainly for the use of the `Reducer` type.
+ * This is not part of `Action` itself to prevent types that extend `Action` from
+ * having an index signature.
+ * @deprecated use Action or UnknownAction instead
  */
 export interface AnyAction extends Action {
   // Allows any extra properties to be defined in an action.

--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -1,4 +1,4 @@
-import { Action, AnyAction } from './actions'
+import { Action, UnknownAction } from './actions'
 
 /* reducers */
 
@@ -29,7 +29,7 @@ import { Action, AnyAction } from './actions'
  */
 export type Reducer<
   S = any,
-  A extends Action = AnyAction,
+  A extends Action = UnknownAction,
   PreloadedState = S
 > = (state: S | PreloadedState | undefined, action: A) => S
 
@@ -42,7 +42,7 @@ export type Reducer<
  */
 export type ReducersMapObject<
   S = any,
-  A extends Action = AnyAction,
+  A extends Action = UnknownAction,
   PreloadedState = S
 > = keyof PreloadedState extends keyof S
   ? {
@@ -63,7 +63,7 @@ export type StateFromReducersMapObject<M> = M[keyof M] extends
   | Reducer<any, any, any>
   | undefined
   ? {
-      [P in keyof M]: M[P] extends Reducer<infer S> ? S : never
+      [P in keyof M]: M[P] extends Reducer<infer S, any, any> ? S : never
     }
   : never
 
@@ -109,7 +109,7 @@ export type PreloadedStateShapeFromReducersMapObject<M> = M[keyof M] extends
   ? {
       [P in keyof M]: M[P] extends (
         inputState: infer InputState,
-        action: AnyAction
+        action: UnknownAction
       ) => any
         ? InputState
         : never

--- a/test/applyMiddleware.spec.ts
+++ b/test/applyMiddleware.spec.ts
@@ -3,7 +3,6 @@ import {
   applyMiddleware,
   Middleware,
   MiddlewareAPI,
-  AnyAction,
   Action,
   Store,
   Dispatch
@@ -128,7 +127,7 @@ describe('applyMiddleware', () => {
     const spy = vi.fn()
     const testCallArgs = ['test']
 
-    interface MultiDispatch<A extends Action = AnyAction> {
+    interface MultiDispatch<A extends Action = Action> {
       <T extends A>(action: T, extraArg?: string[]): T
     }
 

--- a/test/combineReducers.spec.ts
+++ b/test/combineReducers.spec.ts
@@ -4,7 +4,6 @@ import {
   combineReducers,
   Reducer,
   Action,
-  AnyAction,
   __DO_NOT_USE__ActionTypes as ActionTypes
 } from 'redux'
 import { vi } from 'vitest'
@@ -88,7 +87,7 @@ describe('Utils', () => {
       expect(() => reducer({ counter: 0 }, null)).toThrow(
         /"counter".*an action/
       )
-      expect(() => reducer({ counter: 0 }, {} as unknown as AnyAction)).toThrow(
+      expect(() => reducer({ counter: 0 }, {} as unknown as Action)).toThrow(
         /"counter".*an action/
       )
     })
@@ -117,9 +116,9 @@ describe('Utils', () => {
           throw new Error('Error thrown in reducer')
         }
       })
-      expect(() =>
-        reducer(undefined, undefined as unknown as AnyAction)
-      ).toThrow(/Error thrown in reducer/)
+      expect(() => reducer(undefined, undefined as unknown as Action)).toThrow(
+        /Error thrown in reducer/
+      )
     })
 
     it('allows a symbol to be used as an action type', () => {
@@ -185,7 +184,7 @@ describe('Utils', () => {
 
     it('throws an error on first call if a reducer attempts to handle a private action', () => {
       const reducer = combineReducers({
-        counter(state: number, action: Action<unknown>) {
+        counter(state: number, action: Action) {
           switch (action.type) {
             case 'increment':
               return state + 1
@@ -199,9 +198,9 @@ describe('Utils', () => {
           }
         }
       })
-      expect(() =>
-        reducer(undefined, undefined as unknown as AnyAction)
-      ).toThrow(/"counter".*private/)
+      expect(() => reducer(undefined, undefined as unknown as Action)).toThrow(
+        /"counter".*private/
+      )
     })
 
     it('warns if no reducers are passed to combineReducers', () => {
@@ -223,7 +222,7 @@ describe('Utils', () => {
     it('warns if input state does not match reducer shape', () => {
       const preSpy = console.error
       const spy = vi.fn()
-      const nullAction = undefined as unknown as AnyAction
+      const nullAction = undefined as unknown as Action
       console.error = spy
 
       interface ShapeState {

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -66,6 +66,7 @@ describe('createStore', () => {
     const store = createStore(reducers.todos)
     expect(store.getState()).toEqual([])
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(store.getState()).toEqual([])
 
@@ -104,6 +105,7 @@ describe('createStore', () => {
       }
     ])
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(store.getState()).toEqual([
       {
@@ -211,10 +213,12 @@ describe('createStore', () => {
     const listenerB = vi.fn()
 
     let unsubscribeA = store.subscribe(listenerA)
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(1)
     expect(listenerB.mock.calls.length).toBe(0)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(2)
     expect(listenerB.mock.calls.length).toBe(0)
@@ -223,6 +227,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(2)
     expect(listenerB.mock.calls.length).toBe(0)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(1)
@@ -231,6 +236,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(1)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
@@ -239,6 +245,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
@@ -247,6 +254,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(4)
     expect(listenerB.mock.calls.length).toBe(2)
@@ -263,6 +271,7 @@ describe('createStore', () => {
     unsubscribeA()
     unsubscribeA()
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listenerA.mock.calls.length).toBe(0)
     expect(listenerB.mock.calls.length).toBe(1)
@@ -278,6 +287,7 @@ describe('createStore', () => {
     unsubscribeSecond()
     unsubscribeSecond()
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener.mock.calls.length).toBe(1)
   })
@@ -295,7 +305,9 @@ describe('createStore', () => {
     })
     store.subscribe(listenerC)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
+    // @ts-expect-error
     store.dispatch(unknownAction())
 
     expect(listenerA.mock.calls.length).toBe(2)
@@ -323,11 +335,13 @@ describe('createStore', () => {
     )
     unsubscribeHandles.push(store.subscribe(() => listener3()))
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(1)
     expect(listener3.mock.calls.length).toBe(1)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(1)
@@ -355,11 +369,13 @@ describe('createStore', () => {
       maybeAddThirdListener()
     })
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(1)
     expect(listener3.mock.calls.length).toBe(0)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(2)
     expect(listener2.mock.calls.length).toBe(2)
@@ -384,6 +400,7 @@ describe('createStore', () => {
 
       unsubscribe1()
       unsubscribe4 = store.subscribe(listener4)
+      // @ts-expect-error
       store.dispatch(unknownAction())
 
       expect(listener1.mock.calls.length).toBe(1)
@@ -394,6 +411,7 @@ describe('createStore', () => {
     store.subscribe(listener2)
     store.subscribe(listener3)
 
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(2)
@@ -401,6 +419,7 @@ describe('createStore', () => {
     expect(listener4.mock.calls.length).toBe(1)
 
     unsubscribe4()
+    // @ts-expect-error
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(3)
@@ -447,6 +466,7 @@ describe('createStore', () => {
 
   it('only accepts plain object actions', () => {
     const store = createStore(reducers.todos)
+    // @ts-expect-error
     expect(() => store.dispatch(unknownAction())).not.toThrow()
 
     function AwesomeMap() {}
@@ -486,6 +506,7 @@ describe('createStore', () => {
 
     expect(() =>
       store.dispatch(
+        // @ts-expect-error
         dispatchInMiddle(store.dispatch.bind(store, unknownAction()))
       )
     ).toThrow(/may not dispatch/)
@@ -528,6 +549,7 @@ describe('createStore', () => {
     const store = createStore(reducers.errorThrowingReducer)
     expect(() => store.dispatch(throwError())).toThrow()
 
+    // @ts-expect-error
     expect(() => store.dispatch(unknownAction())).not.toThrow()
   })
 
@@ -567,6 +589,7 @@ describe('createStore', () => {
 
   it('throws if action type is undefined', () => {
     const store = createStore(reducers.todos)
+    // @ts-expect-error
     expect(() => store.dispatch({ type: undefined })).toThrow(
       /Actions may not have an undefined "type" property/
     )
@@ -574,9 +597,13 @@ describe('createStore', () => {
 
   it('does not throw if action type is falsy', () => {
     const store = createStore(reducers.todos)
+    // @ts-expect-error
     expect(() => store.dispatch({ type: false })).not.toThrow()
+    // @ts-expect-error
     expect(() => store.dispatch({ type: 0 })).not.toThrow()
+    // @ts-expect-error
     expect(() => store.dispatch({ type: null })).not.toThrow()
+    // @ts-expect-error
     expect(() => store.dispatch({ type: '' })).not.toThrow()
   })
 
@@ -655,12 +682,14 @@ describe('createStore', () => {
 
     expect(() => createStore(reducers.todos, undefined, x => x)).not.toThrow()
 
-    expect(() => createStore(reducers.todos, x => x)).not.toThrow()
+    expect(() =>
+      createStore<any, reducers.TodoAction, {}, {}>(reducers.todos, x => x)
+    ).not.toThrow()
 
     expect(() => createStore(reducers.todos, [])).not.toThrow()
 
     expect(() =>
-      createStore<any, Action, {}, {}>(reducers.todos, {})
+      createStore<any, reducers.TodoAction, {}, {}>(reducers.todos, {})
     ).not.toThrow()
   })
 
@@ -863,6 +892,7 @@ describe('createStore', () => {
     )
 
     store.replaceReducer(
+      // @ts-expect-error
       combineReducers({
         y: combineReducers({
           z: reducer

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -3,7 +3,8 @@ import {
   combineReducers,
   StoreEnhancer,
   Action,
-  Store
+  Store,
+  Reducer
 } from 'redux'
 import { vi } from 'vitest'
 import {
@@ -844,20 +845,27 @@ describe('createStore', () => {
     const originalConsoleError = console.error
     console.error = vi.fn()
 
+    const reducer: Reducer<number> = (s = 0) => s
+
+    const yReducer = combineReducers<{
+      z: typeof reducer
+      w?: typeof reducer
+    }>({
+      z: reducer,
+      w: reducer
+    })
+
     const store = createStore(
-      combineReducers<{ x?: number; y: { z: number; w?: number } }>({
-        x: (s = 0, _) => s,
-        y: combineReducers({
-          z: (s = 0, _) => s,
-          w: (s = 0, _) => s
-        })
+      combineReducers<{ x?: typeof reducer; y: typeof yReducer }>({
+        x: reducer,
+        y: yReducer
       })
     )
 
     store.replaceReducer(
       combineReducers({
         y: combineReducers({
-          z: (s = 0, _) => s
+          z: reducer
         })
       })
     )

--- a/test/helpers/actionCreators.ts
+++ b/test/helpers/actionCreators.ts
@@ -7,9 +7,10 @@ import {
   THROW_ERROR,
   UNKNOWN_ACTION
 } from './actionTypes'
-import { Action, AnyAction, Dispatch } from 'redux'
+import { TodoAction } from './reducers'
+import { Dispatch } from 'redux'
 
-export function addTodo(text: string): AnyAction {
+export function addTodo(text: string): TodoAction {
   return { type: ADD_TODO, text }
 }
 
@@ -31,42 +32,42 @@ export function addTodoIfEmpty(text: string) {
   }
 }
 
-export function dispatchInMiddle(boundDispatchFn: () => void): AnyAction {
+export function dispatchInMiddle(boundDispatchFn: () => void) {
   return {
     type: DISPATCH_IN_MIDDLE,
     boundDispatchFn
-  }
+  } as const
 }
 
-export function getStateInMiddle(boundGetStateFn: () => void): AnyAction {
+export function getStateInMiddle(boundGetStateFn: () => void) {
   return {
     type: GET_STATE_IN_MIDDLE,
     boundGetStateFn
-  }
+  } as const
 }
 
-export function subscribeInMiddle(boundSubscribeFn: () => void): AnyAction {
+export function subscribeInMiddle(boundSubscribeFn: () => void) {
   return {
     type: SUBSCRIBE_IN_MIDDLE,
     boundSubscribeFn
-  }
+  } as const
 }
 
-export function unsubscribeInMiddle(boundUnsubscribeFn: () => void): AnyAction {
+export function unsubscribeInMiddle(boundUnsubscribeFn: () => void) {
   return {
     type: UNSUBSCRIBE_IN_MIDDLE,
     boundUnsubscribeFn
-  }
+  } as const
 }
 
-export function throwError(): Action {
+export function throwError() {
   return {
     type: THROW_ERROR
-  }
+  } as const
 }
 
-export function unknownAction(): Action {
+export function unknownAction() {
   return {
     type: UNKNOWN_ACTION
-  }
+  } as const
 }

--- a/test/helpers/reducers.ts
+++ b/test/helpers/reducers.ts
@@ -6,7 +6,6 @@ import {
   UNSUBSCRIBE_IN_MIDDLE,
   THROW_ERROR
 } from './actionTypes'
-import { AnyAction } from 'redux'
 
 function id(state: { id: number }[]) {
   return (
@@ -18,9 +17,9 @@ export interface Todo {
   id: number
   text: string
 }
-export type TodoAction = { type: 'ADD_TODO'; text: string } | AnyAction
+export type TodoAction = { type: 'ADD_TODO'; text: string }
 
-export function todos(state: Todo[] = [], action: TodoAction) {
+export function todos(state: Todo[] = [], action: TodoAction): Todo[] {
   switch (action.type) {
     case ADD_TODO:
       return [
@@ -52,9 +51,7 @@ export function todosReverse(state: Todo[] = [], action: TodoAction) {
 
 export function dispatchInTheMiddleOfReducer(
   state = [],
-  action:
-    | { type: 'DISPATCH_IN_MIDDLE'; boundDispatchFn: () => void }
-    | AnyAction
+  action: { type: 'DISPATCH_IN_MIDDLE'; boundDispatchFn: () => void }
 ) {
   switch (action.type) {
     case DISPATCH_IN_MIDDLE:
@@ -67,9 +64,7 @@ export function dispatchInTheMiddleOfReducer(
 
 export function getStateInTheMiddleOfReducer(
   state = [],
-  action:
-    | { type: 'DISPATCH_IN_MIDDLE'; boundGetStateFn: () => void }
-    | AnyAction
+  action: { type: 'GET_STATE_IN_MIDDLE'; boundGetStateFn: () => void }
 ) {
   switch (action.type) {
     case GET_STATE_IN_MIDDLE:
@@ -82,9 +77,7 @@ export function getStateInTheMiddleOfReducer(
 
 export function subscribeInTheMiddleOfReducer(
   state = [],
-  action:
-    | { type: 'DISPATCH_IN_MIDDLE'; boundSubscribeFn: () => void }
-    | AnyAction
+  action: { type: 'SUBSCRIBE_IN_MIDDLE'; boundSubscribeFn: () => void }
 ) {
   switch (action.type) {
     case SUBSCRIBE_IN_MIDDLE:
@@ -97,9 +90,7 @@ export function subscribeInTheMiddleOfReducer(
 
 export function unsubscribeInTheMiddleOfReducer(
   state = [],
-  action:
-    | { type: 'DISPATCH_IN_MIDDLE'; boundUnsubscribeFn: () => void }
-    | AnyAction
+  action: { type: 'UNSUBSCRIBE_IN_MIDDLE'; boundUnsubscribeFn: () => void }
 ) {
   switch (action.type) {
     case UNSUBSCRIBE_IN_MIDDLE:
@@ -110,7 +101,10 @@ export function unsubscribeInTheMiddleOfReducer(
   }
 }
 
-export function errorThrowingReducer(state = [], action: AnyAction) {
+export function errorThrowingReducer(
+  state = [],
+  action: { type: 'THROW_ERROR' }
+) {
   switch (action.type) {
     case THROW_ERROR:
       throw new Error()

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -1,4 +1,4 @@
-import { StoreEnhancer, Action, AnyAction, Reducer, createStore } from 'redux'
+import { StoreEnhancer, Action, Reducer, createStore } from 'redux'
 
 interface State {
   someField: 'string'
@@ -169,8 +169,7 @@ function replaceReducerExtender() {
     ExtraState
   >(initialReducer, enhancer)
 
-  const newReducer = (state: PartialState = { test: true }, _: AnyAction) =>
-    state
+  const newReducer = (state: PartialState = { test: true }, _: Action) => state
 
   store.replaceReducer(newReducer)
   store.getState().test
@@ -260,7 +259,7 @@ function mhelmersonExample() {
     store.getState().wrongField
     store.getState().test
 
-    const newReducer = (state: PartialState = { test: true }, _: AnyAction) =>
+    const newReducer = (state: PartialState = { test: true }, _: Action) =>
       state
 
     store.replaceReducer(newReducer)
@@ -335,8 +334,7 @@ function finalHelmersonExample() {
   // @ts-expect-error
   store.getState().wrongField
 
-  const newReducer = (state: PartialState = { test: true }, _: AnyAction) =>
-    state
+  const newReducer = (state: PartialState = { test: true }, _: Action) => state
 
   store.replaceReducer(newReducer)
   store.getState().test

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -5,8 +5,7 @@ import {
   createStore,
   Dispatch,
   Reducer,
-  Action,
-  AnyAction
+  Action
 } from 'redux'
 
 /**

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -1,4 +1,10 @@
-import { Reducer, Action, combineReducers, ReducersMapObject } from 'redux'
+import {
+  Reducer,
+  Action,
+  combineReducers,
+  ReducersMapObject,
+  AnyAction
+} from 'redux'
 
 /**
  * Simple reducer definition with no action shape checks.
@@ -13,14 +19,16 @@ function simple() {
   const reducer: Reducer<State> = (state = 0, action) => {
     if (action.type === 'INCREMENT') {
       const { count = 1 } = action
-
-      return state + count
+      if (typeof count === 'number') {
+        return state + count
+      }
     }
 
     if (action.type === 'DECREMENT') {
       const { count = 1 } = action
-
-      return state - count
+      if (typeof count === 'number') {
+        return state + count
+      }
     }
 
     return state
@@ -186,8 +194,9 @@ function typeGuards() {
     count?: number
   }
 
-  const reducer: Reducer<State> = (state = 0, action) => {
+  const reducer: Reducer<State, AnyAction> = (state = 0, action) => {
     if (isAction<IncrementAction>(action, 'INCREMENT')) {
+      // TODO: this doesn't seem to work correctly with UnknownAction - `action` becomes `UnknownAction & IncrementAction`
       // Action shape is determined by the type guard returned from `isAction`
       // @ts-expect-error
       action.wrongField

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -156,7 +156,7 @@ function discriminated() {
   combined(cs, { type: 'SOME_OTHER_TYPE' })
 
   // Combined reducer can be made to only accept known actions.
-  const strictCombined = combineReducers<{ sub: State }, MyAction0>({
+  const strictCombined = combineReducers({
     sub: reducer0
   })
 

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -5,7 +5,8 @@ import {
   Action,
   StoreEnhancer,
   Unsubscribe,
-  Observer
+  Observer,
+  combineReducers
 } from 'redux'
 import 'symbol-observable'
 
@@ -73,6 +74,70 @@ const storeWithBadPreloadedState: Store<State> = createStore(reducer, {
   b: { c: 'c' },
   e: brandedString
 })
+
+const reducerA: Reducer<string> = (state = 'a') => state
+const reducerB: Reducer<{ c: string; d: string }> = (
+  state = { c: 'c', d: 'd' }
+) => state
+const reducerE: Reducer<BrandedString> = (state = brandedString) => state
+
+const combinedReducer = combineReducers({
+  a: reducerA,
+  b: reducerB,
+  e: reducerE
+})
+
+const storeWithCombineReducer = createStore(combinedReducer, {
+  b: { c: 'c', d: 'd' },
+  e: brandedString
+})
+// @ts-expect-error
+const storeWithCombineReducerAndBadPreloadedState = createStore(
+  combinedReducer,
+  {
+    b: { c: 'c' },
+    e: brandedString
+  }
+)
+
+const nestedCombinedReducer = combineReducers({
+  a: (state: string = 'a') => state,
+  b: combineReducers({
+    c: (state: string = 'c') => state,
+    d: (state: string = 'd') => state
+  }),
+  e: (state: BrandedString = brandedString) => state
+})
+
+// @ts-expect-error
+const storeWithNestedCombineReducer = createStore(nestedCombinedReducer, {
+  b: { c: 5 },
+  e: brandedString
+})
+
+const simpleCombinedReducer = combineReducers({
+  c: (state: string = 'c') => state,
+  d: (state: string = 'd') => state
+})
+
+// @ts-expect-error
+const storeWithSimpleCombinedReducer = createStore(simpleCombinedReducer, {
+  c: 5
+})
+
+// Note: It's not necessary that the errors occur on the lines specified, just as long as something errors somewhere
+// since the preloaded state doesn't match the reducer type.
+
+const simpleCombinedReducerWithImplicitState = combineReducers({
+  c: (state = 'c') => state,
+  d: (state = 'd') => state
+})
+
+// @ts-expect-error
+const storeWithSimpleCombinedReducerWithImplicitState = createStore(
+  simpleCombinedReducerWithImplicitState,
+  { c: 5 }
+)
 
 const storeWithActionReducer = createStore(reducerWithAction)
 const storeWithActionReducerAndPreloadedState = createStore(reducerWithAction, {


### PR DESCRIPTION
---
name: :bug: Bug fix or new feature
about: Fixing a problem with Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Experiments with using Action and UnknownAction to avoid usage of AnyAction.

### Why should this PR be included?
AnyAction introduces unwanted and unsafe `any` values into codebases.
UnknownAction allows accessing (and passing) arbitrary top level keys, but forces the reducer to check the value before use.
Action only allows access to the type property, until type guarded to allow extra properties. (safest, but most inconvenient)

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #4518 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
