### PR TITLE
exclude menu and TOC items from the visited link styles for better UX

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -137,7 +137,7 @@ a.contents__link.contents__link--active {
   font-weight: 600;
 }
 
-a:visited {
+a:visited:not(.menu__link, .table-of-contents__link) {
   color: var(--ifm-color-primary);
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -137,7 +137,7 @@ a.contents__link.contents__link--active {
   font-weight: 600;
 }
 
-a:visited:not(.menu__link, .table-of-contents__link) {
+a:visited:not(.menu__link, .table-of-contents__link, .navbar__link:not([target="_blank"])) {
   color: var(--ifm-color-primary);
 }
 


### PR DESCRIPTION
for better UX, menu and TOC items style should indicate only one thing, which is the current read item

When you click on an item and then scroll to another .... notice: the prev item still having the same style as the current one.

![image](https://github.com/user-attachments/assets/bd557c0a-3784-4cbe-bf26-b07f154eaa23)
 
