### PR TITLE
docs(GettingStarted): update and expand project setup templates section

### DIFF
--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -37,25 +37,38 @@ npm install @reduxjs/toolkit
 yarn add @reduxjs/toolkit
 ```
 
-### Create a React Redux App
+### Creating a New Redux Project
 
-The recommended way to start new apps with React and Redux is by using [our official Redux+TS template for Vite](https://github.com/reduxjs/redux-templates), or by creating a new Next.js project using [Next's `with-redux` template](https://github.com/vercel/next.js/tree/canary/examples/with-redux).
+The recommended way to start new apps with Redux is to use one of our [official templates](https://github.com/reduxjs/redux-templates). These templates come pre-configured with Redux Toolkit, and include a small example app to get you started.
 
-Both of these already have Redux Toolkit and React-Redux configured appropriately for that build tool, and come with a small example app that demonstrates how to use several of Redux Toolkit's features.
+To create a new project, you can use a tool like `degit` to clone and extract the template.
 
 ```bash
-# Vite with our Redux+TS template
-# (using the `degit` tool to clone and extract the template)
+# Vite + TypeScript
 npx degit reduxjs/redux-templates/packages/vite-template-redux my-app
 
-# Next.js using the `with-redux` template
-npx create-next-app --example with-redux my-app
+# Create React App + TypeScript
+npx degit reduxjs/redux-templates/packages/cra-template-redux-typescript my-app
+
+# Create React App + JavaScript
+npx degit reduxjs/redux-templates/packages/cra-template-redux my-app
+
+# Expo + TypeScript
+npx degit reduxjs/redux-templates/packages/expo-template-redux-typescript my-app
+
+# React Native + TypeScript
+npx degit reduxjs/redux-templates/packages/react-native-template-redux-typescript my-app
+
+# Standalone Redux Toolkit App Structure Example
+npx degit reduxjs/redux-templates/packages/rtk-app-structure-example my-app
 ```
 
-We do not currently have official React Native templates, but recommend these templates for standard React Native and for Expo:
+In addition to our official templates, the community has created other templates, such as the [Next.js `with-redux` template](https://github.com/vercel/next.js/tree/canary/examples/with-redux).
 
-- https://github.com/rahsheen/react-native-template-redux-typescript
-- https://github.com/rahsheen/expo-template-redux-typescript
+```bash
+# Next.js + Redux
+npx create-next-app --example with-redux my-app
+```
 
 ### Redux Core
 


### PR DESCRIPTION
This change:
- Adds instructions for Vite, CRA, Expo, and React Native templates.
- Moves the Next.js `with-redux` example to a separate section as a community template.

This PR addresses #4808 

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
