### PR TITLE
Fix the link referencing React Router docs

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -20,7 +20,7 @@ import { DetailedExplanation } from '../../components/DetailedExplanation'
 :::info Prerequisites
 
 - Understanding the [Redux data flow and React-Redux APIs from Part 3](./part-3-data-flow.md)
-- Familiarity with [the React Router `<Link>` and `<Route>` components for page routing](https://reactrouter.com/start/overview)
+- Familiarity with [the React Router `<Link>` and `<Route>` components for page routing](https://reactrouter.com/start/library/routing)
 
 :::
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

fix #4770 

## Checklist

- [X] Is there an existing issue for this PR?
  - [issue link](https://github.com/reduxjs/redux/issues/4770)
- [X] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Redux Essentials, Part 4: Using Redux Data

## What is the problem?
The link is broken.

## What changes does this PR make to fix the problem?
References an updated link.