### PR TITLE
Minor RTK Mutation Query Function Documentation Fix

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -115,7 +115,7 @@ export const EditPostForm = ({ match }) => {
   const onSavePostClicked = async () => {
     if (title && content) {
       // highlight-next-line
-      await updatePost({ id: postId, title, content })
+      await updatePost({ id: postId, title, content }).unwrap()
       history.push(`/posts/${postId}`)
     }
   }


### PR DESCRIPTION
Fix mutation function usage, according to part 7 an `.unwrap()` call is needed.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - https://github.com/reduxjs/redux/issues/4577
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials
- **Page**: Part 8 RTK Query Advanced Patterns

## What is the problem?
Seems like a minor typo/missing function call in the usage of mutation function. In part 7, it is stated that the `.unwrap()` function needs to be called for the RTK mutation query.

> As with the thunk dispatch, we call addNewPost with the initial post object. This returns a special Promise with a .unwrap() method, and we can await addNewPost().unwrap() to handle any potential errors with a standard try/catch block.

Whereas in part 8 code snippet for Editing Post, the `.unwrap()` call is missing for a very similar mutation function.
```
  const [updatePost, { isLoading }] = useEditPostMutation()

  /* code omitted */

  const onSavePostClicked = async () => {
    if (title && content) {
      await updatePost({ id: postId, title, content }) // <- this should have a .unwrap() ?
      history.push(`/posts/${postId}`)
    }
  }
```

## What changes does this PR make to fix the problem?

Add `.unwrap()` to the code snippet