### PR TITLE
Update part-5-async-logic.md

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -1128,7 +1128,7 @@ As a reminder, here's what we covered in this section:
   - Thunk functions receive `dispatch` and `getState` as arguments, and can use those as part of async logic
 - **You can dispatch additional actions to help track the loading status of an API call**
   - The typical pattern is dispatching a "pending" action before the call, then either a "success" containing the data or a "failure" action containing the error
-  - Loading state should usually be stored as an enum, like `'idle' | 'pending' | 'succeeded' | 'rejected'`
+  - Loading state should usually be stored as a union of string literals, like `'idle' | 'pending' | 'succeeded' | 'rejected'`
 - **Redux Toolkit has a `createAsyncThunk` API that dispatches these actions for you**
   - `createAsyncThunk` accepts a "payload creator" callback that should return a Promise, and generates `pending/fulfilled/rejected` action types automatically
   - Generated action creators like `fetchPosts` dispatch those actions based on the Promise you return


### PR DESCRIPTION
At the summary part of the document, where it is stated: "Loading state should usually be stored as an enum, like 'idle' | 'pending' | 'succeeded' | 'rejected'". It is important to realize that the example given wasn't a TypeScript enum, but TypeScript's union of string literals. The documentation should be updated to reflect this.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: https://redux.js.org/tutorials/essentials/part-5-async-logic#what-youve-learned
- **Page**: https://redux.js.org/tutorials/essentials/part-5-async-logic

## What is the problem?
 'idle' | 'pending' | 'succeeded' | 'rejected' is not an enum but a union of string literals.

## What changes does this PR make to fix the problem?
Updates the statement to become: "Loading state should usually be stored as a union of string literals, like 'idle' | 'pending' | 'succeeded' | 'rejected'"