### PR TITLE
fix(docs): correct grammar in part-2-app-structure tutorial regarding…

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -606,7 +606,7 @@ If you're curious _why_ we use thunks for async logic, see this deeper explanati
 
 We know that we're not allowed to put any kind of async logic in reducers. But, that logic has to live somewhere.
 
-If we have access to the Redux store, we could write some async code and call `store.dispatch()` when we're done:
+If we had access to the Redux store, we could write some async code and call `store.dispatch()` when we're done:
 
 ```js
 const store = configureStore({ reducer: counterReducer })


### PR DESCRIPTION
… Redux store access

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [] Is there an existing issue for this PR?
  - _link issue here_
- [] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials, Part 2
- **Page**: https://redux.js.org/tutorials/essentials/part-2-app-structure

## What is the problem?

The sentence "If we have access to the Redux store, we could write some async code and call store.dispatch() when we're done" contains a grammatical inconsistency. It mixes present tense ("have") with a conditional phrase ("could"). This implies that access to the Redux store is hypothetical, but the grammar does not reflect this.

## What changes does this PR make to fix the problem?

The sentence has been changed to: "If we had access to the Redux store, we could write some async code and call store.dispatch() when we're done."

This change aligns the tense and better reflects the hypothetical scenario.
