### PR TITLE
docs(rtk-query): Clarify standard slice exports

### DIFF
--- a/docs/tutorials/essentials/part-7-rtk-query-basics.md
+++ b/docs/tutorials/essentials/part-7-rtk-query-basics.md
@@ -216,7 +216,7 @@ For TypeScript usage, **the `builder.query()` and `builder.mutation()` endpoint 
 
 #### Exporting API Slices and Hooks
 
-In our earlier slice files, we just exported the action creators and the slice reducers, because those are all that's needed in other files. With RTK Query, we typically export the entire "API slice" object itself, because it has several fields that may be useful.
+From our earlier `createSlice` functions, we only needed to export just the action creators and the slice reducers, because those are the only part of the slice functions that are needed in other files. With RTK Query, we typically export the entire "API slice" object itself, because it has several fields that may be useful.
 
 Finally, look carefully at the last line of this file. Where's this `useGetPostsQuery` value coming from?
 


### PR DESCRIPTION
The existing documentation implies that standard slices *only* export action creators and reducers. This can create confusion when users compare this with fuller implementations within the codebase, such as the `postsSlice.ts` example shown earlier in Part 6.

That file demonstrates that robust slices require exporting additional items like async thunks, types, selectors, and listener middleware.

This change updates the wording to clarify that the original statement refers to the *minimal* exports needed from `createSlice`, providing better and unambiguous context before contrasting with `createApi` exports.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
