### PR TITLE
add export to typescript tutorial

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -96,7 +96,7 @@ import type { RootState } from '../../app/store'
 
 // highlight-start
 // Define a type for the slice state
-interface CounterState {
+export interface CounterState {
   value: number
 }
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ x ] Is there an existing issue for this PR?
  - #4541 
- [ x ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: tutorials
- **Page**: typescript-quick-start

## What changes does this PR make to fix the problem?
Add `export` to typescript quick start so the store object does not give same error.
