### PR TITLE
Remove link to DecemberSoft post no longer valid (now have content about bets in australia)

### DIFF
--- a/docs/faq/Actions.md
+++ b/docs/faq/Actions.md
@@ -124,7 +124,6 @@ Since sagas and observables have the same use case, an application would normall
 **Articles**
 
 - [Decembersoft: What is the right way to do asynchronous operations in Redux?](https://decembersoft.com/posts/what-is-the-right-way-to-do-asynchronous-operations-in-redux/)
-- [Decembersoft: Redux-Thunk vs Redux-Saga](https://decembersoft.com/posts/redux-thunk-vs-redux-saga/)
 - [Redux-Thunk vs Redux-Saga: an overview](https://medium.com/@shoshanarosenfield/redux-thunk-vs-redux-saga-93fe82878b2d)
 - [Redux-Saga V.S. Redux-Observable](https://hackmd.io/s/H1xLHUQ8e#side-by-side-comparison)
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [x] Is there an existing issue for this PR?
  -No
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: FAQ
- **Page**: Actions

## What is the problem?

There's a link to DecemberSoft "[Decembersoft: Redux-Thunk vs Redux-Saga](https://decembersoft.com/posts/redux-thunk-vs-redux-saga/)", but the link now have some content about "Top New Betting Sites in Australia".

## What changes does this PR make to fix the problem?

Remove the link to that specific article.