### PR TITLE
update tutorial link HTML & CSS url

### DIFF
--- a/docs/tutorials/essentials/part-1-overview-concepts.md
+++ b/docs/tutorials/essentials/part-1-overview-concepts.md
@@ -31,7 +31,7 @@ We've tried to keep these explanations beginner-friendly, but we do need to make
 
 :::important Prerequisites
 
-- Familiarity with [HTML & CSS](https://internetingishard.com/).
+- Familiarity with [HTML & CSS](https://internetingishard.netlify.app/html-and-css/index.html).
 - Familiarity with [ES6 syntax and features](https://www.taniarascia.com/es6-syntax-and-feature-overview/)
 - Knowledge of React terminology: [JSX](https://react.dev/learn/writing-markup-with-jsx), [State](https://react.dev/learn/state-a-components-memory), [Function Components](https://react.dev/learn/your-first-component), [Props](https://react.dev/learn/passing-props-to-a-component), and [Hooks](https://react.dev/reference/react)
 - Knowledge of [asynchronous JavaScript](https://javascript.info/promise-basics) and [making AJAX requests](https://javascript.info/fetch)


### PR DESCRIPTION
changed to a working URL (https://internetingishard.netlify.app/html-and-css/index.html)

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - #4527 
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials, Part 1: Redux Overview and Concepts
- **Page**: [this](https://redux.js.org/tutorials/essentials/part-1-overview-concepts#how-to-read-this-tutorial)

## What is the problem?
Url was broken
## What changes does this PR make to fix the problem?
Changed to new working URL