### PR TITLE
docs: rename `GetPostSelectFromResultArg` to `GetPostsSelectFromResultArg` for consistency with `Post[]`

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -667,11 +667,11 @@ import { selectUserById } from './usersSlice'
 // highlight-start
 // Create a TS type that represents "the result value passed
 // into the `selectFromResult` function for this hook"
-type GetPostSelectFromResultArg = TypedUseQueryStateResult<Post[], any, any>
+type GetPostsSelectFromResultArg = TypedUseQueryStateResult<Post[], any, any>
 
 const selectPostsForUser = createSelector(
-  (res: GetPostSelectFromResultArg) => res.data,
-  (res: GetPostSelectFromResultArg, userId: string) => userId,
+  (res: GetPostsSelectFromResultArg) => res.data,
+  (res: GetPostsSelectFromResultArg, userId: string) => userId,
   (data, userId) => data?.filter(post => post.user === userId)
 )
 // highlight-end


### PR DESCRIPTION
The `useGetPostsQuery` endpoint returns `Post[]`, but the type name `GetPostSelectFromResultArg` is singular and can be misleading. Especially for beginners, who are new to Redux.

Rename it to `GetPostsSelectFromResultArg` to reflect the actual data shape and improve consistency.

No functional changes.

Thanks for the PR!

To better assist you, please select the type of PR you want to create.

Click the "Preview" tab above, and click on the link for the PR type:

- [:bug: Bug fix or new feature](?template=bugfix.md)
- [:memo: Documentation Fix](?template=documentation-edit.md)
- [:book: New/Updated Documentation Content](?template=documentation-new.md)
