### PR TITLE
add missing highlight

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -385,6 +385,7 @@ export default notificationsSlice.reducer
 We want to mark these notifications as read whenever our `<NotificationsList>` component renders, either because we clicked on the tab to view the notifications, or because we already have it open and we just received some additional notifications. We can do this by dispatching `allNotificationsRead` any time this component re-renders. In order to avoid flashing of old data as this updates, we'll dispatch the action in a `useLayoutEffect` hook. We also want to add an additional classname to any notification list entries in the page, to highlight them:
 
 ```jsx title="features/notifications/NotificationsList.js"
+// highlight-next-line
 import React, { useLayoutEffect } from 'react'
 // highlight-next-line
 import { useSelector, useDispatch } from 'react-redux'


### PR DESCRIPTION
add highlight-next-line

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?
This is the first time we are using useLayoutEffect in this file, so its import should also be highlighted.

## What changes does this PR make to fix the problem?
add missing highlight
