### PR TITLE
Update TypeScript to 5.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['18.x']
-        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3']
+        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.6",
     "tsup": "7.0.0",
-    "typescript": "5.2",
+    "typescript": "^5.4.2",
     "vitest": "^1.2.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5599,7 +5599,7 @@ __metadata:
     rimraf: ^3.0.2
     rxjs: ^7.5.6
     tsup: 7.0.0
-    typescript: 5.2
+    typescript: ^5.4.2
     vitest: ^1.2.1
   languageName: unknown
   linkType: soft
@@ -6450,23 +6450,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:^5.4.2":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: 96d80fde25a09bcb04d399082fb27a808a9e17c2111e43849d2aafbd642d835e4f4ef0de09b0ba795ec2a700be6c4c2c3f62bf4660c05404c948727b5bbfb32a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=1f5320"
+"typescript@patch:typescript@^5.4.2#~builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  checksum: c1b669146bca5529873aae60870e243fa8140c85f57ca32c42f898f586d73ce4a6b4f6bb02ae312729e214d7f5859a0c70da3e527a116fdf5ad00c9fc733ecc6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### This PR:

  - [X] Bumps TypeScript version to 5.4.
  - [X] Adds TypeScript 5.4 to TypeScript versions to test against during CI. 