### PR TITLE
docs(toolkit): unwrap `updatePost` mutation in Part 8 edit form example

### DIFF
--- a/docs/tutorials/essentials/part-8-rtk-query-advanced.md
+++ b/docs/tutorials/essentials/part-8-rtk-query-advanced.md
@@ -130,9 +130,13 @@ export const EditPostForm = () => {
     const content = elements.postContent.value
 
     if (title && content) {
-      // highlight-next-line
-      await updatePost({ id: post.id, title, content })
-      navigate(`/posts/${postId}`)
+      try {
+        // highlight-next-line
+        await updatePost({ id: post.id, title, content }).unwrap()
+        navigate(`/posts/${postId}`)
+      } catch (err) {
+        console.error('Failed to save the post: ', err)
+      }
     }
   }
 


### PR DESCRIPTION
## Checklist

- [x] Is there an existing issue for this PR?
  - Closes #4577
- [x] Have the files been linted and formatted?
  - The edited lines follow the repo Prettier config (`semi: false`, `singleQuote: true`) and match the existing Part 7 example. I intentionally did **not** run Prettier across the whole file — `master`'s copy of this page already has pre-existing formatting deviations, so a full reformat would balloon the diff well beyond this focused fix (per CONTRIBUTING: "try to keep your pull request focused in scope").

## What docs page needs to be fixed?

- **Section**: Redux Essentials
- **Page**: Part 8: RTK Query Advanced Patterns (`docs/tutorials/essentials/part-8-rtk-query-advanced.md`)

## What is the problem?

In the `EditPostForm` example, the `updatePost` mutation is awaited without calling `.unwrap()`:

```ts
if (title && content) {
  await updatePost({ id: post.id, title, content })
  navigate(`/posts/${postId}`)
}
```

This is inconsistent with what the tutorial teaches. Part 7 explicitly explains that the mutation trigger returns "a special Promise with a `.unwrap()` method" that you `await` inside a `try/catch` to handle request errors, and the `AddPostForm` example there does exactly that. As written, the Part 8 edit example swallows a failed request and navigates away as if the edit succeeded.

## What changes does this PR make to fix the problem?

Mirrors the Part 7 pattern in the Part 8 `EditPostForm` example — wraps the call in `try/catch`, adds `.unwrap()`, navigates only on success, and logs on failure:

```ts
if (title && content) {
  try {
    await updatePost({ id: post.id, title, content }).unwrap()
    navigate(`/posts/${postId}`)
  } catch (err) {
    console.error('Failed to save the post: ', err)
  }
}
```

This keeps error handling consistent across both the add and edit forms in the Essentials tutorial. If maintainers prefer the more minimal change of only appending `.unwrap()` (without the surrounding `try/catch`), I'm happy to adjust.
