### PR TITLE
Add Debugging Redux page to documentation

### DIFF
--- a/docs/usage/DebuggingRedux.md
+++ b/docs/usage/DebuggingRedux.md
@@ -1,0 +1,51 @@
+---
+id: debugging-redux
+title: Debugging Redux
+sidebar_label: Debugging Redux
+---
+
+# Debugging Redux
+
+## Tracing Actions
+
+When debugging Redux applications, it's essential to understand the flow of actions and how they affect the state. Tracing actions involves following the sequence of dispatched actions and observing how each action updates the state. This process helps identify issues and understand the application's behavior.
+
+### Steps to Trace Actions
+
+1. **Identify the Action**: Determine which action is causing the issue or needs to be traced.
+2. **Dispatch the Action**: Trigger the action by interacting with the application (e.g., clicking a button).
+3. **Observe State Changes**: Use tools like Redux DevTools to monitor state changes and see how the action affects the state.
+
+## Using Redux DevTools
+
+Redux DevTools is a powerful tool that helps developers debug Redux applications. It provides a visual interface to inspect actions, state changes, and the overall state tree. Redux DevTools can be used as a browser extension or integrated into the application.
+
+### Features of Redux DevTools
+
+- **Action Log**: View a list of dispatched actions and their payloads.
+- **State Tree**: Inspect the current state of the application.
+- **Time Travel**: Rewind and replay actions to see how the state changes over time.
+- **Diff View**: Compare the state before and after an action is dispatched.
+
+### Installing Redux DevTools
+
+To use Redux DevTools, you need to install the browser extension or integrate it into your application. Follow the instructions on the [Redux DevTools GitHub page](https://github.com/reduxjs/redux-devtools) to get started.
+
+## Using Replay
+
+Replay is a tool that allows developers to record and replay user interactions in a Redux application. It helps identify issues by capturing the exact sequence of actions and state changes that led to a problem. Replay can be particularly useful for debugging complex applications with intricate state management.
+
+### Steps to Use Replay
+
+1. **Record a Session**: Start recording a session by enabling Replay in your application.
+2. **Perform Actions**: Interact with the application to reproduce the issue.
+3. **Stop Recording**: Stop the recording once the issue has been captured.
+4. **Replay the Session**: Use the recorded session to replay the actions and observe the state changes.
+
+## Additional Resources
+
+- [Debugging JavaScript](https://www.youtube.com/watch?v=3pXVHRT-amw): A talk by Mark Erikson on debugging JavaScript applications, including Redux.
+- [Redux DevTools Documentation](https://github.com/reduxjs/redux-devtools): Official documentation for Redux DevTools.
+- [Replay Documentation](https://replay.io/docs): Official documentation for Replay.
+
+By following these guidelines and using the tools mentioned, you can effectively debug Redux applications and gain a deeper understanding of their behavior.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -39,3 +39,4 @@ This section provides information about typical Redux patterns and approaches fo
 - [Reducing Boilerplate](ReducingBoilerplate.md)
 - [Deriving Data with Selectors](../usage/deriving-data-selectors.md)
 - [Implementing Undo History](ImplementingUndoHistory.md)
+- [Debugging Redux](DebuggingRedux.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -105,7 +105,8 @@ module.exports = {
           'usage/writing-logic-thunks',
           'usage/side-effects-approaches',
           'usage/writing-custom-middleware',
-          'usage/implementing-undo-history'
+          'usage/implementing-undo-history',
+          'usage/debugging-redux'
         ]
       }
     ],


### PR DESCRIPTION
Related to #4711

Add a "Debugging Redux" page to the documentation.

* **New Page**: Add `docs/usage/DebuggingRedux.md` with sections on tracing actions, using Redux DevTools, and using Replay. Include links to the "Debugging JS" talk and other relevant resources.
* **Index Update**: Modify `docs/usage/index.md` to include a link to the new "Debugging Redux" page.
* **Sidebar Update**: Update `website/sidebars.js` to add an entry for the new "Debugging Redux" page in the sidebar configuration.

