### PR TITLE
Replacing map with filter in an example

### DIFF
--- a/docs/usage/deriving-data-selectors.md
+++ b/docs/usage/deriving-data-selectors.md
@@ -146,7 +146,7 @@ function TodoList() {
   // highlight-start
   // ❌ WARNING: this _always_ returns a new reference, so it will _always_ re-render!
   const completedTodos = useSelector(state =>
-    state.todos.map(todo => todo.completed)
+    state.todos.filter(todo => todo.completed)
   )
   // highlight-end
 }


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: A small fix in an example code
---

## What docs page needs to be fixed?

- **Section**:  Using Redux
- **Page**: Deriving Data with Selectors

## What is the problem?
Example code snippet uses the `map` method in a place where `filter` method should be used instead.

```js
function TodoList() {
  // highlight-start
  // ❌ WARNING: this _always_ returns a new reference, so it will _always_ re-render!
  const completedTodos = useSelector(state =>
    state.todos.map(todo => todo.completed)
  )
  // highlight-end
}
```

## What changes does this PR make to fix the problem?
`map` has been replaced with `filter`