### PR TITLE
docs(part-5): fix thunk logic grammatical error

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -589,7 +589,7 @@ In this case, what happened is:
 - The `useEffect` hook ran for the first time. The `postStatus` value is `'idle'`, so it dispatches the `fetchPosts` thunk.
 - `fetchPosts` immediately dispatches its `fetchPosts.pending` action, so the Redux store _did_ update the status to `'pending'` right away...
 - **but React runs the `useEffect` _again_ without re-rendering the component, so the effect still thinks that `postStatus` is `'idle'` and dispatches `fetchPosts` a second time**
-- Both thunks finish fetching their data, dispatch the `fetchPosts.fulfilled` action, and the `fulfilled` reducer runs twice, adding resulting in a duplicate set of posts being added to the state
+- Both thunks finish fetching their data and dispatch the `fetchPosts.fulfilled` action; consequently, the `fulfilled` reducer runs twice, resulting in a duplicate set of posts being added to the state
 
 So, how can we fix this?
 


### PR DESCRIPTION
Remove redundant wording "adding" to resolve a tautology. The original sentence phrasing "adding resulting in" was grammatically incorrect.

This update clarifies the logic flow where concurrent thunks trigger duplicate state updates, ensuring a smoother reading experience for developers learning async logic in Part 5.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---




## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?

## What changes does this PR make to fix the problem?
