### PR TITLE
Add a note to ignore `@typescript-eslint/ban-types` rule when typing middlewares

### DIFF
--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -280,6 +280,12 @@ export const exampleMiddleware: Middleware<
 }
 ```
 
+:::caution
+
+If you are using `typescript-eslint`, the `@typescript-eslint/ban-types` rule might report an error if you use `{}` for the dispatch value. The recommended changes it makes are incorrect and will break your Redux store types, you should disable the rule for this line and keep using `{}`.
+
+:::
+
 The dispatch generic should likely only be needed if you are dispatching additional thunks within the middleware.
 
 In cases where `type RootState = ReturnType<typeof store.getState>` is used, a [circular type reference between the middleware and store definitions](https://github.com/reduxjs/redux/issues/4267) can be avoided by switching the type definition of `RootState` to:


### PR DESCRIPTION
## PR Type

Update an existing page

## Checklist

- [x] Is there an existing issue for this PR?
  - Not an issue, but a discussion: https://github.com/reduxjs/redux-toolkit/discussions/4312
- [x] Have the files been linted and formatted?

## What docs page is being added or updated?

- **Section**: Using Redux
- **Page**: Usage with Typescript

## For Updating Existing Content

### What updates should be made to the page?

This adds a warning to the docs because a very commonly used ESLint rule (`@typescript-eslint/ban-types`) will recommend switching the `{}` dispatch argument for `Middleware` to something else `(like `Record<string, never>`), which will then break the store's types. As per the discussion linked above, the rule should be ignored for this line and you *need* to use `{}` here.

### Do these updates change any of the assumptions or target audience? If so, how do they change?

This might add an information not useful to some readers, but this page is for Typescript users, and typing middlewares is not very common, so the audience for this part should already be targeted, and there is a high probability of them using `typescript-eslint`