### PR TITLE
Fix markdown links on Next.js page

### DIFF
--- a/docs/usage/nextjs.mdx
+++ b/docs/usage/nextjs.mdx
@@ -386,7 +386,7 @@ The App Router has four seperate caches including `fetch` request and route cach
 export const dynamic = 'force-dynamic'
 ```
 
-After a mutation you should also invalidate the cache by calling (`revalidatePath`)[https://nextjs.org/docs/app/api-reference/functions/revalidatePath] or (`revalidateTag`)[https://nextjs.org/docs/app/api-reference/functions/revalidateTag] as appropriate.
+After a mutation you should also invalidate the cache by calling [`revalidatePath`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath) or [`revalidateTag`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) as appropriate.
 
 ### RTK Query
 


### PR DESCRIPTION
## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Using Redux -> Setup and Organization
- **Page**: https://redux.js.org/usage/nextjs#caching

## What is the problem?

![image](https://github.com/reduxjs/redux/assets/5096735/6563ab39-144d-417e-858a-7b2a6fd853bd)

## What changes does this PR make to fix the problem?

Fixes markdown syntax 