### PR TITLE
Docs: Fix typo in TS quick start

### DIFF
--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -54,7 +54,7 @@ export default configureStore({
 })
 ```
 
-This creates a Redux store, and also automatically configure the Redux DevTools extension so that you can inspect the store while developing.
+This creates a Redux store, and also automatically configures the Redux DevTools extension so that you can inspect the store while developing.
 
 ### Provide the Redux Store to React
 


### PR DESCRIPTION
---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**: Tutorials
- **Page**: TypeScript Quick Start

## What is the problem?
A missing s.

## What changes does this PR make to fix the problem?
Adds the s.