### PR TITLE
chore: updated docs to remove extra heading tag

### DIFF
--- a/docs/tutorials/fundamentals/part-1-overview.md
+++ b/docs/tutorials/fundamentals/part-1-overview.md
@@ -10,8 +10,6 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 <!-- prettier-ignore -->
 import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
 
-# Redux Fundamentals, Part 1: Redux Overview
-
 :::tip What You'll Learn
 
 - What Redux is and why you might want to use it

--- a/docs/tutorials/fundamentals/part-2-concepts-data-flow.md
+++ b/docs/tutorials/fundamentals/part-2-concepts-data-flow.md
@@ -10,8 +10,6 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 <!-- prettier-ignore -->
 import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
 
-# Redux Fundamentals, Part 2: Concepts and Data Flow
-
 :::tip What You'll Learn
 
 - Key terms and concepts for using Redux

--- a/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
+++ b/docs/tutorials/fundamentals/part-3-state-actions-reducers.md
@@ -10,8 +10,6 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 <!-- prettier-ignore -->
 import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
 
-# Redux Fundamentals, Part 3: State, Actions, and Reducers
-
 :::tip What You'll Learn
 
 - How to define state values that contain your app's data

--- a/docs/tutorials/fundamentals/part-4-store.md
+++ b/docs/tutorials/fundamentals/part-4-store.md
@@ -10,8 +10,6 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 <!-- prettier-ignore -->
 import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
 
-# Redux Fundamentals, Part 4: Store
-
 :::tip What You'll Learn
 
 - How to create a Redux store

--- a/docs/tutorials/fundamentals/part-5-ui-and-react.md
+++ b/docs/tutorials/fundamentals/part-5-ui-and-react.md
@@ -7,8 +7,6 @@ description: 'The official Redux Fundamentals tutorial: learn how to use Redux w
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
-# Redux Fundamentals, Part 5: UI and React
-
 :::tip What You'll Learn
 
 - How a Redux store works with a UI

--- a/docs/tutorials/fundamentals/part-6-async-logic.md
+++ b/docs/tutorials/fundamentals/part-6-async-logic.md
@@ -8,8 +8,6 @@ description: 'The official Redux Fundamentals tutorial: learn how to use async l
 <!-- prettier-ignore -->
 import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
 
-# Redux Fundamentals, Part 6: Async Logic and Data Fetching
-
 :::tip What You'll Learn
 
 - How the Redux data flow works with async data

--- a/docs/tutorials/fundamentals/part-7-standard-patterns.md
+++ b/docs/tutorials/fundamentals/part-7-standard-patterns.md
@@ -10,8 +10,6 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 <!-- prettier-ignore -->
 import FundamentalsWarning from "../../components/_FundamentalsWarning.mdx";
 
-# Redux Fundamentals, Part 7: Standard Redux Patterns
-
 :::tip What You'll Learn
 
 - Standard patterns used in real-world Redux apps, and why those patterns exist:

--- a/docs/tutorials/fundamentals/part-8-modern-redux.md
+++ b/docs/tutorials/fundamentals/part-8-modern-redux.md
@@ -7,8 +7,6 @@ description: 'The official Fundamentals tutorial for Redux: learn the modern way
 
 import { DetailedExplanation } from '../../components/DetailedExplanation'
 
-# Redux Fundamentals, Part 8: Modern Redux with Redux Toolkit
-
 :::tip What You'll Learn
 
 - How to simplify your Redux logic using Redux Toolkit


### PR DESCRIPTION

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Fundamentals
- **Page**: All 8 pages

## What is the problem?
We are using docusaurus for the docs and it will automatically add a header tag from the `title` attribute. So there is no need to add a redundant `h1` tag containing the same title. Currently in the [docs here ](https://redux.js.org/tutorials/fundamentals/part-1-overview) it will display 2 titles with same text which is not a good user experience.

<img width="836" alt="image" src="https://github.com/reduxjs/redux/assets/49767636/6f4585ad-d1ab-41a5-a52a-22baea1f5a98">

<img width="779" alt="image" src="https://github.com/reduxjs/redux/assets/49767636/7c956b40-dd99-4452-9995-59b486aa0bb2">

## What changes does this PR make to fix the problem?
I have removed the extra `h1` tag and now we leave it to docusaurus to render the page's title. This is how it has been done 
on the sections i.e. [Redux Essentials](https://redux.js.org/tutorials/essentials/part-1-overview-concepts)