### PR TITLE
docs: fix fetchPosts typo in async logic tutorial

### DIFF
--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -477,7 +477,7 @@ console.log(
 
 We've also seen that we can use [the `extraReducers` field in `createSlice` to respond to actions that were defined outside of the slice](./part-4-using-data.md##using-extrareducers-to-handle-other-actions).
 
-In this case, we need to listen for the "pending" and "fulfilled" action types dispatched by our `fetchPosts` thunk. Those action creators are attached to our actual `fetchPost` function, and we can pass those to `extraReducers` to listen for those actions:
+In this case, we need to listen for the "pending" and "fulfilled" action types dispatched by our `fetchPosts` thunk. Those action creators are attached to our actual `fetchPosts` function, and we can pass those to `extraReducers` to listen for those actions:
 
 ```ts title="features/posts/postsSlice.ts"
 export const fetchPosts = createAsyncThunk('posts/fetchPosts', async () => {


### PR DESCRIPTION
Fixes a typo in the async logic tutorial where `fetchPost` is referenced instead of `fetchPosts`.

The thunk is defined as `fetchPosts`, so this change keeps naming consistent and avoids confusion for readers.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
