### PR TITLE
fix: typo in usage doc

### DIFF
--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -575,7 +575,7 @@ const fetchUserById = createAsyncThunk(
 const lastReturnedAction = await store.dispatch(fetchUserById(3))
 ```
 
-If you need to modify the types of the `thunkApi` parameter, such as supplying the type of the `state` returned by `getState()`, you must supply the first two generic arguments for return type and payload argument, plus whicher "thunkApi argument fields" are relevant in an object:
+If you need to modify the types of the `thunkApi` parameter, such as supplying the type of the `state` returned by `getState()`, you must supply the first two generic arguments for return type and payload argument, plus whichever "thunkApi argument fields" are relevant in an object:
 
 ```ts
 const fetchUserById = createAsyncThunk<

--- a/docs/usage/WritingCustomMiddleware.md
+++ b/docs/usage/WritingCustomMiddleware.md
@@ -114,7 +114,7 @@ In the first part, it listens to `addListener`, `clearAllListeners` and `removeL
 
 In the second part, the code mainly calculates the state after passing the action through the other middlewares and the reducer, and then passes both the original state as well as the new state coming from the reducer to the listeners.
 
-It is common to have side effects after dispatching th eaction, because this allows taking into account both the original and the new state, and because the interaction coming from the side effects shouldn't influence the current action execution anyways (otherwise, it wouldn't be a side effect).
+It is common to have side effects after dispatching the action, because this allows taking into account both the original and the new state, and because the interaction coming from the side effects shouldn't influence the current action execution anyways (otherwise, it wouldn't be a side effect).
 
 ### Modify or cancel actions, or modify the input accepted by dispatch
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - no
- [ ] Have the files been linted and formatted?
  - yes  

## What docs page needs to be fixed?
 
- **Page**: Usage with TypeScript (**Section**: Typing `createAsyncThunk`) 
- **Page**: Writing Custom Middleware (**Section**: Create side effects for actions)

## What is the problem?
Misspelled word `whicher`
Misplaced space `th eaction`

## What changes does this PR make to fix the problem?
Changes `whicher` to `whichever`
Changes `th eaction` to `the action`
