### PR TITLE
fix(docs): correct grammar in thunk typing sentence

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -225,7 +225,7 @@ It's also easy to make mistakes with error handling when writing thunk logic you
 
 #### Typing Handwritten Thunks
 
-If you're writing a thunk by hand, you can declare explicitly type the thunk arguments as `(dispatch: AppDispatch, getState: () => RootState)`. Since this is common, you can also define a reusable `AppThunk` type and use that instead:
+If you're writing a thunk by hand, you can explicitly type the thunk arguments as `(dispatch: AppDispatch, getState: () => RootState)`. Since this is common, you can also define a reusable `AppThunk` type and use that instead:
 
 ```ts title="app/store.ts"
 // highlight-next-line


### PR DESCRIPTION
This fixes a grammatical issue in the documentation where the phrase "declare explicitly type the thunk arguments" was used.

Updated to "explicitly type the thunk arguments" for clarity.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
