### PR TITLE
Update ConfiguringYourStore.md

### DIFF
--- a/docs/usage/ConfiguringYourStore.md
+++ b/docs/usage/ConfiguringYourStore.md
@@ -356,7 +356,7 @@ import rootReducer from './reducers'
 export default function configureAppStore(preloadedState) {
   const store = configureStore({
     reducer: rootReducer,
-    middleware: (getDefaultMiddleware) => [loggerMiddleware, ...getDefaultMiddleware()],
+    middleware: (getDefaultMiddleware) => [loggerMiddleware, ...getDefaultMiddleware().prepend()],
     preloadedState,
     enhancers: [monitorReducersEnhancer]
   })

--- a/docs/usage/ConfiguringYourStore.md
+++ b/docs/usage/ConfiguringYourStore.md
@@ -356,7 +356,7 @@ import rootReducer from './reducers'
 export default function configureAppStore(preloadedState) {
   const store = configureStore({
     reducer: rootReducer,
-    middleware: (getDefaultMiddleware) => [loggerMiddleware, ...getDefaultMiddleware().prepend()],
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().prepend(loggerMiddleware),
     preloadedState,
     enhancers: [monitorReducersEnhancer]
   })

--- a/docs/usage/ConfiguringYourStore.md
+++ b/docs/usage/ConfiguringYourStore.md
@@ -347,7 +347,7 @@ By default, `configureStore` from Redux Toolkit will:
 Here's what the hot reloading example might look like using Redux Toolkit:
 
 ```js
-import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit'
+import { configureStore } from '@reduxjs/toolkit'
 
 import monitorReducersEnhancer from './enhancers/monitorReducers'
 import loggerMiddleware from './middleware/logger'
@@ -356,7 +356,7 @@ import rootReducer from './reducers'
 export default function configureAppStore(preloadedState) {
   const store = configureStore({
     reducer: rootReducer,
-    middleware: [loggerMiddleware, ...getDefaultMiddleware()],
+    middleware: (getDefaultMiddleware) => [loggerMiddleware, ...getDefaultMiddleware()],
     preloadedState,
     enhancers: [monitorReducersEnhancer]
   })


### PR DESCRIPTION

Prefer to use the callback notation for the middleware option in configureStore to access a pre-typed getDefaultMiddleware instead.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:  https://redux.js.org/usage/configuring-your-store#simplifying-setup-with-redux-toolkit
- **Page**: https://redux.js.org/usage/configuring-your-store

## What is the problem?
`getDefaultMiddleware` import from `reduxjs/toolkit` has been marked as deprecated. The documentation however still uses  import.

## What changes does this PR make to fix the problem?
 This PR removes the imported `getDefaultMiddleware` and uses the callback notation for the middleware option.
