### PR TITLE
fix: react renderToString docs link

### DIFF
--- a/docs/usage/ServerRendering.md
+++ b/docs/usage/ServerRendering.md
@@ -78,7 +78,7 @@ The first thing that we need to do on every request is to create a new Redux sto
 
 When rendering, we will wrap `<App />`, our root component, inside a `<Provider>` to make the store available to all components in the component tree, as we saw in ["Redux Fundamentals" Part 5: UI and React](../tutorials/fundamentals/part-5-ui-and-react.md).
 
-The key step in server side rendering is to render the initial HTML of our component _**before**_ we send it to the client side. To do this, we use [ReactDOMServer.renderToString()](https://facebook.github.io/react/docs/react-dom-server.html#rendertostring).
+The key step in server side rendering is to render the initial HTML of our component _**before**_ we send it to the client side. To do this, we use [ReactDOMServer.renderToString()](https://react.dev/reference/react-dom/server/renderToString).
 
 We then get the initial state from our Redux store using [`store.getState()`](../api/Store.md#getState). We will see how this is passed along in our `renderFullPage` function.
 


### PR DESCRIPTION
## Checklist

- [ ] Is there an existing issue for this PR?

- [x] Have the files been linted and formatted?

## What docs page needs to be fixed?
- **Section**
Using Redux -> Setup and Organization 
- **Page**:
Server Rendering

## What is the problem?

The link was incorrect and leads to a blank page

## What changes does this PR make to fix the problem?

I have inserted an up-to-date link to the react documentation