### PR TITLE
Pin workflow actions to specific SHA (latest minor version)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/size.yaml
+++ b/.github/workflows/size.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: preactjs/compressed-size-action@v2
+      - uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,8 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
@@ -57,7 +57,7 @@ jobs:
       - name: Pack
         run: yarn pack
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #actions/upload-artifact@v4
         with:
           name: package
           path: ./package.tgz
@@ -72,10 +72,10 @@ jobs:
         node: ['22.x']
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
@@ -83,7 +83,7 @@ jobs:
       - name: Install deps
         run: yarn install
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #actions/download-artifact@v4
         with:
           name: package
           path: .
@@ -113,10 +113,10 @@ jobs:
         ts: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8']
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
@@ -127,7 +127,7 @@ jobs:
       - name: Install TypeScript ${{ matrix.ts }}
         run: yarn add typescript@${{ matrix.ts }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #actions/download-artifact@v4
         with:
           name: package
           path: .
@@ -156,15 +156,15 @@ jobs:
         node: ['22.x']
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #actions/download-artifact@v4
         with:
           name: package
           path: .
@@ -195,10 +195,10 @@ jobs:
           ]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
@@ -221,7 +221,7 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         run: yarn install
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #actions/download-artifact@v4
         with:
           name: package
           path: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}


### PR DESCRIPTION
---
name: :bug: Bug fix or new feature
about: Fixing a problem with Redux
---

## PR Type

### Does this PR add a new _feature_, or fix a _bug_?
Fix a bug

### Why should this PR be included?
I am hoping that it can help Github workflow tests run properly again.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - No
- [x] Have the files been linted and formatted?
  - I ran yarn lint just in case but nothing changed
- [ ] Have the docs been updated to match the changes in the PR?
  - I dont think this is applicable
- [ ] Have the tests been updated to match the changes in the PR?
  - I dont think this is applicable either
- [ ] Have you run the tests locally to confirm they pass?
  - I dont think this is applicable either, since only files in `.github/workflows` are changed. GitHub actions ran fine when I pushed to my remote branch, though: https://github.com/Talos0248/redux/actions/runs/20124498806 

## Bug Fixes

### What is the current behavior, and the steps to reproduce the issue?
Currently, when opening a PR, Github workflow tests fail, as I believe security policies of the redux repo requires actions to be pinned to a specific SHA; however, current actions only use a generic tag (eg @v4)

### What is the expected behavior?
When opening a PR, Github Workflow tests should NOT throw an error when setting up the job and instead should run properly. Example error that this should fix: 
```
Error: The actions actions/checkout@v4 and dorny/paths-filter@v3 are not allowed in reduxjs/redux because all actions must be pinned to a full-length commit SHA.
```

### How does this PR fix the problem?
I have pinned a specific SHA to each GitHub workflow action. I have chosen the latest minor version available at time of writing (e.g. `v4.3.0` for `actions/download-artifact@v4`). Full list of changes as well as link to release and their SHA values is as follows:


## actions/checkout@v4
https://github.com/actions/checkout/releases/tag/v4.3.1
34e114876b0b11c390a56381ad16ebd13914f8d5



## dorny/paths-filter@v3
https://github.com/dorny/paths-filter/releases/tag/v3.0.2
de90cc6fb38fc0963ad72b210f1f284cd68cea36



## actions/setup-node@v4
https://github.com/actions/setup-node/releases/tag/v4.4.0
49933ea5288caeca8642d1e84afbd3f7d6820020



## actions/download-artifact@v4
https://github.com/actions/download-artifact/releases/tag/v4.3.0
d3f86a106a0bac45b974a628896c90dbdf5c8093



## preactjs/compressed-size-action@v2
https://github.com/preactjs/compressed-size-action/releases/tag/2.8.0
946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a



## actions/upload-artifact@v4
https://github.com/actions/upload-artifact/releases/tag/v4.6.2
ea165f8d65b6e75b540449e92b4886f43607fa02