### PR TITLE
ci: fix `pkg-pr-new` usage

### DIFF
--- a/.github/workflows/release-commit.yml
+++ b/.github/workflows/release-commit.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - run: corepack enable
 
@@ -35,6 +35,6 @@ jobs:
       - name: Publish
         id: publish
         run: >
-          yarn dlx pkg-pr-new publish
+          yarn run --binaries-only --top-level pkg-pr-new publish
           .
-          --yarn --packageManager="npm,yarn,pnpm,bun" --commentWithDev
+          --yarn --packageManager="npm,yarn,pnpm,bun" --commentWithDev --commentWithSha

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "glob": "^10.3.10",
     "netlify-plugin-cache": "^1.0.3",
+    "pkg-pr-new": "^0.0.75",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "rxjs": "^7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6274,6 +6274,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg-pr-new@npm:^0.0.75":
+  version: 0.0.75
+  resolution: "pkg-pr-new@npm:0.0.75"
+  bin:
+    pkg-pr-new: bin/cli.js
+  checksum: 10/5160a67a955a50a5842cc43a5143e16f15e48bd5beaf6368ee4f3c532fd79e8ba703ffffd9479945b7ed52f65ce11990e2e24c96b6efd7dd30a326236721bd90
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -6405,6 +6414,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^4.6.0"
     glob: "npm:^10.3.10"
     netlify-plugin-cache: "npm:^1.0.3"
+    pkg-pr-new: "npm:^0.0.75"
     prettier: "npm:^3.2.5"
     rimraf: "npm:^5.0.5"
     rxjs: "npm:^7.8.1"


### PR DESCRIPTION
## Summary

- Add [`pkg-pr-new`](https://github.com/stackblitz-labs/pkg.pr.new) as a local dev dependency, as recommended in its documentation
- Run [`pkg-pr-new`](https://github.com/stackblitz-labs/pkg.pr.new) via `yarn run --binaries-only --top-level` instead of `yarn dlx`
- Add the `--commentWithSha` flag
- Bump `actions/checkout` from `v6.0.3` to `v7.0.0`