### PR TITLE
fix: handle shadowed keys in combineReducers warnings

### DIFF
--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -40,7 +40,9 @@ function getUnexpectedStateShapeWarningMessage(
   }
 
   const unexpectedKeys = Object.keys(inputState).filter(
-    key => !reducers.hasOwnProperty(key) && !unexpectedKeyCache[key]
+    key =>
+      !Object.prototype.hasOwnProperty.call(reducers, key) &&
+      !unexpectedKeyCache[key]
   )
 
   unexpectedKeys.forEach(key => {
@@ -144,7 +146,7 @@ export default function combineReducers(reducers: {
   // keys multiple times.
   let unexpectedKeyCache: { [key: string]: true }
   if (process.env.NODE_ENV !== 'production') {
-    unexpectedKeyCache = {}
+    unexpectedKeyCache = Object.create(null)
   }
 
   let shapeAssertionError: unknown


### PR DESCRIPTION
## Bug fix

Make the development-only unexpected-state-key check independent of user reducer names and inherited Object properties.

- Call `Object.prototype.hasOwnProperty` directly. A reducer named `hasOwnProperty` currently replaces the lookup method and is accidentally called with a key string and no action; a normal reducer reading `action.type` can then throw.
- Give the warning cache a null prototype. Otherwise unexpected keys such as `toString`, `constructor`, and `valueOf` are incorrectly treated as already warned about.

Production reduction behavior, state shape, return identity, public types, and supported runtimes are unchanged. No breaking changes or new dependencies.

## Verification

- All 119 existing tests/type tests across 18 files pass, with no type errors.
- Lint, targeted formatting, standalone type tests, CJS/ESM/browser/declaration builds, and `git diff --check` pass.
- Inline checks reproduce the shadowed-method crash and suppressed built-in-name warnings before the fix. Afterward the reducer is invoked once with its action, five unexpected-key cases warn exactly once across repeated calls, and normal state identity/update behavior is unchanged.
- No test files were added or changed.
