### PR TITLE
Add color property to 'code' css declaration

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -119,6 +119,7 @@ div[class*='codeBlockTitle'] {
 code {
   background-color: var(--ifm-color-emphasis-300);
   border-radius: 0.2rem;
+  color: var(--ifm-color-content);
 }
 
 a code,


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - #4538 
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- The inline code blocks used inside DetailedExplanation.tsx

## What is the problem?

It's difficult to see the text in inline code blocks inside the DetailedExplanation component in dark mode. The css doesn't match the styles used for inline code blocks on the rest of the documentation.

## What changes does this PR make to fix the problem?

I added a css 'color' property to the code declaration inside website\src\css\custom.css. The value is consistent with what's used outside the DetailedExplanation component.

### Before
![image](https://github.com/reduxjs/redux/assets/61631544/fd52402e-b3c4-41d9-8d0e-05b5f1d70735)

### After
![image](https://github.com/reduxjs/redux/assets/61631544/428e681e-36a4-4158-892c-1d5551f35ef6)