### PR TITLE
docs: fix typo

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -568,7 +568,7 @@ const postsSlice = createSlice({
   // highlight-end
 })
 
-export const { postAdded, postUpdated } = postsSlice.selectors
+export const { selectAllPosts, selectPostById } = postsSlice.selectors
 
 export default postsSlice.reducer
 


### PR DESCRIPTION
We get "selectAllPosts" and "selectPostById" as a result of destructuring "postsSlice.selectors" field.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
