### PR TITLE
Update link for Redux Middleware Tutorial - Fix #4647

### DIFF
--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -158,7 +158,7 @@ _Explanations and examples of how middleware work and how to write them_
   Understanding middlewares through a series of small experiments
 
 - **Redux Middleware Tutorial** <br/>
-  https://www.pshrmn.com/tutorials/react/redux-middleware/ <br/>
+  https://github.com/pshrmn/notes/blob/master/redux/redux-middleware.md <br/>
   An overview of what middleware is, how `applyMiddleware` works, and how to write middleware.
 
 - **ReactCasts #6: Redux Middleware** <br/>


### PR DESCRIPTION
---
name: Update link for Redux Middleware Tutorial
about: Fixing a broken link

## Checklist

- [x] Is there an existing issue for this PR?
  - #4647
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Learning Resources
- **Page**: https://redux.js.org/introduction/learning-resources#middleware

## What is the problem?

The resource for Redux Middleware Tutorial is pointing to a broken link.

## What changes does this PR make to fix the problem?

The original link has been replaced with a GitHub repository containing notes authored by the original writer of the article. This new link provides access to the same content that was initially available on the author's blog.
