### PR TITLE
docs typo fix: change "App.ts" to "App.tsx"

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -532,7 +532,7 @@ export const Navbar = () => {
 }
 ```
 
-Lastly, we need to update `App.ts` with the "Notifications" route so we can navigate to it:
+Lastly, we need to update `App.tsx` with the "Notifications" route so we can navigate to it:
 
 ```tsx title="App.tsx"
 // omit imports


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - Nope! I figured this falls under "sometimes the best way to start a conversation is to send a pull request"
- [x] Have the files been linted and formatted?
  - I ran yarn lint, but there were no linting/formatting changes made by the utility (I only changed one character after all haha) 

## What docs page needs to be fixed?

- **Section**: Adding the Notifications List
- **Page**: Redux Essentials, Part 6: Performance, Normalizing Data, and Reactive Logic

## What is the problem?

There is a minor typo in "Lastly, we need to update App.ts with the "Notifications" route so we can navigate to it". Should be `App.tsx`.

## What changes does this PR make to fix the problem?
Changes `App.ts` to `App.tsx`
