### PR TITLE
Fix webpack 4 support by setting `target: es2017` for `redux.legacy-esm.js`

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,6 @@ import { defineConfig } from 'tsup'
 import * as babel from '@babel/core'
 import type { Plugin } from 'esbuild'
 import { getBuildExtensions } from 'esbuild-extra'
-import fs from 'fs'
 
 // Extract error strings, replace them with error codes, and write messages to a file
 const mangleErrorsTransform: Plugin = {
@@ -44,11 +43,16 @@ export default defineConfig(options => {
       format: ['esm'],
       outExtension: () => ({ js: '.mjs' }), // Add dts: '.d.ts' when egoist/tsup#1053 lands
       dts: true,
-      clean: true,
-      async onSuccess() {
-        // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
-        fs.copyFileSync('dist/redux.mjs', 'dist/redux.legacy-esm.js')
-      }
+      clean: true
+    },
+    // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+    {
+      ...commonOptions,
+      format: ['esm'],
+      target: 'es2017',
+      dts: false,
+      outExtension: () => ({ js: '.js' }),
+      entry: { 'redux.legacy-esm': 'src/index.ts' }
     },
     // Browser-ready ESM, production + minified
     {


### PR DESCRIPTION
## This PR:

  - [X] Fixes webpack 4 support by setting `target: es2017` for `redux.legacy-esm.js` which is related to https://github.com/reduxjs/redux-toolkit/issues/4282.