### PR TITLE
TypeScript Quick Start Tutorial snippet change

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -44,7 +44,7 @@ Since those are types, it's safe to export them directly from your store setup f
 import { configureStore } from '@reduxjs/toolkit'
 // ...
 
-const store = configureStore({
+export const store = configureStore({
   reducer: {
     posts: postsReducer,
     comments: commentsReducer,


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials
- **Page**: TypeScript Quick Start

## What is the problem?

The `app/store.ts` code snippet in the TypeScript Quick Start Tutorial should be updated to include the export keyword for the store constant, as demonstrated in the full example hosted in CodeSandbox within the same page and the snippet for the same file shown in the [`Code Quality > Usage with TypeScript > Define Root State and Dispatch Types`](https://github.com/reduxjs/redux/blob/master/docs/usage/UsageWithTypescript.md#define-root-state-and-dispatch-types) page.

## What changes does this PR make to fix the problem?

This PR adds the export keyword to the store constant declaration in the `app/store.ts` file snippet, aligning with the implementation in the CodeSandbox example and other docs.
