### PR TITLE
fix: add missing closing quote in `replaceReducer` error message

### DIFF
--- a/errors.json
+++ b/errors.json
@@ -9,7 +9,7 @@
   "7": "Actions must be plain objects. Instead, the actual type was: ''. You may need to add middleware to your store setup to handle dispatching other values, such as 'redux-thunk' to handle dispatching functions. See https://redux.js.org/tutorials/fundamentals/part-4-store#middleware and https://redux.js.org/tutorials/fundamentals/part-6-async-logic#using-the-redux-thunk-middleware for examples.",
   "8": "Actions may not have an undefined \"type\" property. You may have misspelled an action type string constant.",
   "9": "Reducers may not dispatch actions.",
-  "10": "Expected the nextReducer to be a function. Instead, received: '",
+  "10": "Expected the nextReducer to be a function. Instead, received: ''",
   "11": "Expected the observer to be an object. Instead, received: ''",
   "12": "The slice reducer for key \"\" returned undefined during initialization. If the state passed to the reducer is undefined, you must explicitly return the initial state. The initial state may not be undefined. If you don't want to set a value for this reducer, you can use null instead of undefined.",
   "13": "The slice reducer for key \"\" returned undefined when probed with a random type. Don't try to handle '' or other actions in \"redux/*\" namespace. They are considered private. Instead, you must return the current state for any unknown actions, unless it is undefined, in which case you must return the initial state, regardless of the action type. The initial state may not be undefined, but can be null.",

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -322,7 +322,7 @@ export function createStore<
       throw new Error(
         `Expected the nextReducer to be a function. Instead, received: '${kindOf(
           nextReducer
-        )}`
+        )}'`
       )
     }
 

--- a/test/createStore.spec.ts
+++ b/test/createStore.spec.ts
@@ -703,7 +703,12 @@ describe('createStore', () => {
 
     // @ts-expect-error
     expect(() => store.replaceReducer(undefined)).toThrow(
-      'Expected the nextReducer to be a function.'
+      "Expected the nextReducer to be a function. Instead, received: 'undefined'"
+    )
+
+    // @ts-expect-error
+    expect(() => store.replaceReducer(null)).toThrow(
+      "Expected the nextReducer to be a function. Instead, received: 'null'"
     )
 
     expect(() => store.replaceReducer(() => [])).not.toThrow()


### PR DESCRIPTION
## Summary

Closes #4890

## Bug

The error thrown by `replaceReducer` when called with a non-function was missing a closing single-quote around the received type value in the error message.

**Before:**
```
Expected the nextReducer to be a function. Instead, received: 'null
```

**After:**
```
Expected the nextReducer to be a function. Instead, received: 'null'
```

## Root Cause

In `src/createStore.ts`, the template literal ended with `}\`` instead of `}'\``:

```ts
// Before (bug)
`Expected the nextReducer to be a function. Instead, received: '${kindOf(
  nextReducer
)}`

// After (fix)
`Expected the nextReducer to be a function. Instead, received: '${kindOf(
  nextReducer
)}'`
```

Every other analogous error message in `createStore.ts` correctly wraps the received type in single quotes:
- `Expected the root reducer to be a function. Instead, received: '${kindOf(reducer)}'`
- `Expected the enhancer to be a function. Instead, received: '${kindOf(enhancer)}'`
- `Expected the listener to be a function. Instead, received: '${kindOf(listener)}'`
- `Expected the observer to be an object. Instead, received: '${kindOf(observer)}'`

## Verification

The existing test only checked a partial string prefix (`'Expected the nextReducer to be a function.'`), which passed even with the broken message. The updated test now asserts the full message including the received type wrapped in quotes, catching this class of regression.