### PR TITLE
Fix Redux logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href='https://redux.js.org'><img src='https://camo.githubusercontent.com/f28b5bc7822f1b7bb28a96d8d09e7d79169248fc/687474703a2f2f692e696d6775722e636f6d2f4a65567164514d2e706e67' height='60' alt='Redux Logo' aria-label='redux.js.org' /></a>
+# <a href='https://redux.js.org'><img src='https://avatars.githubusercontent.com/u/13142323?s=200&v=4' height='60' alt='Redux Logo' aria-label='redux.js.org' /></a>
 
 Redux is a predictable state container for JavaScript apps.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href='https://redux.js.org'><img src='https://avatars.githubusercontent.com/u/13142323?s=200&v=4' height='60' alt='Redux Logo' aria-label='redux.js.org' /></a>
+# <a href='https://redux.js.org'><img src='https://avatars.githubusercontent.com/u/13142323?s=200&v=4' height='60' alt='Redux Logo' aria-label='redux.js.org' />Redux</a> 
 
 Redux is a predictable state container for JavaScript apps.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href='https://redux.js.org'><img src='https://avatars.githubusercontent.com/u/13142323?s=200&v=4' height='60' alt='Redux Logo' aria-label='redux.js.org' />Redux</a> 
+# <a href='https://redux.js.org'><img src='https://avatars.githubusercontent.com/u/13142323?s=200&v=4' height='60' alt='Redux Logo' aria-label='redux.js.org' style="display: flex;align-items: center;"/>Redux</a> 
 
 Redux is a predictable state container for JavaScript apps.
 


### PR DESCRIPTION
The old logo used some GitHub token system that expired and the logo disappeared.