### PR TITLE
fix(types/store): Unexpectedly narrowed return type of function `Store['getState']`

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -5,7 +5,8 @@ import {
   StoreEnhancer,
   Dispatch,
   Observer,
-  ListenerCallback
+  ListenerCallback,
+  UnknownIfNonSpecific
 } from './types/store'
 import { Action } from './types/actions'
 import { Reducer } from './types/reducers'
@@ -46,7 +47,7 @@ export function createStore<
 >(
   reducer: Reducer<S, A>,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S, A, StateExt> & Ext
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
 /**
  * @deprecated
  *
@@ -82,7 +83,7 @@ export function createStore<
   reducer: Reducer<S, A, PreloadedState>,
   preloadedState?: PreloadedState | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S, A, StateExt> & Ext
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
 export function createStore<
   S,
   A extends Action,
@@ -93,7 +94,7 @@ export function createStore<
   reducer: Reducer<S, A, PreloadedState>,
   preloadedState?: PreloadedState | StoreEnhancer<Ext, StateExt> | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S, A, StateExt> & Ext {
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext {
   if (typeof reducer !== 'function') {
     throw new Error(
       `Expected the root reducer to be a function. Instead, received: '${kindOf(
@@ -432,7 +433,7 @@ export function legacy_createStore<
 >(
   reducer: Reducer<S, A>,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S, A, StateExt> & Ext
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
 /**
  * Creates a Redux store that holds the state tree.
  *
@@ -473,7 +474,7 @@ export function legacy_createStore<
   reducer: Reducer<S, A, PreloadedState>,
   preloadedState?: PreloadedState | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S, A, StateExt> & Ext
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
 export function legacy_createStore<
   S,
   A extends Action,
@@ -484,6 +485,6 @@ export function legacy_createStore<
   reducer: Reducer<S, A>,
   preloadedState?: PreloadedState | StoreEnhancer<Ext, StateExt> | undefined,
   enhancer?: StoreEnhancer<Ext, StateExt>
-): Store<S, A, StateExt> & Ext {
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext {
   return createStore(reducer, preloadedState as any, enhancer)
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -81,7 +81,7 @@ export type Observer<T> = {
 export interface Store<
   S = any,
   A extends Action = UnknownAction,
-  StateExt extends {} = {}
+  StateExt extends unknown = unknown
 > {
   /**
    * Dispatches an action. It is the only way to trigger a state change.

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -164,6 +164,8 @@ export interface Store<
   [Symbol.observable](): Observable<S & StateExt>
 }
 
+export type UnknownIfNonSpecific<T> = {} extends T ? unknown : T
+
 /**
  * A store creator is a function that creates a Redux store. Like with
  * dispatching function, we must distinguish the base store creator,
@@ -180,7 +182,7 @@ export interface StoreCreator {
   <S, A extends Action, Ext extends {} = {}, StateExt extends {} = {}>(
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
-  ): Store<S, A, StateExt> & Ext
+  ): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
   <
     S,
     A extends Action,
@@ -191,7 +193,7 @@ export interface StoreCreator {
     reducer: Reducer<S, A, PreloadedState>,
     preloadedState?: PreloadedState | undefined,
     enhancer?: StoreEnhancer<Ext>
-  ): Store<S, A, StateExt> & Ext
+  ): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
 }
 
 /**
@@ -223,7 +225,7 @@ export type StoreEnhancer<Ext extends {} = {}, StateExt extends {} = {}> = <
 ) => StoreEnhancerStoreCreator<NextExt & Ext, NextStateExt & StateExt>
 export type StoreEnhancerStoreCreator<
   Ext extends {} = {},
-  StateExt extends {} = {}
+  StateExt extends unknown = unknown
 > = <S, A extends Action, PreloadedState>(
   reducer: Reducer<S, A, PreloadedState>,
   preloadedState?: PreloadedState | undefined

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -225,7 +225,7 @@ export type StoreEnhancer<Ext extends {} = {}, StateExt extends {} = {}> = <
 ) => StoreEnhancerStoreCreator<NextExt & Ext, NextStateExt & StateExt>
 export type StoreEnhancerStoreCreator<
   Ext extends {} = {},
-  StateExt extends unknown = unknown
+  StateExt extends {} = {}
 > = <S, A extends Action, PreloadedState>(
   reducer: Reducer<S, A, PreloadedState>,
   preloadedState?: PreloadedState | undefined

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -61,6 +61,11 @@ const funcWithStore = (store: Store<State, DerivedAction>) => {}
 
 const store: Store<State> = createStore(reducer)
 
+// test that nullable state is preserved
+const nullableStore = createStore((): string | null => null)
+
+expectTypeOf(nullableStore.getState()).toEqualTypeOf<string | null>()
+
 // ensure that an array-based state works
 const arrayReducer = (state: any[] = []) => state || []
 const storeWithArrayState: Store<any[]> = createStore(arrayReducer)


### PR DESCRIPTION
---
name: :bug: Fix the return type of function `Store['getState']`
about: Unexpectedly narrowed type
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

This PR fixes a bug in the type definitions.

### Why should this PR be included?

#### What is the current behavior, and the steps to reproduce the issue?

The return type of function `Store['getState']` is unexpectedly narrowed to non-nullable.

```ts
import { type Reducer, createStore } from 'redux'

type NonNullableState = { count: number }
const nullableReducer: Reducer<NonNullableState | null> = () => null

const storeWithNullableState = createStore(nullableReducer)
const nullableState = storeWithNullableState.getState()
//    ^? const nullableState: NonNullableState
```

TS Playground: <https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzjAnmApnASugJgVwGN0oAaOQqdAQxnQGUZpMBfOAMyghDgHIqCAD14AoEagxwAchAB2U-ABtF1AEaKGMWpgC8iChHyyYALjiz8IVSTgsRhOQGd4F5Wo04CxKGc9ESADwy8koq6pracAA+5qEAfHB6ABQAlIkJropiDrLOcM7MAOrAMAAWCm7hjJF6lDR0jMxJme7oft4p9k4uoa3VdIn5TFTFZRVhGv3oAHQA5ugwU6kiAPQrcBtwAHoA-GJAA>

#### What is the expected behavior?

If `StateExt` type parameter is not provided, `Store['getState']` should return the untouched type `S`.

#### How does this PR fix the problem?

The problem is in this line:

https://github.com/reduxjs/redux/blob/7876f8e99ac041a6084c0495c5f4fbc1553dda30/src/types/store.ts#L114-L119

If `StateExt` is not given a specific value, the type will be `S & {}` which narrows the type to non-nullable.

The behavior of intersection with `{}` is changed in TypeScript 4.8, ["Improved Intersection Reduction, Union Compatibility, and Narrowing"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#improved-intersection-reduction-union-compatibility-and-narrowing).

In this PR:

- The default value of the type parameter `StateExt` in the `Store` interface is widened to `unknown`. This can ensure that `S & unknown` is still `S`.
- In other types for creating store, the type arguments `StateExt` passed to `Store` is widened using a utility type `UnknownIfNonSpecific`.

```ts
type UnknownIfNonSpecific<T> = {} extends T ? unknown : T
```

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - No.
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
