### PR TITLE
docs(part 6): remove legacy router Redirect

### DIFF
--- a/docs/tutorials/essentials/part-6-performance-normalization.md
+++ b/docs/tutorials/essentials/part-6-performance-normalization.md
@@ -143,7 +143,6 @@ As usual, we will add routes for these components in `<App>`:
           <Route path="/users" element={<UsersList />} />
           <Route path="/users/:userId" element={<UserPage />} />
           // highlight-end
-          <Redirect to="/" />
 ```
 
 We'll also add another tab in `<Navbar>` that links to `/users` so that we can click and go to `<UsersList>`:


### PR DESCRIPTION
The Part 6 tutorial code snippet contained a leftover <Redirect /> component from React Router v5.
This change removes the legacy line to harmonize the documentation with the v6 logic used in the official CodeSandbox examples.

---
name: :memo: Documentation Fix
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [ ] Have the files been linted and formatted?

## What docs page needs to be fixed?

- **Section**:
- **Page**:

## What is the problem?

## What changes does this PR make to fix the problem?
