### PR TITLE
Remove unnecessary memoization from a code example

### DIFF
--- a/docs/usage/deriving-data-selectors.md
+++ b/docs/usage/deriving-data-selectors.md
@@ -228,7 +228,7 @@ const brokenSelector = createSelector(
 Similarly, a memoized selector should _never_ use `state => state` as an input! That will force the selector to always recalculate.
 :::
 
-In typical Reselect usage, you write your top-level "input selectors" as plain functions, and use `createSelector` to create memoized selectors that look up nested values:
+In typical Reselect usage, you write your top-level "input selectors" as plain functions, and use `createSelector` to create memoized selectors that calculate derived values:
 
 ```js
 const state = {
@@ -238,10 +238,8 @@ const state = {
   b: 10
 }
 
-const selectA = state => state.a
+const selectA1 = state => state.a.first
 const selectB = state => state.b
-
-const selectA1 = createSelector([selectA], a => a.first)
 
 const selectResult = createSelector([selectA1, selectB], (a1, b) => {
   console.log('Output selector running')


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Removing unnecessary memoization from a code example as it might confuse people
---

## What docs page needs to be fixed?

- **Section**: Writing Memoized Selectors with Reselect
- **Page**: Deriving Data with Selectors

## What is the problem?
Using (`createSelector`) for the `selectA1` selector directly contradicts the **Balance Selector Usage** section, which says in bold text the following: **A selector function that does a direct lookup and return of a value should be a plain function, not memoized.** Therefore this code example might confuse people about when to use memoization.

```js
const state = {
  a: {
    first: 5
  },
  b: 10
}

const selectA = state => state.a
const selectB = state => state.b

const selectA1 = createSelector([selectA], a => a.first)

const selectResult = createSelector([selectA1, selectB], (a1, b) => {
  console.log('Output selector running')
  return a1 + b
})

const result = selectResult(state)
// Log: "Output selector running"
console.log(result)
// 15

const secondResult = selectResult(state)
// No log output
console.log(secondResult)
// 15
```

## What changes does this PR make to fix the problem?
Not using `createSelector` for this one.
