### PR TITLE
Fix issue with `combineReducer` returning incorrect type when given a custom action

### DIFF
--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -106,7 +106,7 @@ export type PreloadedStateShapeFromReducersMapObject<M> = M[keyof M] extends
   ? {
       [P in keyof M]: M[P] extends (
         inputState: infer InputState,
-        action: UnknownAction
+        action: ActionFromReducersMapObject<M>
       ) => any
         ? InputState
         : never

--- a/test/typescript/reducers.test-d.ts
+++ b/test/typescript/reducers.test-d.ts
@@ -1,4 +1,10 @@
-import type { Action, AnyAction, Reducer, ReducersMapObject } from 'redux'
+import type {
+  Action,
+  AnyAction,
+  PreloadedStateShapeFromReducersMapObject,
+  Reducer,
+  ReducersMapObject
+} from 'redux'
 import { combineReducers } from 'redux'
 
 describe('type tests', () => {
@@ -264,5 +270,31 @@ describe('type tests', () => {
         [undefined, 'not-an-action']
       >()
     }
+  })
+
+  test('`PreloadedStateShapeFromReducersMapObject` has correct type when given a custom action', () => {
+    type MyAction = { type: 'foo' }
+
+    // TODO: not sure how to write this test??
+    // Expect this to match type `{ nested: string | undefined; }`
+    type P = PreloadedStateShapeFromReducersMapObject<{
+      nested: Reducer<string, MyAction>
+    }>
+  })
+
+  test('`combineReducer` has correct return type when given a custom action', () => {
+    type MyAction = { type: 'foo' }
+
+    type State = string
+    const nested: Reducer<State, MyAction> = (state = 'foo') => state
+
+    type Combined = { nested: State }
+
+    // Expect no error
+    const combined: Reducer<
+      Combined,
+      MyAction,
+      Partial<Combined>
+    > = combineReducers({ nested })
   })
 })

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "target": "ESnext",
     "types": ["vitest/globals", "vitest/importMeta"]
   },


### PR DESCRIPTION
Fixes https://github.com/reduxjs/redux/issues/4764. See issue for details.

Note I had to enable `exactOptionalPropertyTypes` to reproduce the bug in the test.