### PR TITLE
fix: redux-thunk docs link

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -514,7 +514,7 @@ There's one more function in this file, but we'll talk about that in a minute wh
 
 :::info Want to Know More?
 
-See [the Redux Thunk docs](https://github.com/reduxjs/redux-thunk), the post [What the heck is a thunk?](https://daveceddia.com/what-is-a-thunk/) and the [Redux FAQ entry on "why do we use middleware for async?"](../../faq/Actions.md#how-can-i-represent-side-effects-such-as-ajax-calls-why-do-we-need-things-like-action-creators-thunks-and-middleware-to-do-async-behavior) for more information.
+See [the Redux Thunk docs](https://redux.js.org/usage/writing-logic-thunks), the post [What the heck is a thunk?](https://daveceddia.com/what-is-a-thunk/) and the [Redux FAQ entry on "why do we use middleware for async?"](../../faq/Actions.md#how-can-i-represent-side-effects-such-as-ajax-calls-why-do-we-need-things-like-action-creators-thunks-and-middleware-to-do-async-behavior) for more information.
 
 :::
 

--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -514,7 +514,7 @@ There's one more function in this file, but we'll talk about that in a minute wh
 
 :::info Want to Know More?
 
-See [the Redux Thunk docs](https://redux.js.org/usage/writing-logic-thunks), the post [What the heck is a thunk?](https://daveceddia.com/what-is-a-thunk/) and the [Redux FAQ entry on "why do we use middleware for async?"](../../faq/Actions.md#how-can-i-represent-side-effects-such-as-ajax-calls-why-do-we-need-things-like-action-creators-thunks-and-middleware-to-do-async-behavior) for more information.
+See [the Redux Thunk docs](../../usage/writing-logic-thunks.mdx), the post [What the heck is a thunk?](https://daveceddia.com/what-is-a-thunk/) and the [Redux FAQ entry on "why do we use middleware for async?"](../../faq/Actions.md#how-can-i-represent-side-effects-such-as-ajax-calls-why-do-we-need-things-like-action-creators-thunks-and-middleware-to-do-async-behavior) for more information.
 
 :::
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - #4529
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials, Part 2: Redux Toolkit App Structure [link](https://redux.js.org/tutorials/essentials/part-2-app-structure#writing-async-logic-with-thunks)
- **Page**: [this page](https://redux.js.org/tutorials/essentials/part-2-app-structure#writing-async-logic-with-thunks)

## What is the problem?
we should redirect to thunk docs instead of github repo

## What changes does this PR make to fix the problem?
