### PR TITLE
fix(types): getState is not bound to MiddlewareAPI

### DIFF
--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -2,7 +2,7 @@ import type { Dispatch } from './store'
 
 export interface MiddlewareAPI<D extends Dispatch = Dispatch, S = any> {
   dispatch: D
-  getState(this: void): S
+  getState: () => S
 }
 
 /**

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -2,7 +2,7 @@ import type { Dispatch } from './store'
 
 export interface MiddlewareAPI<D extends Dispatch = Dispatch, S = any> {
   dispatch: D
-  getState(): S
+  getState(this: void): S
 }
 
 /**

--- a/test/typescript/middleware.test-d.ts
+++ b/test/typescript/middleware.test-d.ts
@@ -89,6 +89,18 @@ describe('type tests', () => {
     }
   })
 
+  test('middleware has unbound getState function.', () => {
+    type State = { field: 'string' }
+
+    const customMiddleware: Middleware<{}, State> = api => next => action => {
+      const { getState } = api
+
+      expectTypeOf(getState).thisParameter.toEqualTypeOf()
+
+      return next(action)
+    }
+  })
+
   test('middleware that expects custom dispatch.', () => {
     type MyAction = { type: 'INCREMENT' } | { type: 'DECREMENT' }
 

--- a/test/typescript/middleware.test-d.ts
+++ b/test/typescript/middleware.test-d.ts
@@ -89,18 +89,6 @@ describe('type tests', () => {
     }
   })
 
-  test('middleware has unbound getState function.', () => {
-    type State = { field: 'string' }
-
-    const customMiddleware: Middleware<{}, State> = api => next => action => {
-      const { getState } = api
-
-      expectTypeOf(getState).thisParameter.toEqualTypeOf()
-
-      return next(action)
-    }
-  })
-
   test('middleware that expects custom dispatch.', () => {
     type MyAction = { type: 'INCREMENT' } | { type: 'DECREMENT' }
 


### PR DESCRIPTION
## PR Type

### Does this PR add a new _feature_, or fix a _bug_?

Fixes a type bug

### Why should this PR be included?

The `getState` function provided by `MiddlewareAPI` is not bound to any object, and as such it can be used freely as in the examples.

The `MiddlewareAPI` type does not make this explicit, and typescript linters can report this as problematic usage.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
  - there's a file that needs formatting, but is outside the scope of my change: `docs/usage/deriving-data-selectors.md`
- [x] Have the docs been updated to match the changes in the PR?
  - No updates needed IMO
- [x] Have the tests been updated to match the changes in the PR?
  - No new tests added - the linting rules required to 
- [x] Have you run the tests locally to confirm they pass?


## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?

- Enable the [@typescript-eslint/unbound-method](https://typescript-eslint.io/rules/unbound-method/) linting rule
- Load up one of the examples
  ```ts
  const middleware: Middleware<unknown, unknown> =
    ({ getState }) =>
    (next) =>
    (action) => {
      // ...
    };
  ```
- The linter will report that the rule is being violated

### What is the expected behavior?

`getState` can be used with the linting rule enabled and not produce errors

### How does this PR fix the problem?

Fixes the signature of `getState` 