### PR TITLE
Add isAction type predicate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import combineReducers from './combineReducers'
 import bindActionCreators from './bindActionCreators'
 import applyMiddleware from './applyMiddleware'
 import compose from './compose'
+import isAction from './utils/isAction'
 import __DO_NOT_USE__ActionTypes from './utils/actionTypes'
 
 // types
@@ -42,5 +43,6 @@ export {
   bindActionCreators,
   applyMiddleware,
   compose,
+  isAction,
   __DO_NOT_USE__ActionTypes
 }

--- a/src/utils/isAction.ts
+++ b/src/utils/isAction.ts
@@ -1,0 +1,10 @@
+import { Action } from '../types/actions'
+import isPlainObject from './isPlainObject'
+
+export default function isAction(action: unknown): action is Action<string> {
+  return (
+    isPlainObject(action) &&
+    'type' in action &&
+    typeof (action as Record<'type', unknown>).type === 'string'
+  )
+}

--- a/src/utils/isPlainObject.ts
+++ b/src/utils/isPlainObject.ts
@@ -2,7 +2,7 @@
  * @param obj The object to inspect.
  * @returns True if the argument appears to be a plain object.
  */
-export default function isPlainObject(obj: any): boolean {
+export default function isPlainObject(obj: any): obj is object {
   if (typeof obj !== 'object' || obj === null) return false
 
   let proto = obj

--- a/test/utils/isAction.spec.ts
+++ b/test/utils/isAction.spec.ts
@@ -1,0 +1,23 @@
+import { isAction } from 'redux'
+
+describe('isAction', () => {
+  it('should only return true for plain objects with a string type property', () => {
+    const actionCreator = () => ({ type: 'anAction' })
+    class Action {
+      type = 'totally an action'
+    }
+    const testCases: [action: unknown, expected: boolean][] = [
+      [{ type: 'an action' }, true],
+      [{ type: 'more props', extra: true }, true],
+      [{ type: 0 }, false],
+      [actionCreator(), true],
+      [actionCreator, false],
+      [Promise.resolve({ type: 'an action' }), false],
+      [new Action(), false],
+      ['a string', false]
+    ]
+    for (const [action, expected] of testCases) {
+      expect(isAction(action)).toBe(expected)
+    }
+  })
+})

--- a/test/utils/isAction.spec.ts
+++ b/test/utils/isAction.spec.ts
@@ -1,4 +1,4 @@
-import { isAction } from 'redux'
+import isAction from '@internal/utils/isAction'
 
 describe('isAction', () => {
   it('should only return true for plain objects with a string type property', () => {


### PR DESCRIPTION
This is already exported from RTK, but seems useful to move to core as the middleware typing changes now (correctly) treat `action` as `unknown` - exporting this provides an "official" way to check that a value is an action object (with the same restrictions as the final reducers - plain object with type string)