### PR TITLE
Fix typo in documentation: redux essentials

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -957,7 +957,7 @@ const initialReactions: Reactions = {
 }
 // highlight-end
 
-const initialState: Posts[] = [
+const initialState: Post[] = [
   // omit initial state
 ]
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**: Part 4: Using Redux Data

## What is the problem?
`initialState` is an array of `Post`(defined in the same code block) not `Posts`

## What changes does this PR make to fix the problem?
Reference the correct type name
