### PR TITLE
Changed TypeSCript to TypeScript at the bottom for the testing section.

### DIFF
--- a/docs/tutorials/videos.md
+++ b/docs/tutorials/videos.md
@@ -64,6 +64,6 @@ A course that covers how to modernize existing React+Redux applications from old
 
 ### Confidently Testing Redux Applications with Jest & TypeScript
 
-[Egghead course: Confidently Testing Redux Applications with Jest & TypeSCript](https://app.egghead.io/lessons/jest-intro-to-confidently-testing-redux-applications-with-jest-typescript?pl=confidently-testing-redux-applications-with-jest-typescript-16e17d9b&af=7pnhj6)
+[Egghead course: Confidently Testing Redux Applications with Jest & TypeScript](https://app.egghead.io/lessons/jest-intro-to-confidently-testing-redux-applications-with-jest-typescript?pl=confidently-testing-redux-applications-with-jest-typescript-16e17d9b&af=7pnhj6)
 
 Best practices for building & testing Redux applications have changed dramatically over time. This course aims to be a comprehensive and up-to-date resource for those seeking to confidently test their Redux apps.


### PR DESCRIPTION
Changed TypeSCript to TypeScript at the bottom for the testing section.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Confidently Testing Redux Applications with Jest & TypeScript
- **Page**: https://redux.js.org/tutorials/videos

## What is the problem?
There's a typo. TypeSCript should be TypeScript
## What changes does this PR make to fix the problem?
Fixes the typo