### PR TITLE
docs: add missing title "features/posts/postsSlice.ts" to code block

### DIFF
--- a/docs/tutorials/essentials/part-4-using-data.md
+++ b/docs/tutorials/essentials/part-4-using-data.md
@@ -919,7 +919,7 @@ Then, we can define a new reducer that will handle updating the reaction count f
 
 Like with editing posts, we need to know the ID of the post, and which reaction button the user clicked on. We'll have our `action.payload` be an object that looks like `{id, reaction}`. The reducer can then find the right post object, and update the correct reactions field.
 
-```ts
+```ts title="features/posts/postsSlice.ts"
 import { createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit'
 import { sub } from 'date-fns'
 


### PR DESCRIPTION
…in "Post Reaction Buttons" section

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - Nope. Figured this also falls under "sometimes the best way to start a conversation is to send a pull request"
- [x] Have the files been linted and formatted?
  - Yes, I ran yarn lint just in case.

## What docs page needs to be fixed?
https://redux.js.org/tutorials/essentials/part-4-using-data#tracking-reactions-data-in-posts
- **Section**: Tracking Reactions Data in Posts
- **Page**: Redux Essentials, Part 4: Using Redux Data

## What is the problem?

The code block in the section is missing the title (path to the file to be changed)

## What changes does this PR make to fix the problem?

Added the title to the code block: `title="features/posts/postsSlice.ts"`
