### PR TITLE
Don't notify subscribers when after action state hasn't changed, add test

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -294,6 +294,7 @@ export function createStore<
       throw new Error('Reducers may not dispatch actions.')
     }
 
+    const previousState = currentState
     try {
       isDispatching = true
       currentState = currentReducer(currentState, action)
@@ -302,9 +303,12 @@ export function createStore<
     }
 
     const listeners = (currentListeners = nextListeners)
-    listeners.forEach(listener => {
-      listener()
-    })
+    if (previousState !== currentState) {
+      listeners.forEach(listener => {
+        listener()
+      })
+    }
+
     return action
   }
 

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -207,19 +207,28 @@ describe('createStore', () => {
     ])
   })
 
+  it(`doesn't notify listeners when state didn't change after action`, () => {
+    const store = createStore(reducers.todos)
+    const listener = vi.fn()
+
+    store.subscribe(listener)
+    // @ts-expect-error
+    store.dispatch(unknownAction())
+
+    expect(listener.mock.calls.length).toBe(0)
+  })
+
   it('supports multiple subscriptions', () => {
     const store = createStore(reducers.todos)
     const listenerA = vi.fn()
     const listenerB = vi.fn()
 
     let unsubscribeA = store.subscribe(listenerA)
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(1)
     expect(listenerB.mock.calls.length).toBe(0)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(2)
     expect(listenerB.mock.calls.length).toBe(0)
 
@@ -227,8 +236,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(2)
     expect(listenerB.mock.calls.length).toBe(0)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(1)
 
@@ -236,8 +244,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(1)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
 
@@ -245,8 +252,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
 
@@ -254,8 +260,7 @@ describe('createStore', () => {
     expect(listenerA.mock.calls.length).toBe(3)
     expect(listenerB.mock.calls.length).toBe(2)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(4)
     expect(listenerB.mock.calls.length).toBe(2)
   })
@@ -271,8 +276,7 @@ describe('createStore', () => {
     unsubscribeA()
     unsubscribeA()
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listenerA.mock.calls.length).toBe(0)
     expect(listenerB.mock.calls.length).toBe(1)
   })
@@ -287,8 +291,7 @@ describe('createStore', () => {
     unsubscribeSecond()
     unsubscribeSecond()
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener.mock.calls.length).toBe(1)
   })
 
@@ -305,10 +308,8 @@ describe('createStore', () => {
     })
     store.subscribe(listenerC)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
+    store.dispatch(addTodo(''))
 
     expect(listenerA.mock.calls.length).toBe(2)
     expect(listenerB.mock.calls.length).toBe(1)
@@ -335,14 +336,12 @@ describe('createStore', () => {
     )
     unsubscribeHandles.push(store.subscribe(() => listener3()))
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(1)
     expect(listener3.mock.calls.length).toBe(1)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(1)
     expect(listener3.mock.calls.length).toBe(1)
@@ -369,14 +368,12 @@ describe('createStore', () => {
       maybeAddThirdListener()
     })
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(1)
     expect(listener3.mock.calls.length).toBe(0)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener1.mock.calls.length).toBe(2)
     expect(listener2.mock.calls.length).toBe(2)
     expect(listener3.mock.calls.length).toBe(1)
@@ -400,8 +397,7 @@ describe('createStore', () => {
 
       unsubscribe1()
       unsubscribe4 = store.subscribe(listener4)
-      // @ts-expect-error
-      store.dispatch(unknownAction())
+      store.dispatch(addTodo(''))
 
       expect(listener1.mock.calls.length).toBe(1)
       expect(listener2.mock.calls.length).toBe(1)
@@ -411,16 +407,14 @@ describe('createStore', () => {
     store.subscribe(listener2)
     store.subscribe(listener3)
 
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(2)
     expect(listener3.mock.calls.length).toBe(2)
     expect(listener4.mock.calls.length).toBe(1)
 
     unsubscribe4()
-    // @ts-expect-error
-    store.dispatch(unknownAction())
+    store.dispatch(addTodo(''))
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(3)
     expect(listener3.mock.calls.length).toBe(3)


### PR DESCRIPTION
---
name: Optimization of subscriptions
about: Performance
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

No.

### Why should this PR be included?

**Problem**

Up to 50% of all dispatched actions in the apps that use `redux-saga` or `redux-thunk` could be ones that don't change the redux state but start some async logic.

Current implementation notifies subscribers for each such action even if state hasn't changed, causing all active selectors to be reevaluated without any good reason.

In huge apps there can be hundreds of subscribed selectors and dozens of actions per second, so this leads to additional CPU usage for no good reason.

**Solution**

Don't notify subscribers when action did not change the state.

**Can it break existing code?**

As far as I can see, the only reason to subscribe to the store is to get the new state using store.getState(). There is no sense in subscribing to get the called action because there is no way to get the latest action called from subscription. So it should not break any existing code.

But I would vote for raising major version here.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
 No, as far as I know.
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
