### PR TITLE
Updated obsolete link that pointed to an old repo for cra-template-re…

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -24,7 +24,7 @@ Now, let's look at a real working example to see how these pieces fit together.
 
 The sample project we'll look at is a small counter application that lets us add or subtract from a number as we click buttons. It may not be very exciting, but it shows all the important pieces of a React+Redux application in action.
 
-The project has been created using [the official Redux template for Create-React-App](https://github.com/reduxjs/cra-template-redux). Out of the box, it has already been configured with a standard Redux application structure, using [Redux Toolkit](https://redux-toolkit.js.org) to create the Redux store and logic, and [React-Redux](https://react-redux.js.org) to connect together the Redux store and the React components.
+The project has been created using [the official Redux template for Create-React-App](https://github.com/reduxjs/redux-templates). Out of the box, it has already been configured with a standard Redux application structure, using [Redux Toolkit](https://redux-toolkit.js.org) to create the Redux store and logic, and [React-Redux](https://react-redux.js.org) to connect together the Redux store and the React components.
 
 Here's the live version of the project. You can play around with it by clicking the buttons in the app preview on the right, and browse through the source files on the left.
 


### PR DESCRIPTION
…dux.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4570
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:  https://redux.js.org/tutorials/essentials/part-2-app-structure#the-counter-example-app
- **Page**: https://redux.js.org/tutorials/essentials/part-2-app-structure#the-counter-example-app

## What is the problem?
   In the paragraph with the title The Counter Example app there is a link to https://github.com/reduxjs/cra-template-redux 
   which points to and old repo
## What changes does this PR make to fix the problem?
I replaced the old link https://github.com/reduxjs/cra-template-redux with new one https://redux.js.org/tutorials/essentials/part-2-app-structure#the-counter-example-app