### PR TITLE
Closes #4672 Update combineReducers.md

### DIFF
--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -117,7 +117,7 @@ export default function counter(state = 0, action) {
 #### `reducers/index.js`
 
 ```js
-import { combineReducers } from 'redux'
+import { combineReducers } from '@reduxjs/toolkit'
 import todos from './todos'
 import counter from './counter'
 
@@ -130,10 +130,13 @@ export default combineReducers({
 #### `App.js`
 
 ```js
-import { createStore } from 'redux'
+import { configureStore } from '@reduxjs/toolkit' 
 import reducer from './reducers/index'
 
-const store = createStore(reducer)
+const store = configureStore({
+  reducer
+  // ...ConfigureStoreOptions ref: https://redux-toolkit.js.org/api/configureStore
+})
 console.log(store.getState())
 // {
 //   counter: 0,

--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -135,7 +135,6 @@ import reducer from './reducers/index'
 
 const store = configureStore({
   reducer
-  // ...ConfigureStoreOptions ref: https://redux-toolkit.js.org/api/configureStore
 })
 console.log(store.getState())
 // {


### PR DESCRIPTION
The Docs for Redux, in many places, cite moving to configureStore. Though `createStore` is still available, it is also marked as deprecated. This doc may need to update to reflect modern recommendations.

---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

**Does this PR add a _new_ page, or update an _existing_ page?**
update an _existing_ page
## Checklist

- [x] Is there an existing issue for this PR?
  - #4672 
- [ ] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**:
- **Page**:
https://redux.js.org/api/combinereducers

at anchor https://redux.js.org/api/combinereducers#appjs
code example


## For Updating Existing Content

### What updates should be made to the page?
lower adopter/developer confusion on the approach to Redux. 

### Do these updates change any of the assumptions or target audience? If so, how do they change?
This update makes a huge assumption in blending of the lines of ownership/documents of use and responsibilities between Redux and @reduxjs/toolkit