### PR TITLE
docs(typescript): align `AppThunk` extra arg type with `createAsyncThunk.withTypes`

### DIFF
--- a/docs/tutorials/essentials/part-2-app-structure.md
+++ b/docs/tutorials/essentials/part-2-app-structure.md
@@ -152,7 +152,7 @@ export type AppDispatch = AppStore['dispatch']
 export type AppThunk<ThunkReturnType = void> = ThunkAction<
   ThunkReturnType,
   RootState,
-  unknown,
+  undefined,
   Action
 >
 ```

--- a/docs/tutorials/essentials/part-5-async-logic.md
+++ b/docs/tutorials/essentials/part-5-async-logic.md
@@ -241,7 +241,7 @@ export type AppDispatch = typeof store.dispatch
 export type RootState = ReturnType<typeof store.getState>
 // highlight-start
 // Export a reusable type for handwritten thunks
-export type AppThunk = ThunkAction<void, RootState, unknown, Action>
+export type AppThunk = ThunkAction<void, RootState, undefined, Action>
 // highlight-end
 ```
 

--- a/docs/usage/UsageWithTypescript.md
+++ b/docs/usage/UsageWithTypescript.md
@@ -326,7 +326,7 @@ export type ThunkAction<
 > = (dispatch: ThunkDispatch<S, E, A>, getState: () => S, extraArgument: E) => R
 ```
 
-You will typically want to provide the `R` (return type) and `S` (state) generic arguments. Unfortunately, TS does not allow only providing _some_ generic arguments, so the usual values for the other arguments are `unknown` for `E` and `UnknownAction` for `A`:
+You will typically want to provide the `R` (return type) and `S` (state) generic arguments. Unfortunately, TS does not allow only providing _some_ generic arguments, so the usual values for the other arguments are `undefined` for `E` and `UnknownAction` for `A`:
 
 ```ts
 import { UnknownAction } from 'redux'
@@ -335,7 +335,7 @@ import { RootState } from './store'
 import { ThunkAction } from 'redux-thunk'
 
 export const thunkSendMessage =
-  (message: string): ThunkAction<void, RootState, unknown, UnknownAction> =>
+  (message: string): ThunkAction<void, RootState, undefined, UnknownAction> =>
   async dispatch => {
     const asyncResp = await exampleAPI()
     dispatch(
@@ -358,7 +358,7 @@ To reduce repetition, you might want to define a reusable `AppThunk` type once, 
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
   RootState,
-  unknown,
+  undefined,
   UnknownAction
 >
 ```

--- a/examples/counter-ts/src/app/store.ts
+++ b/examples/counter-ts/src/app/store.ts
@@ -12,6 +12,6 @@ export type RootState = ReturnType<typeof store.getState>
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
   RootState,
-  unknown,
+  undefined,
   Action<string>
 >


### PR DESCRIPTION
## Summary

Aligns the `AppThunk` / `ThunkAction` examples in the docs and the
`counter-ts` example with how Redux Toolkit's `createAsyncThunk.withTypes`
actually types the thunk dispatcher.

Fixes #4602

## The problem

The Redux docs recommend defining `AppThunk` with `unknown` as the
extra-argument generic. Meanwhile, RTK's `createAsyncThunk.withTypes`
defaults the extra argument to `undefined` when no `extra` is provided.
The result is a `ThunkDispatch<RootState, unknown, ...>` vs
`ThunkDispatch<RootState, undefined, ...>` mismatch, so dispatching a
typed RTK async thunk from inside a handwritten `AppThunk` raises a
TypeScript error.

## The fix

Change the extra-argument generic from `unknown` to `undefined` in the
documented examples and in the `counter-ts` template, so the two
recommended patterns agree.

## Files changed

- `docs/usage/UsageWithTypescript.md` — `AppThunk` type, `ThunkAction` example, and surrounding prose
- `docs/tutorials/essentials/part-2-app-structure.md` — `AppThunk` type
- `docs/tutorials/essentials/part-5-async-logic.md` — `AppThunk` type
- `examples/counter-ts/src/app/store.ts` — `AppThunk` type

Total: 6 lines across 4 files.

## Testing

Docs-only / example-only changes; no runtime behavior is affected.
Relying on CI to validate the Docusaurus build and the `counter-ts`
typecheck.