### PR TITLE
String action type

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -282,6 +282,14 @@ export function createStore<
       )
     }
 
+    if (typeof action.type !== 'string') {
+      throw new Error(
+        `Action "type" property must be a string. Instead, the actual type was: ${kindOf(
+          action.type
+        )}.`
+      )
+    }
+
     if (isDispatching) {
       throw new Error('Reducers may not dispatch actions.')
     }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -284,9 +284,9 @@ export function createStore<
 
     if (typeof action.type !== 'string') {
       throw new Error(
-        `Action "type" property must be a string. Instead, the actual type was: ${kindOf(
+        `Action "type" property must be a string. Instead, the actual type was: '${kindOf(
           action.type
-        )}.`
+        )}'. Value was: '${action.type}' (stringified)`
       )
     }
 

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -6,8 +6,7 @@
  *
  * Actions must have a `type` field that indicates the type of action being
  * performed. Types can be defined as constants and imported from another
- * module. It's better to use strings for `type` than Symbols because strings
- * are serializable.
+ * module. These must be strings, as strings are serializable.
  *
  * Other than `type`, the structure of an action object is really up to you.
  * If you're interested, check out Flux Standard Action for recommendations on
@@ -15,7 +14,7 @@
  *
  * @template T the type of the action's `type` tag.
  */
-export interface Action<T = any> {
+export interface Action<T extends string = string> {
   type: T
 }
 

--- a/test/combineReducers.spec.ts
+++ b/test/combineReducers.spec.ts
@@ -65,7 +65,7 @@ describe('Utils', () => {
 
     it('throws an error if a reducer returns undefined handling an action', () => {
       const reducer = combineReducers({
-        counter(state: number = 0, action: Action<unknown>) {
+        counter(state: number = 0, action: Action) {
           switch (action && action.type) {
             case 'increment':
               return state + 1
@@ -95,7 +95,7 @@ describe('Utils', () => {
 
     it('throws an error on first call if a reducer returns undefined initializing', () => {
       const reducer = combineReducers({
-        counter(state: number, action: Action<unknown>) {
+        counter(state: number, action: Action) {
           switch (action.type) {
             case 'increment':
               return state + 1
@@ -122,23 +122,6 @@ describe('Utils', () => {
       ).toThrow(/Error thrown in reducer/)
     })
 
-    it('allows a symbol to be used as an action type', () => {
-      const increment = Symbol('INCREMENT')
-
-      const reducer = combineReducers({
-        counter(state: number = 0, action: Action<unknown>) {
-          switch (action.type) {
-            case increment:
-              return state + 1
-            default:
-              return state
-          }
-        }
-      })
-
-      expect(reducer({ counter: 0 }, { type: increment }).counter).toEqual(1)
-    })
-
     it('maintains referential equality if the reducers it is combining do', () => {
       const reducer = combineReducers({
         child1(state = {}) {
@@ -161,10 +144,7 @@ describe('Utils', () => {
         child1(state = {}) {
           return state
         },
-        child2(
-          state: { count: number } = { count: 0 },
-          action: Action<unknown>
-        ) {
+        child2(state: { count: number } = { count: 0 }, action: Action) {
           switch (action.type) {
             case 'increment':
               return { count: state.count + 1 }
@@ -185,7 +165,7 @@ describe('Utils', () => {
 
     it('throws an error on first call if a reducer attempts to handle a private action', () => {
       const reducer = combineReducers({
-        counter(state: number, action: Action<unknown>) {
+        counter(state: number, action: Action) {
           switch (action.type) {
             case 'increment':
               return state + 1

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -575,16 +575,15 @@ describe('createStore', () => {
 
   it('throws if action type is not string', () => {
     const store = createStore(reducers.todos)
-    const expectedErr = /Action "type" property must be a string/
     expect(() =>
       store.dispatch({ type: false } as unknown as AnyAction)
-    ).toThrow(expectedErr)
+    ).toThrow(/the actual type was: 'boolean'.*Value was: 'false'/)
     expect(() => store.dispatch({ type: 0 } as unknown as AnyAction)).toThrow(
-      expectedErr
+      /the actual type was: 'number'.*Value was: '0'/
     )
     expect(() =>
       store.dispatch({ type: null } as unknown as AnyAction)
-    ).toThrow(expectedErr)
+    ).toThrow(/the actual type was: 'null'.*Value was: 'null'/)
 
     expect(() =>
       store.dispatch({ type: '' } as unknown as AnyAction)

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -4,7 +4,8 @@ import {
   StoreEnhancer,
   Action,
   Store,
-  Reducer
+  Reducer,
+  AnyAction
 } from 'redux'
 import { vi } from 'vitest'
 import {
@@ -567,17 +568,27 @@ describe('createStore', () => {
 
   it('throws if action type is undefined', () => {
     const store = createStore(reducers.todos)
-    expect(() => store.dispatch({ type: undefined })).toThrow(
-      /Actions may not have an undefined "type" property/
-    )
+    expect(() =>
+      store.dispatch({ type: undefined } as unknown as AnyAction)
+    ).toThrow(/Actions may not have an undefined "type" property/)
   })
 
-  it('does not throw if action type is falsy', () => {
+  it('throws if action type is not string', () => {
     const store = createStore(reducers.todos)
-    expect(() => store.dispatch({ type: false })).not.toThrow()
-    expect(() => store.dispatch({ type: 0 })).not.toThrow()
-    expect(() => store.dispatch({ type: null })).not.toThrow()
-    expect(() => store.dispatch({ type: '' })).not.toThrow()
+    const expectedErr = /Action "type" property must be a string/
+    expect(() =>
+      store.dispatch({ type: false } as unknown as AnyAction)
+    ).toThrow(expectedErr)
+    expect(() => store.dispatch({ type: 0 } as unknown as AnyAction)).toThrow(
+      expectedErr
+    )
+    expect(() =>
+      store.dispatch({ type: null } as unknown as AnyAction)
+    ).toThrow(expectedErr)
+
+    expect(() =>
+      store.dispatch({ type: '' } as unknown as AnyAction)
+    ).not.toThrow()
   })
 
   it('accepts enhancer as the third argument', () => {

--- a/test/typescript/actions.ts
+++ b/test/typescript/actions.ts
@@ -39,21 +39,3 @@ namespace StringLiteralTypeAction {
 
   const type: ActionType = action.type
 }
-
-namespace EnumTypeAction {
-  enum ActionType {
-    A,
-    B,
-    C
-  }
-
-  interface Action extends ReduxAction {
-    type: ActionType
-  }
-
-  const action: Action = {
-    type: ActionType.A
-  }
-
-  const type: ActionType = action.type
-}

--- a/test/typescript/enhancers.ts
+++ b/test/typescript/enhancers.ts
@@ -159,12 +159,12 @@ function replaceReducerExtender() {
     test?: boolean
   }
 
-  const initialReducer: Reducer<PartialState, Action<unknown>> = () => ({
+  const initialReducer: Reducer<PartialState, Action> = () => ({
     someField: 'string'
   })
   const store = createStore<
     PartialState,
-    Action<unknown>,
+    Action,
     { method(): string },
     ExtraState
   >(initialReducer, enhancer)
@@ -246,10 +246,10 @@ function mhelmersonExample() {
       test?: boolean
     }
 
-    const initialReducer: Reducer<PartialState, Action<unknown>> = () => ({
+    const initialReducer: Reducer<PartialState, Action> = () => ({
       someField: 'string'
     })
-    const store = createStore<PartialState, Action<unknown>, {}, ExtraState>(
+    const store = createStore<PartialState, Action, {}, ExtraState>(
       initialReducer,
       enhancer
     )
@@ -276,7 +276,7 @@ function finalHelmersonExample() {
     foo: string
   }
 
-  function persistReducer<S, A extends Action<unknown>, PreloadedState>(
+  function persistReducer<S, A extends Action, PreloadedState>(
     config: any,
     reducer: Reducer<S, A, PreloadedState>
   ) {
@@ -300,7 +300,7 @@ function finalHelmersonExample() {
     persistConfig: any
   ): StoreEnhancer<{}, ExtraState> {
     return createStore =>
-      <S, A extends Action<unknown>, PreloadedState>(
+      <S, A extends Action, PreloadedState>(
         reducer: Reducer<S, A, PreloadedState>,
         preloadedState?: PreloadedState | undefined
       ) => {
@@ -323,10 +323,10 @@ function finalHelmersonExample() {
     test?: boolean
   }
 
-  const initialReducer: Reducer<PartialState, Action<unknown>> = () => ({
+  const initialReducer: Reducer<PartialState, Action> = () => ({
     someField: 'string'
   })
-  const store = createStore<PartialState, Action<unknown>, {}, ExtraState>(
+  const store = createStore<PartialState, Action, {}, ExtraState>(
     initialReducer,
     createPersistEnhancer('hi')
   )


### PR DESCRIPTION
---
name: :bug: Bug fix or new feature
about: Require action types to be strings
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

It prevents passing non-string action types to store.

### Why should this PR be included?

Per https://github.com/reduxjs/redux/issues/4129#issuecomment-955854794 :

> we've always said they should be serializable, and ought to be strings.
> 
> Someone over on Twitter said they'd once tried to use Symbols to make them truly unique, but tbh slice namespacing gives you like 95% uniqueness anyway, so I don't see that as a reason to continue to allow them. As mentioned above, TS enums can have number values, but again why would you do that? We want them to be readable in the DevTools.
> 
> So, given that we've always effectively said they should be strings, we might as well enforce it.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4543
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Non-string action types are allowed to be dispatched to store.

### What is the expected behavior?
Action types should be enforced as string

### How does this PR fix the problem?
Store throws an error if action type is not string.