### PR TITLE
Fix missing call to `getDefaultMiddleware`

### DIFF
--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -736,7 +736,7 @@ export const store = configureStore({
   reducer: rootReducer,
   // Add the listener middleware _before_ the thunk or dev checks
   middleware: getDefaultMiddleware =>
-    getDefaultMiddleware.prepend(listenerMiddleware.middleware)
+    getDefaultMiddleware().prepend(listenerMiddleware.middleware)
 })
 ```
 


### PR DESCRIPTION
There is a typo in the docs for the listener middleware where it tries to prepend a middleware without calling `getDefaultMIddleware` first

`getDefaultMiddleware.prepend` is invalid
`getDefaultMiddleware().prepend` is ok

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---