### PR TITLE
Run CI jobs if `yarn.lock` changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
               - 'test/**'
               - '.github/**/*.yaml'
               - 'tsup.config.ts'
+              - 'yarn.lock'
 
   build:
     needs: changes


### PR DESCRIPTION
## This PR:

  - [X] Enables CI jobs for when `yarn.lock` changes.