### PR TITLE
Use default Node version in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 
@@ -144,7 +144,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,21 +24,17 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' }}
 
-    name: Lint, Test, Build & Pack on Node ${{ matrix.node }}
+    name: Lint, Test, Build & Pack on Node
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['16.x']
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -59,18 +55,13 @@ jobs:
     name: Test against dist
     needs: [build]
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['16.x']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -99,16 +90,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16.x']
         ts: ['4.7', '4.8', '4.9', '5.0']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -140,7 +129,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16.x']
         example:
           [
             'cra4',
@@ -155,10 +143,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Clone RTK repo


### PR DESCRIPTION
Deprecated Node versions are used in CI, potentially causing security and reliability issues. Instead, it's better to use GitHub's default Node version, which also doesn't require additional downloads or installations.