### PR TITLE
Use typed useDispatch in PostsList example

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -1213,7 +1213,7 @@ function PostExcerpt({ postId }: PostExcerptProps) {
 }
 
 export const PostsList = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   // highlight-next-line
   const orderedPostIds = useAppSelector(selectPostIds)
 


### PR DESCRIPTION
Correct the documentation for the `PostsList` component to use the type-safe `useAppDispatch` hook.

The example previously used the untyped `useDispatch` hook from `react-redux`. The corrected version reflects the recommended approach for working with Redux Toolkit and TypeScript, which provides stronger type-checking and improved developer experience.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?

## What changes does this PR make to fix the problem?
