### PR TITLE
docs: recommend `createEntityAdapter` for normalized state

### DIFF
--- a/docs/usage/structuring-reducers/NormalizingStateShape.md
+++ b/docs/usage/structuring-reducers/NormalizingStateShape.md
@@ -214,4 +214,8 @@ Operations like "Look up all books by this author", can then be accomplished eas
 
 ## Normalizing Nested Data
 
-Because APIs frequently send back data in a nested form, that data needs to be transformed into a normalized shape before it can be included in the state tree. The [Normalizr](https://github.com/paularmstrong/normalizr) library is usually used for this task. You can define schema types and relations, feed the schema and the response data to Normalizr, and it will output a normalized transformation of the response. That output can then be included in an action and used to update the store. See the Normalizr documentation for more details on its usage.
+Because APIs frequently send back data in a nested form, that data needs to be transformed into a normalized shape before it can be included in the state tree.
+
+For most applications, [Redux Toolkit's `createEntityAdapter`](https://redux-toolkit.js.org/api/createEntityAdapter) is the recommended way to store and update normalized entity collections in your slices. It provides a standard `{ ids, entities }` state shape along with generated reducers and selectors. See [Performance and Normalizing Data](../../tutorials/essentials/part-6-performance-normalization.md) for a walkthrough.
+
+If you need to transform deeply nested API responses with complex relational schemas into normalized data, the [Normalizr](https://github.com/paularmstrong/normalizr) library is still a common option. You can define schema types and relations, feed the schema and the response data to Normalizr, and it will output a normalized transformation of the response. That output can then be included in an action and used to update the store (including slices that use `createEntityAdapter`). Normalizr is stable and feature-rich for relational normalization, but it is [no longer actively maintained](https://github.com/paularmstrong/normalizr/discussions/493#discussioncomment-2395540).

--- a/docs/usage/structuring-reducers/PrerequisiteConcepts.md
+++ b/docs/usage/structuring-reducers/PrerequisiteConcepts.md
@@ -88,7 +88,9 @@ Because of these rules, it's important that the following core concepts are full
 
 - [Database Normalization in Simple English](https://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english/)
 - [Idiomatic Redux: Normalizing the State Shape](https://egghead.io/lessons/javascript-redux-normalizing-the-state-shape)
-- [Normalizr Documentation](https://github.com/paularmstrong/normalizr)
+- [Redux Toolkit: `createEntityAdapter`](https://redux-toolkit.js.org/api/createEntityAdapter)
+- [Essentials: Performance and Normalizing Data](../../tutorials/essentials/part-6-performance-normalization.md)
+- [Normalizr Documentation](https://github.com/paularmstrong/normalizr) (stable, but no longer actively maintained)
 - [Redux Without Profanity: Normalizr](https://tonyhb.gitbooks.io/redux-without-profanity/content/normalizer.html)
 - [Querying a Redux Store](https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f)
 - [Wikipedia: Associative Entity](https://en.wikipedia.org/wiki/Associative_entity)


### PR DESCRIPTION
## Summary
- Update the Normalizing Nested Data section to recommend Redux Toolkit's `createEntityAdapter` for storing and updating normalized entity collections.
- Keep Normalizr as an option for complex relational API transforms, with a note that it is stable but no longer actively maintained.
- Add matching links on the Prerequisite Concepts reading list.

Fixes #4699

## Test plan
- [ ] Preview the Normalizing State Shape page and confirm the new guidance and links render correctly
- [ ] Confirm the Essentials tutorial and `createEntityAdapter` API links resolve