### PR TITLE
Docs: Enhance and correct selector memoization example in Essentials Part 6

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -899,7 +899,7 @@ selectPostsByUser(state1, 'user1')
 // Output selector runs, because `userId` changed
 selectPostsByUser(state1, 'user2')
 
-dispatch(reactionAdded())
+dispatch(fetchUsers())
 const state2 = getState()
 // Output selector does not run, because `posts` and `userId` are the same
 selectPostsByUser(state2, 'user2')


### PR DESCRIPTION
fixes #4820

This PR updates the code example in Part 6 of the Redux Essentials tutorial ("Memoizing Selector Functions") to be technically accurate and better aligned with the section's teaching goals.

**[CURRENT STATUS AND FIX]**

I have updated the PR based on feedback from @markerikson.

**Implementation Details:**

The misleading `dispatch(reactionAdded())` (which incorrectly claimed the selector didn't run) has been replaced with `dispatch(fetchUsers())`. This action correctly demonstrates selector stability since the output selector DOES NOT RUN, because `fetchUsers` only modifies the `users` slice, keeping the `posts` input reference stable. And also, the original sequence of "recalculates / doesn't recalculate" is preserved.

**Final Updated Code Block:**
```ts Selector Calculation Examples
const state1 = getState()
// Output selector runs, because it's the first call
selectPostsByUser(state1, 'user1')
// Output selector does _not_ run, because the arguments haven't changed
selectPostsByUser(state1, 'user1')
// Output selector runs, because `userId` changed
selectPostsByUser(state1, 'user2')

dispatch(fetchUsers())
const state2 = getState()
// Output selector does not run, because `posts` and `userId` are the same
selectPostsByUser(state2, 'user2')

// Add some more posts
dispatch(addNewPost())
const state3 = getState()
// Output selector runs, because `posts` has changed
selectPostsByUser(state3, 'user2')
```

**THE DESCRIPTION BELOW WAS THE INITIAL PROPOSITION, YOU CAN IGNORE THE REST OF THE TEXT**
NOTE: This PR originally planned to include the reactionAdded() flaw and the fetchNotifications() action to demonstrate all cases, but has been fixed to be more in line with the surrounding section of the tutorial.


The docs example had two issues which are addressed here:

- Technical Correction (reactionAdded): The example previously claimed the selector did not run after reactionAdded(). Because this action changes a post (and thus the parent posts array reference via Immer), the selector's input does change. This PR corrects the assertion to state that the output selector runs.

- Pedagogical Enhancement (fetchNotifications): The core of this tutorial section is about preventing re-renders from unrelated state changes (like fetching notifications). The new block includes dispatch(fetchNotifications()) to provide the clear example that the memoized selector does not run when only an unrelated slice changes.

The revised example now covers all four key memoization scenarios clearly.

*(Technical Note: Stating that the output selector runs is the most accurate description of the internal memoization logic in this context, even if the eventual component re-render might be prevented by a more complex equal function (which isn't the primary focus here). This was my thought process, although at first I explicitly stated this in the example, it cluttered the example and I came to the conclusion that it could potentially cause more confusion rather than helping the reader.)*