### PR TITLE
docs(what-you-have-learned): Correct grammar

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -1592,7 +1592,7 @@ Now when we add a new post, we should see a small green toast pop up in the lowe
 
 ## What You've Learned
 
-We've built a lot of new behavior in this section. Let's see what how the app looks with all those changes:
+We've built a lot of new behavior in this section. Let's see how the app looks with all those changes:
 
 <iframe
   class="codesandbox"


### PR DESCRIPTION
Fixes a grammatical error in the summary section of the Redux Toolkit tutorial. The phrase "what how the app looks" was corrected to "how the app looks" to improve clarity

This ensures the documentation is grammatically correct and meets high professional standards.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?

## What changes does this PR make to fix the problem?
