### PR TITLE
[DOCS] replace root reducer with persisted reducer

### DIFF
--- a/docs/usage/migrating-to-modern-redux.mdx
+++ b/docs/usage/migrating-to-modern-redux.mdx
@@ -169,8 +169,8 @@ const persistConfig = {
 const persistedReducer = persistReducer(persistConfig, rootReducer)
 
 const store = configureStore({
-  // Can create a root reducer separately and pass that in
-  reducer: rootReducer,
+  // Pass previously created persisted reducer
+  reducer: persistedReducer,
   middleware: getDefaultMiddleware => {
     const middleware = getDefaultMiddleware({
       // Pass in a custom `extra` argument to the thunk middleware


### PR DESCRIPTION
---
Documentation Fix
Fixing a problem in an existing docs page
---

## What docs page needs to be fixed?

- **Migrations: Migrating to Modern Redux (https://redux.js.org/usage/migrating-to-modern-redux)**:
- **Store Setup with configureStore (https://redux.js.org/usage/migrating-to-modern-redux#store-setup-with-configurestore)**:

## What is the problem?

At the end of the section "Store Setup with configureStore" the "Detailed Example: Custom Store Setup with Persistence and Middleware" example is given which uses Redux-Persist library. In the example configureStore's reducer is provided with rootReducer which is ambiguous due to the fact that persistor will be typically created after based on the created store. However, for example, when the persistor will be given to the PersistGate component, the app won't work as expected.

## What changes does this PR make to fix the problem?

The code in the PR changes rootReducer in the configureStore to be persistedReducer
