### PR TITLE
Docs: Update part-6-performance-normalization.md

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -137,11 +137,11 @@ As we've seen before, we can take data from one `useSelector` call, or from prop
 As usual, we will add routes for these components in `<App>`:
 
 ```tsx title="App.tsx"
-          <Route path="/posts/:postId" element={SinglePostPage} />
-          <Route path="/editPost/:postId" element={EditPostForm} />
+          <Route path="/posts/:postId" element={<SinglePostPage />} />
+          <Route path="/editPost/:postId" element={<EditPostForm />} />
           // highlight-start
-          <Route path="/users" element={UsersList} />
-          <Route path="/users/:userId" element={UserPage} />
+          <Route path="/users" element={<UsersList />} />
+          <Route path="/users/:userId" element={<UserPage />} />
           // highlight-end
           <Redirect to="/" />
 ```

--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -137,11 +137,11 @@ As we've seen before, we can take data from one `useSelector` call, or from prop
 As usual, we will add routes for these components in `<App>`:
 
 ```tsx title="App.tsx"
-          <Route path="/posts/:postId" component={SinglePostPage} />
-          <Route path="/editPost/:postId" component={EditPostForm} />
+          <Route path="/posts/:postId" element={SinglePostPage} />
+          <Route path="/editPost/:postId" element={EditPostForm} />
           // highlight-start
-          <Route path="/users" component={UsersList} />
-          <Route path="/users/:userId" component={UserPage} />
+          <Route path="/users" element={UsersList} />
+          <Route path="/users/:userId" element={UserPage} />
           // highlight-end
           <Redirect to="/" />
 ```


### PR DESCRIPTION
Fixed typo in router

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [X] Is there an existing issue for this PR? No
- [X] Have the files been linted and formatted? Yes

## What docs page needs to be fixed?

- **Section**:  #adding-user-pages
- **Page**: https://redux.js.org/tutorials/essentials/part-6-performance-normalization

## What is the problem?
React router dom, strictly use **element** attribute since v6  instead of **component**

