### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -207,7 +207,7 @@ jobs:
         run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit
 
       - name: Cache example deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/node_modules
           key: test-published-artifact-${{ matrix.example }}-node_modules


### PR DESCRIPTION
This PR updates an outdated GitHub Action version. The `actions/cache` package is being updated from `v4` to `v5` in `.github/workflows/test.yaml`. The changes will be tested in the CI pipeline of the pull request.