### PR TITLE
docs: fix typos in reducer and store type JSDoc

### DIFF
--- a/src/types/reducers.ts
+++ b/src/types/reducers.ts
@@ -5,10 +5,10 @@ import type { Action, UnknownAction } from './actions'
 /**
  * A *reducer* is a function that accepts
  * an accumulation and a value and returns a new accumulation. They are used
- * to reduce a collection of values down to a single value
+ * to reduce a collection of values down to a single value.
  *
  * Reducers are not unique to Redux—they are a fundamental concept in
- * functional programming.  Even most non-functional languages, like
+ * functional programming. Even most non-functional languages, like
  * JavaScript, have a built-in API for reducing. In JavaScript, it's
  * `Array.prototype.reduce()`.
  *

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -133,7 +133,7 @@ export interface Store<
    * progress. However, the next `dispatch()` call, whether nested or not,
    * will use a more recent snapshot of the subscription list.
    *
-   * 2. The listener should not expect to see all states changes, as the state
+   * 2. The listener should not expect to see all state changes, as the state
    * might have been updated multiple times during a nested `dispatch()` before
    * the listener is called. It is, however, guaranteed that all subscribers
    * registered before the `dispatch()` started will be called with the latest


### PR DESCRIPTION
## Summary

Three small typo/grammar fixes in JSDoc comments. Comment-only — no runtime or type changes.

- `src/types/store.ts`: `all states changes` → `all state changes`. This matches the identical passage in `createStore.ts`, which already reads "all state changes".
- `src/types/reducers.ts`: add a missing period at the end of "...down to a single value".
- `src/types/reducers.ts`: collapse a double space in "functional programming.  Even".

## Notes

No behavior, API, or type changes — documentation comments only.