### PR TITLE
Update part-5-async-logic.md

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -592,6 +592,7 @@ export const PostsList = () => {
   return (
     <section className="posts-list">
       <h2>Posts</h2>
+      // highlight-next-line
       {content}
     </section>
   )


### PR DESCRIPTION
Highlight next line in doc's code block as `{renderedPosts}` in example changes to `{content}` for the reader following along.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  - None
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Displaying Loading State
- **Page**: Redux Essentials, Part 5: Async Logic and Data Fetching

## What is the problem?
An example code line needs to be highlighted to indicate to the reader that the line is being updated from previous example to code to the current example code.

## What changes does this PR make to fix the problem?
Adds the `// highlight-next-line` comment above the line that is to be indicated to the user per the problem above.
