### PR TITLE
docs: update History of Redux with conference talk link

### DIFF
--- a/docs/understanding/history-and-design/history-of-redux.md
+++ b/docs/understanding/history-and-design/history-of-redux.md
@@ -22,7 +22,7 @@ Facebook announced this "Flux Architecture" concept around 2014, but didn't prov
 
 ## 2015: The Birth of Redux
 
-In mid-2015, Dan Abramov began building yet another Flux-inspired library, called Redux. The idea was to demonstrate "time-travel debugging" for a conference talk. The library was designed to use the Flux pattern, but with some functional programming principles applied. Rather than Store _instances_, you could use predictable reducer functions that did immutable updates. This would allow jumping back and forth in time to see how the state looked at various points. It would also make the code more straightforward, testable, and understandable.
+In mid-2015, Dan Abramov began building yet another Flux-inspired library, called Redux. The idea was to demonstrate "time-travel debugging" for a [conference talk](https://youtu.be/xsSnOQynTHs?t=601). The library was designed to use the Flux pattern, but with some functional programming principles applied. Rather than Store _instances_, you could use predictable reducer functions that did immutable updates. This would allow jumping back and forth in time to see how the state looked at various points. It would also make the code more straightforward, testable, and understandable.
 
 Redux came out in 2015, and quickly killed off all the other Flux-inspired libraries. It got early adoption from advanced developers in the React ecosystem, and by 2016, many people began to say that "if you're using React, you _must_ be using Redux too". (Frankly, this led to a lot of people using Redux in places they didn't _need_ to be using it!)
 


### PR DESCRIPTION
Hi @markerikson,

I came across your insightful comment on this Reddit post [^1] and wanted to thank you for sharing your knowledge! It was a valuable resource for me.

I believe adding a reference to Dan Abramov's conference talk in the documentation could further enrich the learning experience for users like myself who are interested in delving deeper.

[^1]: https://www.reddit.com/r/reactjs/comments/18tzuyt/redux_what_problems_does_it_solve/

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Understanding Redux > History and Design
- **Page**: The History of Redux

## For Updating Existing Content

### What updates should be made to the page?

Add a link to Dan Abramov's demonstration for the Flux pattern at react-europe 2015.

### Do these updates change any of the assumptions or target audience? If so, how do they change?

No.