### PR TITLE
Fix: Add missing `StateExt` generic to `StoreCreator` second overload

### DIFF
--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -192,7 +192,7 @@ export interface StoreCreator {
   >(
     reducer: Reducer<S, A, PreloadedState>,
     preloadedState?: PreloadedState | undefined,
-    enhancer?: StoreEnhancer<Ext>
+    enhancer?: StoreEnhancer<Ext, StateExt>
   ): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext
 }
 


### PR DESCRIPTION
The enhancer parameter in the second overload of `StoreCreator` was typed as `StoreEnhancer<Ext>`, omitting `StateExt`. This caused TypeScript to never infer `StateExt` from the enhancer, always falling back to `{}`, despite it being declared in the overload's generics and used in the return type.