### PR TITLE
fix(docs): remove duplicate reduxBatch

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -216,8 +216,7 @@ const store = configureStore({
   reducer,
   enhancers: existingEnhancersArray => [
     reduxBatch,
-    ...existingEnhancersArray,
-    reduxBatch
+    ...existingEnhancersArray
   ]
 })
 store.dispatch([{ type: 'INCREMENT' }, { type: 'INCREMENT' }])


### PR DESCRIPTION
In https://redux.js.org/introduction/ecosystem#batching I notice that there is a duplicate reduxBatch in the enhancers 

- [:memo: Documentation Fix](?template=documentation-edit.md)
