### PR TITLE
Updated broken links to the Flux documentation

### DIFF
--- a/docs/understanding/history-and-design/PriorArt.md
+++ b/docs/understanding/history-and-design/PriorArt.md
@@ -16,12 +16,12 @@ Dan talked about some of his intent and approach in [Changelog episode 187](http
 
 ## Influences
 
-Redux evolves the ideas of [Flux](https://facebook.github.io/flux/), but avoids its complexity by taking cues from [Elm](https://github.com/evancz/elm-architecture-tutorial/).
+Redux evolves the ideas of [Flux](https://facebookarchive.github.io/flux/), but avoids its complexity by taking cues from [Elm](https://github.com/evancz/elm-architecture-tutorial/).
 Even if you haven't used Flux or Elm, Redux only takes a few minutes to get started with.
 
 ### Flux
 
-Redux was inspired by several important qualities of [Flux](https://facebook.github.io/flux/). Like Flux, Redux prescribes that you concentrate your model update logic in a certain layer of your application (“stores” in Flux, “reducers” in Redux). Instead of letting the application code directly mutate the data, both tell you to describe every mutation as a plain object called an “action”.
+Redux was inspired by several important qualities of [Flux](https://facebookarchive.github.io/flux/). Like Flux, Redux prescribes that you concentrate your model update logic in a certain layer of your application (“stores” in Flux, “reducers” in Redux). Instead of letting the application code directly mutate the data, both tell you to describe every mutation as a plain object called an “action”.
 
 Unlike Flux, **Redux does not have the concept of a Dispatcher**. This is because it relies on pure functions instead of event emitters, and pure functions are easy to compose and don't need an additional entity managing them. Depending on how you view Flux, you may see this as either a deviation or an implementation detail. Flux has often been [described as `(state, action) => state`](https://speakerdeck.com/jmorrell/jsconf-uy-flux-those-who-forget-the-past-dot-dot-dot-1). In this sense, Redux is true to the Flux architecture, but makes it simpler thanks to pure functions.
 


### PR DESCRIPTION
---
name: :book: New/Updated Documentation Content
about: Adding a new docs page, or updating content in an existing docs page
---

## PR Type

Update an existing page: [Understanding Redux > History and Design > Prior Art](https://redux.js.org/understanding/history-and-design/prior-art)

## Checklist

- [x] Is there an existing issue for this PR?
  - No
- [x] Have the files been linted and formatted?
  - Yes

## What docs page is being added or updated?

- **Section**: Understanding Redux
- **Page**: Prior Art

### What updates should be made to the page?

The [original Flux repository](https://github.com/facebookarchive/flux) was archived in March 2023 and has been moved to the [Meta Archive](http://github.com/facebookarchive) organization. This breaks the links to the Flux documentation. This PR  updates them to the corrected links.

### Do these updates change any of the assumptions or target audience? If so, how do they change?

No